### PR TITLE
EOBot: Add support for objects in script files. Define $account, $character, and $mapstate built-in variables.

### DIFF
--- a/EOBot/EOBot.csproj
+++ b/EOBot/EOBot.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Interpreter\BotTokenParser.cs" />
     <Compile Include="Interpreter\BotTokenType.cs" />
     <Compile Include="Interpreter\BuiltInIdentifierConfigurator.cs" />
+    <Compile Include="Interpreter\Extensions\SymbolTableExtensions.cs" />
     <Compile Include="Interpreter\Extensions\ProgramStateExtensions.cs" />
     <Compile Include="Interpreter\IdentifierBotToken.cs" />
     <Compile Include="Interpreter\States\AssignmentEvaluator.cs" />
@@ -124,6 +125,7 @@
     <Compile Include="Interpreter\Variables\BoolVariable.cs" />
     <Compile Include="Interpreter\VariableBotToken.cs" />
     <Compile Include="Interpreter\Variables\AsyncFunction.cs" />
+    <Compile Include="Interpreter\Variables\ObjectVariable.cs" />
     <Compile Include="Interpreter\Variables\PredefinedIdentifiers.cs" />
     <Compile Include="Interpreter\Variables\UndefinedVariable.cs" />
     <Compile Include="Interpreter\Variables\AsyncVoidFunction.cs" />

--- a/EOBot/Interpreter/BotTokenParser.cs
+++ b/EOBot/Interpreter/BotTokenParser.cs
@@ -75,7 +75,7 @@ namespace EOBot.Interpreter
                     do
                     {
                         inputChar = Read();
-                    } while (inputChar != '\n');
+                    } while (inputChar != '\n' && !_inputStream.EndOfStream);
 
                     LineNumber++;
                     Column = 1;
@@ -86,7 +86,7 @@ namespace EOBot.Interpreter
             if (char.IsLetter(inputChar))
             {
                 var identifier = inputChar.ToString();
-                while (char.IsLetterOrDigit(Peek()) || Peek() == '_')
+                while ((char.IsLetterOrDigit(Peek()) || Peek() == '_') && !_inputStream.EndOfStream)
                     identifier += Read();
 
                 var type = Keywords.Contains(identifier)
@@ -98,7 +98,7 @@ namespace EOBot.Interpreter
             else if (char.IsDigit(inputChar))
             {
                 var number = inputChar.ToString();
-                while (char.IsDigit((char)_inputStream.Peek()))
+                while (char.IsDigit((char)_inputStream.Peek()) && !_inputStream.EndOfStream)
                     number += Read();
                 return Token(BotTokenType.Literal, number);
             }
@@ -117,8 +117,12 @@ namespace EOBot.Interpreter
                     case '"':
                         {
                             var stringLiteral = string.Empty;
-                            while ((char)_inputStream.Peek() != '"')
+                            while ((char)_inputStream.Peek() != '"' && !_inputStream.EndOfStream)
                                 stringLiteral += Read();
+
+                            if (_inputStream.EndOfStream)
+                                return Token(BotTokenType.Error, string.Empty);
+
                             Read();
                             return Token(BotTokenType.Literal, stringLiteral);
                         }

--- a/EOBot/Interpreter/BotTokenParser.cs
+++ b/EOBot/Interpreter/BotTokenParser.cs
@@ -184,6 +184,7 @@ namespace EOBot.Interpreter
                     case '-': return Token(BotTokenType.MinusOperator, inputChar.ToString());
                     case '*': return Token(BotTokenType.MultiplyOperator, inputChar.ToString());
                     case '/': return Token(BotTokenType.DivideOperator, inputChar.ToString());
+                    case '.': return Token(BotTokenType.Dot, inputChar.ToString());
                     default: return Token(BotTokenType.Error, inputChar.ToString());
                 }
             }

--- a/EOBot/Interpreter/BotTokenType.cs
+++ b/EOBot/Interpreter/BotTokenType.cs
@@ -26,6 +26,7 @@
         MinusOperator,
         MultiplyOperator,
         DivideOperator,
+        Dot,
         NewLine,
         Error,
     }

