### PR TITLE
Cleaned-up PELoaderLib graphics correction

### DIFF
--- a/EOLib.Graphics/NativeGraphicsLoader.cs
+++ b/EOLib.Graphics/NativeGraphicsLoader.cs
@@ -35,24 +35,17 @@ namespace EOLib.Graphics
             var offSet = (int)(bm.Width * 0.02);
             for (int y = 0; y < bm.Height; y++)
             {
+                var flippedY = bm.Height - 1 - y;
                 for (int x = 0; x < offSet; x++)
                 {
-                    temp.SetPixel(x, y, bm.GetPixel(x + bm.Width - offSet, y));
+                    temp.SetPixel(x, y, bm.GetPixel(x + bm.Width - offSet, flippedY));
                 }
                 for (int x = offSet; x < bm.Width; x++)
                 {
-                    temp.SetPixel(x, y, bm.GetPixel(x - offSet, y));
+                    temp.SetPixel(x, y, bm.GetPixel(x - offSet, flippedY));
                 }
             }
-
-            // flipping
-            for (int y = 0; y < bm.Height; y++)
-            {
-                for (int x = 0; x < bm.Width; x++)
-                {
-                    bm.SetPixel(x, y, temp.GetPixel(x, temp.Height - 1 - y));
-                }
-            }
+            bm = temp;
 #endif
             return bm;
         }

--- a/EOLib.Graphics/NativeGraphicsLoader.cs
+++ b/EOLib.Graphics/NativeGraphicsLoader.cs
@@ -26,7 +26,19 @@ namespace EOLib.Graphics
                 throw new GFXLoadException(resourceValue, file);
 
             var ms = new MemoryStream(fileBytes);
-            return (Bitmap)Image.FromStream(ms);
+
+            var bm = (Bitmap)Image.FromStream(ms);
+#if !LINUX
+            var temp = new Bitmap(bm);
+            for (int y = 0; y < bm.Height; y++)
+            {
+                for (int x = 0; x < bm.Width; x++)
+                {
+                    bm.SetPixel(x, y, temp.GetPixel(x, temp.Height - 1 - y));
+                }
+            }
+#endif
+            return bm;
         }
     }
 }

--- a/EOLib.Graphics/NativeGraphicsLoader.cs
+++ b/EOLib.Graphics/NativeGraphicsLoader.cs
@@ -28,8 +28,22 @@ namespace EOLib.Graphics
             var ms = new MemoryStream(fileBytes);
 
             var bm = (Bitmap)Image.FromStream(ms);
+
 #if !LINUX
             var temp = new Bitmap(bm);
+
+            var offSet = (int)(bm.Width * 0.02);
+            for (int y = 0; y < bm.Height; y++)
+            {
+                for (int x = 0; x < offSet; x++)
+                {
+                    temp.SetPixel(x, y, bm.GetPixel(x + bm.Width - offSet, y));
+                }
+                for (int x = offSet; x < bm.Width; x++)
+                {
+                    temp.SetPixel(x, y, bm.GetPixel(x - offSet, y));
+                }
+            }
             for (int y = 0; y < bm.Height; y++)
             {
                 for (int x = 0; x < bm.Width; x++)

--- a/EOLib.Graphics/NativeGraphicsLoader.cs
+++ b/EOLib.Graphics/NativeGraphicsLoader.cs
@@ -44,6 +44,8 @@ namespace EOLib.Graphics
                     temp.SetPixel(x, y, bm.GetPixel(x - offSet, y));
                 }
             }
+
+            // flipping
             for (int y = 0; y < bm.Height; y++)
             {
                 for (int x = 0; x < bm.Width; x++)


### PR DESCRIPTION
I flipped the loaded graphics and shifted them over by 2% of the width.
![Screen Shot 2019-04-03 at 5 49 02 PM](https://user-images.githubusercontent.com/21302119/55522203-ca145c00-5638-11e9-8dc6-37773ed77705.png)
