### PR TITLE
Handle login ban

### DIFF
--- a/EOLib/Domain/Login/LoginActions.cs
+++ b/EOLib/Domain/Login/LoginActions.cs
@@ -4,6 +4,7 @@ using AutomaticTypeMapper;
 using EOLib.Domain.Character;
 using EOLib.Domain.Chat;
 using EOLib.Domain.Map;
+using EOLib.Domain.Protocol;
 using EOLib.Localization;
 using EOLib.Net;
 using EOLib.Net.Communication;
@@ -181,7 +182,8 @@ namespace EOLib.Domain.Login
 
         private bool IsInvalidResponse(IPacket response)
         {
-            return response.Family != PacketFamily.Login || response.Action != PacketAction.Reply;
+            return !(response.Family == PacketFamily.Login && response.Action == PacketAction.Reply)
+                && !(response.Family == PacketFamily.Init && response.Action == PacketAction.Init && response.PeekByte() == (byte)InitReply.BannedFromServer);
         }
 
         private bool IsInvalidWelcome(IPacket response)

--- a/EOLib/Domain/Login/LoginReply.cs
+++ b/EOLib/Domain/Login/LoginReply.cs
@@ -5,6 +5,7 @@
         WrongUser = 1,
         WrongUserPass = 2,
         Ok = 3,
+        AccountBanned = 4,
         LoggedIn = 5,
         Busy = 6,
         THIS_IS_WRONG = 255

--- a/EOLib/Net/Translators/AccountLoginPacketTranslator.cs
+++ b/EOLib/Net/Translators/AccountLoginPacketTranslator.cs
@@ -2,6 +2,7 @@
 using AutomaticTypeMapper;
 using EOLib.Domain.Character;
 using EOLib.Domain.Login;
+using EOLib.Domain.Protocol;
 
 namespace EOLib.Net.Translators
 {
@@ -10,11 +11,30 @@ namespace EOLib.Net.Translators
     {
         public override IAccountLoginData TranslatePacket(IPacket packet)
         {
-            var reply = (LoginReply) packet.ReadShort();
-
+            LoginReply reply;
             var characters = new List<ICharacter>();
-            if (reply == LoginReply.Ok)
-                characters.AddRange(GetCharacters(packet));
+
+            if (packet.Family == PacketFamily.Login && packet.Action == PacketAction.Reply)
+            {
+                reply = (LoginReply)packet.ReadShort();
+
+                if (reply == LoginReply.Ok)
+                    characters.AddRange(GetCharacters(packet));
+            }
+            else if (packet.Family == PacketFamily.Init && packet.Action == PacketAction.Init)
+            {
+                var initReply = (InitReply)packet.ReadByte();
+                var banType = (BanType)packet.ReadByte();
+
+                if (initReply != InitReply.BannedFromServer && banType != BanType.PermanentBan)
+                    reply = LoginReply.THIS_IS_WRONG;
+                else
+                    reply = LoginReply.AccountBanned;
+            }
+            else
+            {
+                reply = LoginReply.THIS_IS_WRONG;
+            }
 
             return new AccountLoginData(reply, characters);
         }

--- a/EndlessClient/Controllers/LoginController.cs
+++ b/EndlessClient/Controllers/LoginController.cs
@@ -80,7 +80,10 @@ namespace EndlessClient.Controllers
             if (reply == LoginReply.Ok)
                 _gameStateActions.ChangeToState(GameStates.LoggedIn);
             else
+            {
                 _errorDisplayAction.ShowLoginError(reply);
+                _gameStateActions.ChangeToState(GameStates.Initial);
+            }
         }
 
         public async Task LoginToCharacter(ICharacter character)

--- a/EndlessClient/Dialogs/Actions/ErrorDialogDisplayAction.cs
+++ b/EndlessClient/Dialogs/Actions/ErrorDialogDisplayAction.cs
@@ -119,6 +119,7 @@ namespace EndlessClient.Dialogs.Actions
             {
                 case LoginReply.WrongUser: message = DialogResourceID.LOGIN_ACCOUNT_NAME_NOT_FOUND; break;
                 case LoginReply.WrongUserPass: message = DialogResourceID.LOGIN_ACCOUNT_NAME_OR_PASSWORD_NOT_FOUND; break;
+                case LoginReply.AccountBanned: message = DialogResourceID.LOGIN_BANNED_FROM_SERVER; break;
                 case LoginReply.LoggedIn: message = DialogResourceID.LOGIN_ACCOUNT_ALREADY_LOGGED_ON; break;
                 case LoginReply.Busy: message = DialogResourceID.CONNECTION_SERVER_IS_FULL;  break;
                 default: throw new ArgumentOutOfRangeException(nameof(loginError), loginError, null);

--- a/EndlessClient/Dialogs/Actions/ErrorDialogDisplayAction.cs
+++ b/EndlessClient/Dialogs/Actions/ErrorDialogDisplayAction.cs
@@ -121,7 +121,8 @@ namespace EndlessClient.Dialogs.Actions
                 case LoginReply.WrongUserPass: message = DialogResourceID.LOGIN_ACCOUNT_NAME_OR_PASSWORD_NOT_FOUND; break;
                 case LoginReply.AccountBanned: message = DialogResourceID.LOGIN_BANNED_FROM_SERVER; break;
                 case LoginReply.LoggedIn: message = DialogResourceID.LOGIN_ACCOUNT_ALREADY_LOGGED_ON; break;
-                case LoginReply.Busy: message = DialogResourceID.CONNECTION_SERVER_IS_FULL;  break;
+                case LoginReply.Busy: message = DialogResourceID.CONNECTION_SERVER_IS_FULL; break;
+                case LoginReply.THIS_IS_WRONG: message = DialogResourceID.LOGIN_SERVER_COULD_NOT_PROCESS; break;
                 default: throw new ArgumentOutOfRangeException(nameof(loginError), loginError, null);
             }
 


### PR DESCRIPTION
Add handling for bans when attempting to log in with an account.

Handles both login ban message types - LoginReply value of 4 (not used in EOSERV), and an INIT_INIT packet with permanent ban content.