--- a/EOBot/Interpreter/BuiltInIdentifierConfigurator.cs
+++ b/EOBot/Interpreter/BuiltInIdentifierConfigurator.cs
@@ -35,8 +35,9 @@ namespace EOBot.Interpreter
             _state.SymbolTable[PredefinedIdentifiers.PRINT_FUNC] = Readonly(new VoidFunction<object>(PredefinedIdentifiers.PRINT_FUNC, param1 => ConsoleHelper.WriteMessage(ConsoleHelper.Type.None, param1.ToString())));
             _state.SymbolTable[PredefinedIdentifiers.LEN_FUNC] = Readonly(new Function<ArrayVariable, int>(PredefinedIdentifiers.LEN_FUNC, param1 => param1.Value.Count));
             _state.SymbolTable[PredefinedIdentifiers.ARRAY_FUNC] = Readonly(new Function<int, List<IVariable>>(PredefinedIdentifiers.ARRAY_FUNC, param1 => Enumerable.Repeat(UndefinedVariable.Instance, param1).Cast<IVariable>().ToList()));
-            _state.SymbolTable[PredefinedIdentifiers.SLEEP] = Readonly(new VoidFunction<int>(PredefinedIdentifiers.SLEEP, param1 => Thread.Sleep(param1)));
-            _state.SymbolTable[PredefinedIdentifiers.TIME] = Readonly(new Function<string>(PredefinedIdentifiers.TIME, () => DateTime.Now.ToLongTimeString()));
+            _state.SymbolTable[PredefinedIdentifiers.SLEEP_FUNC] = Readonly(new VoidFunction<int>(PredefinedIdentifiers.SLEEP_FUNC, param1 => Thread.Sleep(param1)));
+            _state.SymbolTable[PredefinedIdentifiers.TIME_FUNC] = Readonly(new Function<string>(PredefinedIdentifiers.TIME_FUNC, () => DateTime.Now.ToLongTimeString()));
+            _state.SymbolTable[PredefinedIdentifiers.OBJECT_FUNC] = Readonly(new Function<ObjectVariable>(PredefinedIdentifiers.OBJECT_FUNC, () => new ObjectVariable()));
 
             BotDependencySetup();
             _state.SymbolTable[PredefinedIdentifiers.CONNECT_FUNC] = Readonly(new AsyncVoidFunction<string, int>(PredefinedIdentifiers.CONNECT_FUNC, ConnectAsync));

--- a/EOBot/Interpreter/Extensions/ProgramStateExtensions.cs
+++ b/EOBot/Interpreter/Extensions/ProgramStateExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using EOBot.Interpreter.States;
-using EOBot.Interpreter.Variables;
 
 namespace EOBot.Interpreter.Extensions
 {
@@ -24,51 +23,6 @@ namespace EOBot.Interpreter.Extensions
                 return input.Program[input.Program.Count - 1];
 
             return input.Program[input.ExecutionIndex];
-        }
-
-        public static (EvalResult Result, string Reason, IVariable Variable) GetVariable(this ProgramState input, string identifier, int? arrayIndex = null)
-        {
-            if (!input.SymbolTable.ContainsKey(identifier))
-                input.SymbolTable[identifier] = (false, UndefinedVariable.Instance);
-
-            var variableValue = input.SymbolTable[identifier].Identifiable as IVariable;
-            if (variableValue == null)
-            {
-                return (EvalResult.Failed, $"Identifier {identifier} is not a variable", null);
-            }
-
-            if (arrayIndex != null)
-            {
-                var arrayVariable = variableValue as ArrayVariable;
-                if (arrayVariable == null)
-                {
-                    return (EvalResult.Failed, $"Identifier {identifier} is not an array", null);
-                }
-
-                if (arrayVariable.Value.Count <= arrayIndex.Value)
-                {
-                    return (EvalResult.Failed, $"Index {identifier} is out of range of the array {identifier} (size {arrayVariable.Value.Count})", null);
-                }
-
-                variableValue = arrayVariable.Value[arrayIndex.Value];
-            }
-
-            return (EvalResult.Ok, string.Empty, variableValue);
-        }
-
-        public static (EvalResult Result, string Reason, T Variable) GetVariable<T>(this ProgramState input, string identifier, int? arrayIndex = null)
-            where T : class, IVariable
-        {
-            var getResult = GetVariable(input, identifier, arrayIndex);
-
-            if (getResult.Result != EvalResult.Ok)
-                return (getResult.Result, getResult.Reason, null);
-
-            var variable = getResult.Variable as T;
-            if (variable == null)
-                return (EvalResult.Failed, $"Identifier {identifier} is not a {typeof(T).Name}", null);
-
-            return (EvalResult.Ok, string.Empty, variable);
         }
     }
 }

