### PR TITLE
Add command-line argument for specifying host

### DIFF
--- a/EndlessClient/GameExecution/DebugGameRunner.cs
+++ b/EndlessClient/GameExecution/DebugGameRunner.cs
@@ -11,7 +11,7 @@ namespace EndlessClient.GameExecution
     /// </summary>
     public class DebugGameRunner : GameRunnerBase
     {
-        public DebugGameRunner(ITypeRegistry registry)
-            : base(registry) { }
+        public DebugGameRunner(ITypeRegistry registry, string[] args)
+            : base(registry, args) { }
     }
 }

--- a/EndlessClient/GameExecution/GameRunnerBase.cs
+++ b/EndlessClient/GameExecution/GameRunnerBase.cs
@@ -2,6 +2,7 @@
 // This file is subject to the GPL v2 License
 // For additional details, see the LICENSE file
 
+using System.Diagnostics;
 using System.IO;
 using System.Windows.Forms;
 using AutomaticTypeMapper;
@@ -15,10 +16,12 @@ namespace EndlessClient.GameExecution
     public abstract class GameRunnerBase : IGameRunner
     {
         private readonly ITypeRegistry _registry;
+        private readonly string[] _args;
 
-        protected GameRunnerBase(ITypeRegistry registry)
+        protected GameRunnerBase(ITypeRegistry registry, string[] args)
         {
             _registry = registry;
+            _args = args;
         }
 
         public virtual bool SetupDependencies()
@@ -59,6 +62,24 @@ namespace EndlessClient.GameExecution
                     $"There was an error loading GFX{(int) lle.WhichGFX:000}.EGF : {lle.WhichGFX}. Place all .GFX files in .\\gfx\\. The error message is:\n\n\"{lle.Message}\"";
                 ShowErrorMessage(message, "GFX Load Error");
                 return false;
+            }
+
+            for (int i = 0; i < _args.Length; ++i)
+            {
+                var arg = _args[i];
+
+                if (string.Equals(arg, "--host") && i < _args.Length - 1)
+                {
+                    var host = _args[i + 1];
+                    _registry.Resolve<IConfigurationRepository>()
+                        .Host = host;
+
+                    i++;
+                }
+                else
+                {
+                    Debug.WriteLine($"Unrecognized argument: {arg}. Will be ignored.");
+                }
             }
 
             return true;

--- a/EndlessClient/GameExecution/ReleaseGameRunner.cs
+++ b/EndlessClient/GameExecution/ReleaseGameRunner.cs
@@ -13,8 +13,8 @@ namespace EndlessClient.GameExecution
     /// </summary>
     public class ReleaseGameRunner : GameRunnerBase
     {
-        public ReleaseGameRunner(ITypeRegistry registry)
-            : base(registry) { }
+        public ReleaseGameRunner(ITypeRegistry registry, string[] args)
+            : base(registry, args) { }
 
         public override bool SetupDependencies()
         {

--- a/EndlessClient/Program.cs
+++ b/EndlessClient/Program.cs
@@ -14,7 +14,7 @@ namespace EndlessClient
         private static IGameRunner _gameRunner;
 
         [STAThread]
-        public static void Main()
+        public static void Main(string[] args)
         {
             var assemblyNames = new []
             {
@@ -30,9 +30,9 @@ namespace EndlessClient
             using (ITypeRegistry registry = new UnityRegistry(assemblyNames))
             {
 #if DEBUG
-                _gameRunner = new DebugGameRunner(registry);
+                _gameRunner = new DebugGameRunner(registry, args);
 #else
-                _gameRunner = new ReleaseGameRunner(registry);
+                _gameRunner = new ReleaseGameRunner(registry, args);
 #endif
                 if (_gameRunner.SetupDependencies())
                     _gameRunner.RunGame();

--- a/EndlessClient/Rendering/CharacterProperties/HatRenderer.cs
+++ b/EndlessClient/Rendering/CharacterProperties/HatRenderer.cs
@@ -40,7 +40,10 @@ namespace EndlessClient.Rendering.CharacterProperties
             var flippedOffset = _renderProperties.IsFacing(EODirection.Up, EODirection.Right) ? -2 : 0;
             var drawLoc = new Vector2(offsets.X + flippedOffset, offsets.Y - 3);
 
+#if LINUX
             _shaderProvider.Shaders[ShaderRepository.HairClip].CurrentTechnique.Passes[0].Apply();
+#endif
+
             Render(spriteBatch, _hatSheet, drawLoc);
         }
     }

--- a/EndlessClient/Rendering/CharacterProperties/HatRenderer.cs
+++ b/EndlessClient/Rendering/CharacterProperties/HatRenderer.cs
@@ -9,6 +9,7 @@ using EOLib.Domain.Character;
 using EOLib.Domain.Extensions;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using System.Diagnostics;
 
 namespace EndlessClient.Rendering.CharacterProperties
 {
@@ -39,12 +40,16 @@ namespace EndlessClient.Rendering.CharacterProperties
             var offsets = _hairRenderLocationCalculator.CalculateDrawLocationOfCharacterHair(_hairSheet.SourceRectangle, parentCharacterDrawArea);
             var flippedOffset = _renderProperties.IsFacing(EODirection.Up, EODirection.Right) ? -2 : 0;
             var drawLoc = new Vector2(offsets.X + flippedOffset, offsets.Y - 3);
-
-#if LINUX
-            _shaderProvider.Shaders[ShaderRepository.HairClip].CurrentTechnique.Passes[0].Apply();
-#endif
+            
+            ApplyHairClipShader();
 
             Render(spriteBatch, _hatSheet, drawLoc);
+        }
+
+        [Conditional("LINUX")]
+        private void ApplyHairClipShader()
+        {
+            _shaderProvider.Shaders[ShaderRepository.HairClip].CurrentTechnique.Passes[0].Apply();
         }
     }
 }


### PR DESCRIPTION
Allows force-override of host when debugging. Useful for not having to modify the nuget settings.ini file in order to debug while connecting to a non-default server.