--- a/EOBot/Interpreter/Extensions/ProgramStateExtensions.cs
+++ b/EOBot/Interpreter/Extensions/ProgramStateExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using EOBot.Interpreter.States;
+using EOBot.Interpreter.Variables;
 
 namespace EOBot.Interpreter.Extensions
 {
@@ -23,6 +24,51 @@ namespace EOBot.Interpreter.Extensions
                 return input.Program[input.Program.Count - 1];
 
             return input.Program[input.ExecutionIndex];
+        }
+
+        public static (EvalResult Result, string Reason, IVariable Variable) GetVariable(this ProgramState input, string identifier, int? arrayIndex = null)
+        {
+            if (!input.SymbolTable.ContainsKey(identifier))
+                input.SymbolTable[identifier] = (false, UndefinedVariable.Instance);
+
+            var variableValue = input.SymbolTable[identifier].Identifiable as IVariable;
+            if (variableValue == null)
+            {
+                return (EvalResult.Failed, $"Identifier {identifier} is not a variable", null);
+            }
+
+            if (arrayIndex != null)
+            {
+                var arrayVariable = variableValue as ArrayVariable;
+                if (arrayVariable == null)
+                {
+                    return (EvalResult.Failed, $"Identifier {identifier} is not an array", null);
+                }
+
+                if (arrayVariable.Value.Count <= arrayIndex.Value)
+                {
+                    return (EvalResult.Failed, $"Index {identifier} is out of range of the array {identifier} (size {arrayVariable.Value.Count})", null);
+                }
+
+                variableValue = arrayVariable.Value[arrayIndex.Value];
+            }
+
+            return (EvalResult.Ok, string.Empty, variableValue);
+        }
+
+        public static (EvalResult Result, string Reason, T Variable) GetVariable<T>(this ProgramState input, string identifier, int? arrayIndex = null)
+            where T : class, IVariable
+        {
+            var getResult = GetVariable(input, identifier, arrayIndex);
+
+            if (getResult.Result != EvalResult.Ok)
+                return (getResult.Result, getResult.Reason, null);
+
+            var variable = getResult.Variable as T;
+            if (variable == null)
+                return (EvalResult.Failed, $"Identifier {identifier} is not a {typeof(T).Name}", null);
+
+            return (EvalResult.Ok, string.Empty, variable);
         }
     }
 }

--- a/EOBot/Interpreter/Extensions/SymbolTableExtensions.cs
+++ b/EOBot/Interpreter/Extensions/SymbolTableExtensions.cs
@@ -1,0 +1,56 @@
+﻿using EOBot.Interpreter.States;
+using EOBot.Interpreter.Variables;
+using System.Collections.Generic;
+
+namespace EOBot.Interpreter.Extensions
+{
+    public static class SymbolTableExtensions
+    {
+
+        public static (EvalResult Result, string Reason, IVariable Variable) GetVariable(this Dictionary<string, (bool, IIdentifiable Identifiable)> symbols, string identifier, int? arrayIndex = null)
+        {
+            if (!symbols.ContainsKey(identifier))
+                symbols[identifier] = (false, UndefinedVariable.Instance);
+
+            var variableValue = symbols[identifier].Identifiable as IVariable;
+            if (variableValue == null)
+            {
+                return (EvalResult.Failed, $"Identifier {identifier} is not a variable", null);
+            }
+
+            if (arrayIndex != null)
+            {
+                var arrayVariable = variableValue as ArrayVariable;
+
+                if (arrayVariable == null)
+                {
+                    return (EvalResult.Failed, $"Identifier {identifier} is not an array", null);
+                }
+
+                if (arrayVariable.Value.Count <= arrayIndex.Value)
+                {
+                    return (EvalResult.Failed, $"Index {arrayIndex.Value} is out of range of the array {identifier} (size {arrayVariable.Value.Count})", null);
+                }
+
+                variableValue = arrayVariable.Value[arrayIndex.Value];
+            }
+
+            return (EvalResult.Ok, string.Empty, variableValue);
+        }
+
+        public static (EvalResult Result, string Reason, T Variable) GetVariable<T>(this Dictionary<string, (bool, IIdentifiable)> symbols, string identifier, int? arrayIndex = null)
+            where T : class, IVariable
+        {
+            var getResult = GetVariable(symbols, identifier, arrayIndex);
+
+            if (getResult.Result != EvalResult.Ok)
+                return (getResult.Result, getResult.Reason, null);
+
+            var variable = getResult.Variable as T;
+            if (variable == null)
+                return (EvalResult.Failed, $"Identifier {identifier} is not a {typeof(T).Name}", null);
+
+            return (EvalResult.Ok, string.Empty, variable);
+        }
+    }
+}

--- a/EOBot/Interpreter/IdentifierBotToken.cs
+++ b/EOBot/Interpreter/IdentifierBotToken.cs
@@ -4,10 +4,13 @@
     {
         public int? ArrayIndex { get; }
 
-        public IdentifierBotToken(BotTokenType tokenType, string tokenValue, int lineNumber, int column, int? arrayIndex = null)
-            : base(tokenType, tokenValue, lineNumber, column)
+        public IdentifierBotToken Member { get; }
+
+        public IdentifierBotToken(BotToken identifier, int? arrayIndex = null, IdentifierBotToken member = null)
+            : base(identifier.TokenType, identifier.TokenValue, identifier.LineNumber, identifier.Column)
         {
             ArrayIndex = arrayIndex;
+            Member = member;
         }
     }
 }

--- a/EOBot/Interpreter/States/AssignmentEvaluator.cs
+++ b/EOBot/Interpreter/States/AssignmentEvaluator.cs
@@ -46,13 +46,11 @@ namespace EOBot.Interpreter.States
                 if (!input.SymbolTable.ContainsKey(variable.TokenValue))
                     return IdentifierNotFoundError(variable);
 
-                var targetArray = input.SymbolTable[variable.TokenValue].Identifiable as ArrayVariable;
-                if (targetArray == null)
-                    return (EvalResult.Failed, $"Identifier {variable.TokenValue} is not an array", variable);
+                var getVariableResult = input.GetVariable<ArrayVariable>(variable.TokenValue, variable.ArrayIndex);
+                if (getVariableResult.Result != EvalResult.Ok)
+                    return (getVariableResult.Result, getVariableResult.Reason, variable);
 
-                if (targetArray.Value.Count <= variable.ArrayIndex.Value)
-                    return (EvalResult.Failed, $"Index {variable.ArrayIndex} is out of range of the array {variable.TokenValue} (size {targetArray.Value.Count})", variable);
-
+                var targetArray = getVariableResult.Variable;
                 targetArray.Value[variable.ArrayIndex.Value] = expressionResult.VariableValue;
             }
             else

--- a/EOBot/Interpreter/States/AssignmentEvaluator.cs
+++ b/EOBot/Interpreter/States/AssignmentEvaluator.cs
@@ -35,33 +35,50 @@ namespace EOBot.Interpreter.States
 
             if (input.OperationStack.Count == 0)
                 return StackEmptyError(input.Current());
-            var variable = (IdentifierBotToken)input.OperationStack.Pop();
+            var assignmentTarget = (IdentifierBotToken)input.OperationStack.Pop();
 
-            if (input.SymbolTable.ContainsKey(variable.TokenValue) &&
-                input.SymbolTable[variable.TokenValue].ReadOnly)
-                return ReadOnlyVariableError(variable);
+            return Assign2(input.SymbolTable, assignmentTarget, expressionResult);
+        }
 
-            if (variable.ArrayIndex != null)
+        private (EvalResult, string, BotToken) Assign2(Dictionary<string, (bool ReadOnly, IIdentifiable Identifiable)> symbols, IdentifierBotToken assignmentTarget, VariableBotToken expressionResult)
+        {
+            if (assignmentTarget.Member != null)
             {
-                if (!input.SymbolTable.ContainsKey(variable.TokenValue))
-                    return IdentifierNotFoundError(variable);
+                if (!symbols.ContainsKey(assignmentTarget.TokenValue))
+                    return IdentifierNotFoundError(assignmentTarget);
 
-                var getVariableResult = input.GetVariable<ArrayVariable>(variable.TokenValue, variable.ArrayIndex);
+                var getVariableResult = symbols.GetVariable<ObjectVariable>(assignmentTarget.TokenValue, assignmentTarget.ArrayIndex);
                 if (getVariableResult.Result != EvalResult.Ok)
-                    return (getVariableResult.Result, getVariableResult.Reason, variable);
+                    return (getVariableResult.Result, getVariableResult.Reason, assignmentTarget);
+
+                var targetObject = getVariableResult.Variable;
+                return Assign2(targetObject.SymbolTable, assignmentTarget.Member, expressionResult);
+            }
+
+            if (assignmentTarget.ArrayIndex != null)
+            {
+                if (!symbols.ContainsKey(assignmentTarget.TokenValue))
+                    return IdentifierNotFoundError(assignmentTarget);
+
+                var getVariableResult = symbols.GetVariable<ArrayVariable>(assignmentTarget.TokenValue);
+                if (getVariableResult.Result != EvalResult.Ok)
+                    return (getVariableResult.Result, getVariableResult.Reason, assignmentTarget);
 
                 var targetArray = getVariableResult.Variable;
-                targetArray.Value[variable.ArrayIndex.Value] = expressionResult.VariableValue;
+                targetArray.Value[assignmentTarget.ArrayIndex.Value] = expressionResult.VariableValue;
             }
             else
             {
-                if (input.SymbolTable.ContainsKey(variable.TokenValue) && input.SymbolTable[variable.TokenValue].Identifiable.GetType() != expressionResult.VariableValue.GetType())
+                if (symbols.ContainsKey(assignmentTarget.TokenValue) && symbols[assignmentTarget.TokenValue].ReadOnly)
+                    return ReadOnlyVariableError(assignmentTarget);
+
+                if (symbols.ContainsKey(assignmentTarget.TokenValue) && symbols[assignmentTarget.TokenValue].Identifiable.GetType() != expressionResult.VariableValue.GetType())
                 {
                     // todo: surface warnings to caller and let caller decide what to do with it instead of making the interpreter write to console directly
-                    ConsoleHelper.WriteMessage(ConsoleHelper.Type.Warning, $"Changing type of variable {variable.TokenValue} from {input.SymbolTable[variable.TokenValue].Identifiable.GetType()} to {expressionResult.VariableValue.GetType()}", System.ConsoleColor.DarkYellow);
+                    ConsoleHelper.WriteMessage(ConsoleHelper.Type.Warning, $"Changing type of variable {assignmentTarget.TokenValue} from {symbols[assignmentTarget.TokenValue].Identifiable.GetType()} to {expressionResult.VariableValue.GetType()}", System.ConsoleColor.DarkYellow);
                 }
 
-                input.SymbolTable[variable.TokenValue] = (false, expressionResult.VariableValue);
+                symbols[assignmentTarget.TokenValue] = (false, expressionResult.VariableValue);
             }
 
             return Success();

--- a/EOBot/Interpreter/States/ExpressionEvaluator.cs
+++ b/EOBot/Interpreter/States/ExpressionEvaluator.cs
@@ -157,27 +157,11 @@ namespace EOBot.Interpreter.States
                 if (identifier == null)
                     return (EvalResult.Failed, $"Expected operand of type Variable or Identifier but got {nextToken.TokenType}", nextToken);
 
-                if (!input.SymbolTable.ContainsKey(identifier.TokenValue))
-                    input.SymbolTable[identifier.TokenValue] = (true, UndefinedVariable.Instance);
+                var getVariableRes = input.GetVariable(identifier.TokenValue, identifier.ArrayIndex);
+                if (getVariableRes.Result != EvalResult.Ok)
+                    return (getVariableRes.Result, getVariableRes.Reason, identifier);
 
-                var variableValue = (IVariable)input.SymbolTable[identifier.TokenValue].Identifiable;
-                if (identifier.ArrayIndex != null)
-                {
-                    var arrayVariable = variableValue as ArrayVariable;
-                    if (arrayVariable == null)
-                    {
-                        return (EvalResult.Failed, $"Identifier {identifier.TokenValue} is not an array", identifier);
-                    }
-
-                    if (arrayVariable.Value.Count <= identifier.ArrayIndex.Value)
-                    {
-                        return (EvalResult.Failed, $"Index {identifier.ArrayIndex} is out of range of the array {identifier.TokenValue} (size {arrayVariable.Value.Count})", identifier);
-                    }
-
-                    variableValue = arrayVariable.Value[identifier.ArrayIndex.Value];
-                }
-
-                operand = new VariableBotToken(BotTokenType.Literal, variableValue.ToString(), variableValue);
+                operand = new VariableBotToken(BotTokenType.Literal, getVariableRes.Variable.ToString(), getVariableRes.Variable);
             }
 
             return Success(operand);

--- a/EOBot/Interpreter/States/GotoEvaluator.cs
+++ b/EOBot/Interpreter/States/GotoEvaluator.cs
@@ -19,7 +19,7 @@ namespace EOBot.Interpreter.States
 
             var label = input.OperationStack.Pop();
             if (!input.Labels.ContainsKey(label.TokenValue))
-                return Task.FromResult(IdentifierNotFoundError(new IdentifierBotToken(BotTokenType.Identifier, label.TokenValue, label.LineNumber, label.Column)));
+                return Task.FromResult(IdentifierNotFoundError(new IdentifierBotToken(label)));
             
             var result = input.Goto(input.Labels[label.TokenValue]);
             return Task.FromResult(result ? Success() : GotoError(label));

--- a/EOBot/Interpreter/Variables/BoolVariable.cs
+++ b/EOBot/Interpreter/Variables/BoolVariable.cs
@@ -8,8 +8,6 @@
 
         public string StringValue => Value.ToString();
 
-        public IVariable<bool> WithNewValue(bool value) => new BoolVariable(value);
-
         public override bool Equals(object obj) => CompareTo(obj) == 0;
 
         public override int GetHashCode() => Value.GetHashCode();

--- a/EOBot/Interpreter/Variables/IVariable.cs
+++ b/EOBot/Interpreter/Variables/IVariable.cs
@@ -10,7 +10,5 @@ namespace EOBot.Interpreter.Variables
     public interface IVariable<T> : IVariable
     {
         T Value { get; }
-
-        IVariable<T> WithNewValue(T value);
     }
 }

--- a/EOBot/Interpreter/Variables/IntVariable.cs
+++ b/EOBot/Interpreter/Variables/IntVariable.cs
@@ -8,8 +8,6 @@
 
         public string StringValue => Value.ToString();
 
-        public IVariable<int> WithNewValue(int value) => new IntVariable(value);
-
         public override bool Equals(object obj) => CompareTo(obj) == 0;
 
         public override int GetHashCode() => Value.GetHashCode();

--- a/EOBot/Interpreter/Variables/ObjectVariable.cs
+++ b/EOBot/Interpreter/Variables/ObjectVariable.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace EOBot.Interpreter.Variables
@@ -11,7 +12,28 @@ namespace EOBot.Interpreter.Variables
 
         public ObjectVariable() => SymbolTable = new Dictionary<string, (bool, IIdentifiable)>();
 
+        public ObjectVariable(Dictionary<string, (bool, IIdentifiable)> symbolTable) => SymbolTable = symbolTable;
+
         public string StringValue => $"Object: [{string.Join(", ", SymbolTable.Select(x => $"({x.Key}, {x.Value.Variable})"))}]";
+
+        public override bool Equals(object obj) => CompareTo(obj) == 0;
+
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public int CompareTo(object obj) => obj is ObjectVariable ? SymbolTable.Equals(((ObjectVariable)obj).SymbolTable) ? 0 : -1 : -1;
+
+        public override string ToString() => StringValue;
+    }
+
+    public class RuntimeEvaluatedMemberObjectVariable : IVariable<object>
+    {
+        public object Value => SymbolTable;
+
+        public Dictionary<string, (bool ReadOnly, Func<IIdentifiable> Variable)> SymbolTable { get; }
+
+        public RuntimeEvaluatedMemberObjectVariable() => SymbolTable = new Dictionary<string, (bool, Func<IIdentifiable>)>();
+
+        public string StringValue => $"Object: [{string.Join(", ", SymbolTable.Select(x => $"({x.Key}, {x.Value.Variable()})"))}]";
 
         public override bool Equals(object obj) => CompareTo(obj) == 0;
 

--- a/EOBot/Interpreter/Variables/ObjectVariable.cs
+++ b/EOBot/Interpreter/Variables/ObjectVariable.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace EOBot.Interpreter.Variables
+{
+    public class ObjectVariable : IVariable<object>
+    {
+        public object Value => SymbolTable;
+
+        public Dictionary<string, (bool ReadOnly, IIdentifiable Variable)> SymbolTable { get; }
+
+        public ObjectVariable() => SymbolTable = new Dictionary<string, (bool, IIdentifiable)>();
+
+        public string StringValue => $"Object: [{string.Join(", ", SymbolTable.Select(x => $"({x.Key}, {x.Value.Variable})"))}]";
+
+        public override bool Equals(object obj) => CompareTo(obj) == 0;
+
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public int CompareTo(object obj) => obj is ObjectVariable ? SymbolTable.Equals(((ObjectVariable)obj).SymbolTable) ? 0 : -1 : -1;
+
+        public override string ToString() => StringValue;
+    }
+}

--- a/EOBot/Interpreter/Variables/PredefinedIdentifiers.cs
+++ b/EOBot/Interpreter/Variables/PredefinedIdentifiers.cs
@@ -17,6 +17,9 @@
         public const string CHARACTER = "character";
         public const string MAPSTATE = "mapstate";
 
+        public const string NAME = "name";
+        public const string CHARACTERS = "characters";
+
         // interpreter functions
         public const string PRINT_FUNC = "print";
         public const string LEN_FUNC = "len";

--- a/EOBot/Interpreter/Variables/PredefinedIdentifiers.cs
+++ b/EOBot/Interpreter/Variables/PredefinedIdentifiers.cs
@@ -21,8 +21,9 @@
         public const string PRINT_FUNC = "print";
         public const string LEN_FUNC = "len";
         public const string ARRAY_FUNC = "array";
-        public const string SLEEP = "sleep";
-        public const string TIME = "time";
+        public const string OBJECT_FUNC = "object";
+        public const string SLEEP_FUNC = "sleep";
+        public const string TIME_FUNC = "time";
 
         // game functions
         public const string CONNECT_FUNC = "Connect";

--- a/EOBot/Interpreter/Variables/StringVariable.cs
+++ b/EOBot/Interpreter/Variables/StringVariable.cs
@@ -8,8 +8,6 @@
 
         public string StringValue => Value;
 
-        public IVariable<string> WithNewValue(string value) => new StringVariable(value);
-
         public override bool Equals(object obj) => CompareTo(obj) == 0;
 
         public override int GetHashCode() => Value.GetHashCode();

--- a/EOBot/Program.cs
+++ b/EOBot/Program.cs
@@ -215,6 +215,7 @@ namespace EOBot
                     await f.RunAsync();
                 }
 
+                Console.WriteLine();
                 ConsoleHelper.WriteMessage(ConsoleHelper.Type.None, "All bots completed.");
             }
             catch (BotException bex)


### PR DESCRIPTION
Objects work sort of like arrays. Each one is a property bag, properties are assigned dynamically and created if they don't exist. Properties can be nested objects or arrays. Arrays may contain objects.
```
$obj = object()
$obj.$prop1 = "My property"
print ($obj.$prop1)
```

Built-in objects $account, $character, and $mapstate evaluate their properties when they are accessed, since the data structures are immutable and instances can change.