### PR TITLE
Finish pub spec

### DIFF
--- a/EOLib.IO.Test/Pub/EIFRecordTest.cs
+++ b/EOLib.IO.Test/Pub/EIFRecordTest.cs
@@ -277,7 +277,7 @@ namespace EOLib.IO.Test.Pub
             ret.AddRange(nes.EncodeNumber(rec.Accuracy, 2));
             ret.AddRange(nes.EncodeNumber(rec.Evade, 2));
             ret.AddRange(nes.EncodeNumber(rec.Armor, 2));
-            ret.AddRange(Enumerable.Repeat((byte)254, 1));
+            ret.AddRange(nes.EncodeNumber(rec.UnkByte19, 1));
             ret.AddRange(nes.EncodeNumber(rec.Str, 1));
             ret.AddRange(nes.EncodeNumber(rec.Int, 1));
             ret.AddRange(nes.EncodeNumber(rec.Wis, 1));
@@ -301,9 +301,10 @@ namespace EOLib.IO.Test.Pub
             ret.AddRange(nes.EncodeNumber(rec.AgiReq, 2));
             ret.AddRange(nes.EncodeNumber(rec.ConReq, 2));
             ret.AddRange(nes.EncodeNumber(rec.ChaReq, 2));
-            ret.AddRange(Enumerable.Repeat((byte)254, 2));
+            ret.AddRange(nes.EncodeNumber(rec.Element, 1));
+            ret.AddRange(nes.EncodeNumber(rec.ElementPower, 1));
             ret.AddRange(nes.EncodeNumber(rec.Weight, 1));
-            ret.AddRange(Enumerable.Repeat((byte)254, 1));
+            ret.AddRange(nes.EncodeNumber(rec.UnkByte56, 1));
             ret.AddRange(nes.EncodeNumber((byte)rec.Size, 1));
 
             return ret.ToArray();

--- a/EOLib.IO.Test/Pub/ENFRecordTest.cs
+++ b/EOLib.IO.Test/Pub/ENFRecordTest.cs
@@ -176,21 +176,25 @@ namespace EOLib.IO.Test.Pub
             var ret = new List<byte>();
 
             ret.AddRange(nes.EncodeNumber(rec.Graphic, 2));
-            ret.AddRange(Enumerable.Repeat((byte)254, 1));
+            ret.AddRange(nes.EncodeNumber(rec.UnkByte2, 1));
             ret.AddRange(nes.EncodeNumber(rec.Boss, 2));
             ret.AddRange(nes.EncodeNumber(rec.Child, 2));
             ret.AddRange(nes.EncodeNumber((short)rec.Type, 2));
             ret.AddRange(nes.EncodeNumber(rec.VendorID, 2));
             ret.AddRange(nes.EncodeNumber(rec.HP, 3));
-            ret.AddRange(Enumerable.Repeat((byte)254, 2));
+            ret.AddRange(nes.EncodeNumber(rec.UnkShort14, 2));
             ret.AddRange(nes.EncodeNumber(rec.MinDam, 2));
             ret.AddRange(nes.EncodeNumber(rec.MaxDam, 2));
             ret.AddRange(nes.EncodeNumber(rec.Accuracy, 2));
             ret.AddRange(nes.EncodeNumber(rec.Evade, 2));
             ret.AddRange(nes.EncodeNumber(rec.Armor, 2));
-            ret.AddRange(Enumerable.Repeat((byte)254, 10));
-            ret.AddRange(nes.EncodeNumber(rec.Exp, 2));
-            ret.AddRange(Enumerable.Repeat((byte)254, 1));
+            ret.AddRange(nes.EncodeNumber(rec.UnkByte26, 1));
+            ret.AddRange(nes.EncodeNumber(rec.UnkShort27, 2));
+            ret.AddRange(nes.EncodeNumber(rec.UnkShort29, 2));
+            ret.AddRange(nes.EncodeNumber(rec.ElementWeak, 2));
+            ret.AddRange(nes.EncodeNumber(rec.ElementWeakPower, 2));
+            ret.AddRange(nes.EncodeNumber(rec.UnkByte35, 1));
+            ret.AddRange(nes.EncodeNumber(rec.Exp, 3));
 
             return ret.ToArray();
         }

--- a/EOLib.IO.Test/Pub/ESFRecordTest.cs
+++ b/EOLib.IO.Test/Pub/ESFRecordTest.cs
@@ -183,18 +183,31 @@ namespace EOLib.IO.Test.Pub
             ret.AddRange(nes.EncodeNumber(rec.TP, 2));
             ret.AddRange(nes.EncodeNumber(rec.SP, 2));
             ret.AddRange(nes.EncodeNumber(rec.CastTime, 1));
-            ret.AddRange(Enumerable.Repeat((byte)254, 2));
-            ret.AddRange(nes.EncodeNumber((byte)rec.Type, 1));
-            ret.AddRange(Enumerable.Repeat((byte)254, 5));
+            ret.AddRange(nes.EncodeNumber(rec.UnkByte9, 1));
+            ret.AddRange(nes.EncodeNumber(rec.UnkByte10, 1));
+            ret.AddRange(nes.EncodeNumber((int)rec.Type, 3));
+            ret.AddRange(nes.EncodeNumber(rec.UnkByte14, 1));
+            ret.AddRange(nes.EncodeNumber(rec.UnkShort15, 2));
             ret.AddRange(nes.EncodeNumber((byte)rec.TargetRestrict, 1));
             ret.AddRange(nes.EncodeNumber((byte)rec.Target, 1));
-            ret.AddRange(Enumerable.Repeat((byte)254, 4));
+            ret.AddRange(nes.EncodeNumber(rec.UnkByte19, 1));
+            ret.AddRange(nes.EncodeNumber(rec.UnkByte20, 1));
+            ret.AddRange(nes.EncodeNumber(rec.UnkShort21, 2));
             ret.AddRange(nes.EncodeNumber(rec.MinDam, 2));
             ret.AddRange(nes.EncodeNumber(rec.MaxDam, 2));
             ret.AddRange(nes.EncodeNumber(rec.Accuracy, 2));
-            ret.AddRange(Enumerable.Repeat((byte)254, 5));
+            ret.AddRange(nes.EncodeNumber(rec.UnkShort29, 2));
+            ret.AddRange(nes.EncodeNumber(rec.UnkShort31, 2));
+            ret.AddRange(nes.EncodeNumber(rec.UnkByte33, 1));
             ret.AddRange(nes.EncodeNumber(rec.HP, 2));
-            ret.AddRange(Enumerable.Repeat((byte)254, 15));
+            ret.AddRange(nes.EncodeNumber(rec.UnkShort36, 2));
+            ret.AddRange(nes.EncodeNumber(rec.UnkByte38, 1));
+            ret.AddRange(nes.EncodeNumber(rec.UnkShort39, 2));
+            ret.AddRange(nes.EncodeNumber(rec.UnkShort41, 2));
+            ret.AddRange(nes.EncodeNumber(rec.UnkShort43, 2));
+            ret.AddRange(nes.EncodeNumber(rec.UnkShort45, 2));
+            ret.AddRange(nes.EncodeNumber(rec.UnkShort47, 2));
+            ret.AddRange(nes.EncodeNumber(rec.UnkShort49, 2));
 
             return ret.ToArray();
         }

--- a/EOLib.IO/Pub/EIFRecord.cs
+++ b/EOLib.IO/Pub/EIFRecord.cs
@@ -30,7 +30,7 @@ namespace EOLib.IO.Pub
         public short Evade { get; set; }
         public short Armor { get; set; }
 
-        public byte UnkB { get; set; }
+        public byte UnkByte19 { get; set; }
 
         public byte Str { get; set; }
         public byte Int { get; set; }
@@ -72,12 +72,12 @@ namespace EOLib.IO.Pub
         public short ConReq { get; set; }
         public short ChaReq { get; set; }
 
-        public byte UnkD { get; set; } // Element (?)
-        public byte UnkE { get; set; } // Element Power (?)
+        public byte Element { get; set; }
+        public byte ElementPower { get; set; }
 
         public byte Weight { get; set; }
 
-        public byte UnkF { get; set; }
+        public byte UnkByte56 { get; set; }
 
         public ItemSize Size { get; set; }
 
@@ -121,7 +121,7 @@ namespace EOLib.IO.Pub
                 mem.Write(numberEncoderService.EncodeNumber(Evade, 2), 0, 2);
                 mem.Write(numberEncoderService.EncodeNumber(Armor, 2), 0, 2);
 
-                mem.WriteByte(numberEncoderService.EncodeNumber(UnkB, 1)[0]);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkByte19, 1)[0]);
 
                 mem.WriteByte(numberEncoderService.EncodeNumber(Str, 1)[0]);
                 mem.WriteByte(numberEncoderService.EncodeNumber(Int, 1)[0]);
@@ -151,11 +151,11 @@ namespace EOLib.IO.Pub
                 mem.Write(numberEncoderService.EncodeNumber(ConReq, 2), 0, 2);
                 mem.Write(numberEncoderService.EncodeNumber(ChaReq, 2), 0, 2);
 
-                mem.WriteByte(numberEncoderService.EncodeNumber(UnkD, 1)[0]);
-                mem.WriteByte(numberEncoderService.EncodeNumber(UnkE, 1)[0]);
+                mem.WriteByte(numberEncoderService.EncodeNumber(Element, 1)[0]);
+                mem.WriteByte(numberEncoderService.EncodeNumber(ElementPower, 1)[0]);
 
                 mem.WriteByte(numberEncoderService.EncodeNumber(Weight, 1)[0]);
-                mem.WriteByte(numberEncoderService.EncodeNumber(UnkF, 1)[0]);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkByte56, 1)[0]);
                 mem.WriteByte(numberEncoderService.EncodeNumber((byte)Size, 1)[0]);
             }
 
@@ -166,14 +166,6 @@ namespace EOLib.IO.Pub
         {
             if (recordBytes.Length != DATA_SIZE)
                 throw new ArgumentOutOfRangeException(nameof(recordBytes), "Data is not properly sized for correct deserialization");
-
-
-            Console.Write(this.Name + " [");
-            for (int i = 0; i < recordBytes.Length; i++)
-            {
-                Console.Write(recordBytes[i] + "[pos:" + i + "], ");
-            }
-            Console.Write("]\n");
 
             Graphic = (short)numberEncoderService.DecodeNumber(recordBytes[0], recordBytes[1]);
             Type = (ItemType)numberEncoderService.DecodeNumber(recordBytes[2]);
@@ -188,7 +180,7 @@ namespace EOLib.IO.Pub
             Evade = (short)numberEncoderService.DecodeNumber(recordBytes[15], recordBytes[16]);
             Armor = (short)numberEncoderService.DecodeNumber(recordBytes[17], recordBytes[18]);
 
-            UnkB = (byte)numberEncoderService.DecodeNumber(recordBytes[19]);
+            UnkByte19 = (byte)numberEncoderService.DecodeNumber(recordBytes[19]);
 
             Str = (byte)numberEncoderService.DecodeNumber(recordBytes[20]);
             Int = (byte)numberEncoderService.DecodeNumber(recordBytes[21]);
@@ -218,11 +210,11 @@ namespace EOLib.IO.Pub
             ConReq = (short)numberEncoderService.DecodeNumber(recordBytes[49], recordBytes[50]);
             ChaReq = (short)numberEncoderService.DecodeNumber(recordBytes[51], recordBytes[52]);
 
-            UnkD = (byte)numberEncoderService.DecodeNumber(recordBytes[53]);
-            UnkE = (byte)numberEncoderService.DecodeNumber(recordBytes[54]);
+            Element = (byte)numberEncoderService.DecodeNumber(recordBytes[53]);
+            ElementPower = (byte)numberEncoderService.DecodeNumber(recordBytes[54]);
 
             Weight = (byte)numberEncoderService.DecodeNumber(recordBytes[55]);
-            UnkF = (byte)numberEncoderService.DecodeNumber(recordBytes[56]);
+            UnkByte56 = (byte)numberEncoderService.DecodeNumber(recordBytes[56]);
             Size = (ItemSize)numberEncoderService.DecodeNumber(recordBytes[57]);
 
             if (ID == 365 && Name == "Gun")

--- a/EOLib.IO/Pub/EIFRecord.cs
+++ b/EOLib.IO/Pub/EIFRecord.cs
@@ -30,6 +30,8 @@ namespace EOLib.IO.Pub
         public short Evade { get; set; }
         public short Armor { get; set; }
 
+        public byte UnkB { get; set; }
+
         public byte Str { get; set; }
         public byte Int { get; set; }
         public byte Wis { get; set; }
@@ -70,7 +72,12 @@ namespace EOLib.IO.Pub
         public short ConReq { get; set; }
         public short ChaReq { get; set; }
 
+        public byte UnkD { get; set; } // Element (?)
+        public byte UnkE { get; set; } // Element Power (?)
+
         public byte Weight { get; set; }
+
+        public byte UnkF { get; set; }
 
         public ItemSize Size { get; set; }
 
@@ -88,7 +95,7 @@ namespace EOLib.IO.Pub
             var propertyInfo = GetType().GetProperty(name, BindingFlags.Instance | BindingFlags.Public);
             var boxedValue = propertyInfo.GetValue(this);
 
-            return (TValue) boxedValue;
+            return (TValue)boxedValue;
         }
 
         public byte[] SerializeToByteArray(INumberEncoderService numberEncoderService)
@@ -102,9 +109,9 @@ namespace EOLib.IO.Pub
                 mem.Write(name, 0, name.Length);
 
                 mem.Write(numberEncoderService.EncodeNumber(Graphic, 2), 0, 2);
-                mem.WriteByte(numberEncoderService.EncodeNumber((byte) Type, 1)[0]);
-                mem.WriteByte(numberEncoderService.EncodeNumber((byte) SubType, 1)[0]);
-                mem.WriteByte(numberEncoderService.EncodeNumber((byte) Special, 1)[0]);
+                mem.WriteByte(numberEncoderService.EncodeNumber((byte)Type, 1)[0]);
+                mem.WriteByte(numberEncoderService.EncodeNumber((byte)SubType, 1)[0]);
+                mem.WriteByte(numberEncoderService.EncodeNumber((byte)Special, 1)[0]);
 
                 mem.Write(numberEncoderService.EncodeNumber(HP, 2), 0, 2);
                 mem.Write(numberEncoderService.EncodeNumber(TP, 2), 0, 2);
@@ -114,7 +121,8 @@ namespace EOLib.IO.Pub
                 mem.Write(numberEncoderService.EncodeNumber(Evade, 2), 0, 2);
                 mem.Write(numberEncoderService.EncodeNumber(Armor, 2), 0, 2);
 
-                mem.Seek(21 + Name.Length, SeekOrigin.Begin);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkB, 1)[0]);
+
                 mem.WriteByte(numberEncoderService.EncodeNumber(Str, 1)[0]);
                 mem.WriteByte(numberEncoderService.EncodeNumber(Int, 1)[0]);
                 mem.WriteByte(numberEncoderService.EncodeNumber(Wis, 1)[0]);
@@ -143,10 +151,12 @@ namespace EOLib.IO.Pub
                 mem.Write(numberEncoderService.EncodeNumber(ConReq, 2), 0, 2);
                 mem.Write(numberEncoderService.EncodeNumber(ChaReq, 2), 0, 2);
 
-                mem.Seek(56 + Name.Length, SeekOrigin.Begin);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkD, 1)[0]);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkE, 1)[0]);
+
                 mem.WriteByte(numberEncoderService.EncodeNumber(Weight, 1)[0]);
-                mem.Seek(58 + Name.Length, SeekOrigin.Begin);
-                mem.WriteByte(numberEncoderService.EncodeNumber((byte) Size, 1)[0]);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkF, 1)[0]);
+                mem.WriteByte(numberEncoderService.EncodeNumber((byte)Size, 1)[0]);
             }
 
             return ret;
@@ -157,49 +167,63 @@ namespace EOLib.IO.Pub
             if (recordBytes.Length != DATA_SIZE)
                 throw new ArgumentOutOfRangeException(nameof(recordBytes), "Data is not properly sized for correct deserialization");
 
-            Graphic = (short) numberEncoderService.DecodeNumber(recordBytes[0], recordBytes[1]);
-            Type = (ItemType) numberEncoderService.DecodeNumber(recordBytes[2]);
-            SubType = (ItemSubType) numberEncoderService.DecodeNumber(recordBytes[3]);
 
-            Special = (ItemSpecial) numberEncoderService.DecodeNumber(recordBytes[4]);
-            HP = (short) numberEncoderService.DecodeNumber(recordBytes[5], recordBytes[6]);
-            TP = (short) numberEncoderService.DecodeNumber(recordBytes[7], recordBytes[8]);
-            MinDam = (short) numberEncoderService.DecodeNumber(recordBytes[9], recordBytes[10]);
-            MaxDam = (short) numberEncoderService.DecodeNumber(recordBytes[11], recordBytes[12]);
-            Accuracy = (short) numberEncoderService.DecodeNumber(recordBytes[13], recordBytes[14]);
-            Evade = (short) numberEncoderService.DecodeNumber(recordBytes[15], recordBytes[16]);
-            Armor = (short) numberEncoderService.DecodeNumber(recordBytes[17], recordBytes[18]);
+            Console.Write(this.Name + " [");
+            for (int i = 0; i < recordBytes.Length; i++)
+            {
+                Console.Write(recordBytes[i] + "[pos:" + i + "], ");
+            }
+            Console.Write("]\n");
 
-            Str = (byte) numberEncoderService.DecodeNumber(recordBytes[20]);
-            Int = (byte) numberEncoderService.DecodeNumber(recordBytes[21]);
-            Wis = (byte) numberEncoderService.DecodeNumber(recordBytes[22]);
-            Agi = (byte) numberEncoderService.DecodeNumber(recordBytes[23]);
-            Con = (byte) numberEncoderService.DecodeNumber(recordBytes[24]);
-            Cha = (byte) numberEncoderService.DecodeNumber(recordBytes[25]);
+            Graphic = (short)numberEncoderService.DecodeNumber(recordBytes[0], recordBytes[1]);
+            Type = (ItemType)numberEncoderService.DecodeNumber(recordBytes[2]);
+            SubType = (ItemSubType)numberEncoderService.DecodeNumber(recordBytes[3]);
 
-            Light = (byte) numberEncoderService.DecodeNumber(recordBytes[26]);
-            Dark = (byte) numberEncoderService.DecodeNumber(recordBytes[27]);
-            Earth = (byte) numberEncoderService.DecodeNumber(recordBytes[28]);
-            Air = (byte) numberEncoderService.DecodeNumber(recordBytes[29]);
-            Water = (byte) numberEncoderService.DecodeNumber(recordBytes[30]);
-            Fire = (byte) numberEncoderService.DecodeNumber(recordBytes[31]);
+            Special = (ItemSpecial)numberEncoderService.DecodeNumber(recordBytes[4]);
+            HP = (short)numberEncoderService.DecodeNumber(recordBytes[5], recordBytes[6]);
+            TP = (short)numberEncoderService.DecodeNumber(recordBytes[7], recordBytes[8]);
+            MinDam = (short)numberEncoderService.DecodeNumber(recordBytes[9], recordBytes[10]);
+            MaxDam = (short)numberEncoderService.DecodeNumber(recordBytes[11], recordBytes[12]);
+            Accuracy = (short)numberEncoderService.DecodeNumber(recordBytes[13], recordBytes[14]);
+            Evade = (short)numberEncoderService.DecodeNumber(recordBytes[15], recordBytes[16]);
+            Armor = (short)numberEncoderService.DecodeNumber(recordBytes[17], recordBytes[18]);
+
+            UnkB = (byte)numberEncoderService.DecodeNumber(recordBytes[19]);
+
+            Str = (byte)numberEncoderService.DecodeNumber(recordBytes[20]);
+            Int = (byte)numberEncoderService.DecodeNumber(recordBytes[21]);
+            Wis = (byte)numberEncoderService.DecodeNumber(recordBytes[22]);
+            Agi = (byte)numberEncoderService.DecodeNumber(recordBytes[23]);
+            Con = (byte)numberEncoderService.DecodeNumber(recordBytes[24]);
+            Cha = (byte)numberEncoderService.DecodeNumber(recordBytes[25]);
+
+            Light = (byte)numberEncoderService.DecodeNumber(recordBytes[26]);
+            Dark = (byte)numberEncoderService.DecodeNumber(recordBytes[27]);
+            Earth = (byte)numberEncoderService.DecodeNumber(recordBytes[28]);
+            Air = (byte)numberEncoderService.DecodeNumber(recordBytes[29]);
+            Water = (byte)numberEncoderService.DecodeNumber(recordBytes[30]);
+            Fire = (byte)numberEncoderService.DecodeNumber(recordBytes[31]);
 
             ScrollMap = numberEncoderService.DecodeNumber(recordBytes[32], recordBytes[33], recordBytes[34]);
-            ScrollX = (byte) numberEncoderService.DecodeNumber(recordBytes[35]);
-            ScrollY = (byte) numberEncoderService.DecodeNumber(recordBytes[36]);
+            ScrollX = (byte)numberEncoderService.DecodeNumber(recordBytes[35]);
+            ScrollY = (byte)numberEncoderService.DecodeNumber(recordBytes[36]);
 
-            LevelReq = (short) numberEncoderService.DecodeNumber(recordBytes[37], recordBytes[38]);
-            ClassReq = (short) numberEncoderService.DecodeNumber(recordBytes[39], recordBytes[40]);
+            LevelReq = (short)numberEncoderService.DecodeNumber(recordBytes[37], recordBytes[38]);
+            ClassReq = (short)numberEncoderService.DecodeNumber(recordBytes[39], recordBytes[40]);
 
-            StrReq = (short) numberEncoderService.DecodeNumber(recordBytes[41], recordBytes[42]);
-            IntReq = (short) numberEncoderService.DecodeNumber(recordBytes[43], recordBytes[44]);
-            WisReq = (short) numberEncoderService.DecodeNumber(recordBytes[45], recordBytes[46]);
-            AgiReq = (short) numberEncoderService.DecodeNumber(recordBytes[47], recordBytes[48]);
-            ConReq = (short) numberEncoderService.DecodeNumber(recordBytes[49], recordBytes[50]);
-            ChaReq = (short) numberEncoderService.DecodeNumber(recordBytes[51], recordBytes[52]);
+            StrReq = (short)numberEncoderService.DecodeNumber(recordBytes[41], recordBytes[42]);
+            IntReq = (short)numberEncoderService.DecodeNumber(recordBytes[43], recordBytes[44]);
+            WisReq = (short)numberEncoderService.DecodeNumber(recordBytes[45], recordBytes[46]);
+            AgiReq = (short)numberEncoderService.DecodeNumber(recordBytes[47], recordBytes[48]);
+            ConReq = (short)numberEncoderService.DecodeNumber(recordBytes[49], recordBytes[50]);
+            ChaReq = (short)numberEncoderService.DecodeNumber(recordBytes[51], recordBytes[52]);
 
-            Weight = (byte) numberEncoderService.DecodeNumber(recordBytes[55]);
-            Size = (ItemSize) numberEncoderService.DecodeNumber(recordBytes[57]);
+            UnkD = (byte)numberEncoderService.DecodeNumber(recordBytes[53]);
+            UnkE = (byte)numberEncoderService.DecodeNumber(recordBytes[54]);
+
+            Weight = (byte)numberEncoderService.DecodeNumber(recordBytes[55]);
+            UnkF = (byte)numberEncoderService.DecodeNumber(recordBytes[56]);
+            Size = (ItemSize)numberEncoderService.DecodeNumber(recordBytes[57]);
 
             if (ID == 365 && Name == "Gun")
                 SubType = ItemSubType.Ranged;

--- a/EOLib.IO/Pub/ENFRecord.cs
+++ b/EOLib.IO/Pub/ENFRecord.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -19,20 +19,33 @@ namespace EOLib.IO.Pub
 
         public int Graphic { get; set; }
 
+        public byte UnkA { get; set; }
+
         public short Boss { get; set; }
         public short Child { get; set; }
         public NPCType Type { get; set; }
 
+        public short UnkB { get; set; }
+
         public short VendorID { get; set; }
 
         public int HP { get; set; }
-        public ushort Exp { get; set; }
+
         public short MinDam { get; set; }
         public short MaxDam { get; set; }
 
         public short Accuracy { get; set; }
         public short Evade { get; set; }
         public short Armor { get; set; }
+
+        public byte UnkC { get; set; }
+        public short UnkD { get; set; }
+        public short UnkE { get; set; }
+        public short UnkF { get; set; }
+        public short UnkG { get; set; }
+        public byte UnkH { get; set; }
+
+        public int Exp { get; set; }
 
         public TValue Get<TValue>(PubRecordProperty type)
         {
@@ -63,22 +76,30 @@ namespace EOLib.IO.Pub
 
                 mem.Write(numberEncoderService.EncodeNumber(Graphic, 2), 0, 2);
 
-                mem.Seek(4 + Name.Length, SeekOrigin.Begin);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkA, 1)[0]);
+
                 mem.Write(numberEncoderService.EncodeNumber(Boss, 2), 0, 2);
                 mem.Write(numberEncoderService.EncodeNumber(Child, 2), 0, 2);
                 mem.Write(numberEncoderService.EncodeNumber((short)Type, 2), 0, 2);
                 mem.Write(numberEncoderService.EncodeNumber(VendorID, 2), 0, 2);
                 mem.Write(numberEncoderService.EncodeNumber(HP, 3), 0, 3);
 
-                mem.Seek(17 + Name.Length, SeekOrigin.Begin);
+                mem.Write(numberEncoderService.EncodeNumber(UnkB, 2), 0, 2);
+
                 mem.Write(numberEncoderService.EncodeNumber(MinDam, 2), 0, 2);
                 mem.Write(numberEncoderService.EncodeNumber(MaxDam, 2), 0, 2);
                 mem.Write(numberEncoderService.EncodeNumber(Accuracy, 2), 0, 2);
                 mem.Write(numberEncoderService.EncodeNumber(Evade, 2), 0, 2);
                 mem.Write(numberEncoderService.EncodeNumber(Armor, 2), 0, 2);
 
-                mem.Seek(37 + Name.Length, SeekOrigin.Begin);
-                mem.Write(numberEncoderService.EncodeNumber(Exp, 2), 0, 2);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkC, 1)[0]);
+                mem.Write(numberEncoderService.EncodeNumber(UnkD, 2), 0, 2);
+                mem.Write(numberEncoderService.EncodeNumber(UnkE, 2), 0, 2);
+                mem.Write(numberEncoderService.EncodeNumber(UnkF, 2), 0, 2);
+                mem.Write(numberEncoderService.EncodeNumber(UnkG, 2), 0, 2);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkH, 1)[0]);
+
+                mem.Write(numberEncoderService.EncodeNumber(Exp, 3), 0, 3);
             }
 
             return ret;
@@ -89,13 +110,24 @@ namespace EOLib.IO.Pub
             if (recordBytes.Length != DATA_SIZE)
                 throw new ArgumentOutOfRangeException(nameof(recordBytes), "Data is not properly sized for correct deserialization");
 
+            Console.Write(this.Name + " [");
+            for (int i = 0; i < recordBytes.Length; i++)
+            {
+                Console.Write(recordBytes[i] + "[pos:" + i + "], ");
+            }
+            Console.Write("]\n");
+
             Graphic = numberEncoderService.DecodeNumber(recordBytes[0], recordBytes[1]);
+
+            UnkA = (byte)numberEncoderService.DecodeNumber(recordBytes[2]);
 
             Boss = (short)numberEncoderService.DecodeNumber(recordBytes[3], recordBytes[4]);
             Child = (short)numberEncoderService.DecodeNumber(recordBytes[5], recordBytes[6]);
             Type = (NPCType)numberEncoderService.DecodeNumber(recordBytes[7], recordBytes[8]);
             VendorID = (short)numberEncoderService.DecodeNumber(recordBytes[9], recordBytes[10]);
             HP = numberEncoderService.DecodeNumber(recordBytes[11], recordBytes[12], recordBytes[13]);
+
+            UnkB = (short)numberEncoderService.DecodeNumber(recordBytes[14], recordBytes[15]);
 
             MinDam = (short)numberEncoderService.DecodeNumber(recordBytes[16], recordBytes[17]);
             MaxDam = (short)numberEncoderService.DecodeNumber(recordBytes[18], recordBytes[19]);
@@ -104,7 +136,14 @@ namespace EOLib.IO.Pub
             Evade = (short)numberEncoderService.DecodeNumber(recordBytes[22], recordBytes[23]);
             Armor = (short)numberEncoderService.DecodeNumber(recordBytes[24], recordBytes[25]);
 
-            Exp = (ushort)numberEncoderService.DecodeNumber(recordBytes[36], recordBytes[37]);
+            UnkC = (byte)numberEncoderService.DecodeNumber(recordBytes[26]);
+            UnkD = (short)numberEncoderService.DecodeNumber(recordBytes[27], recordBytes[28]);
+            UnkE = (short)numberEncoderService.DecodeNumber(recordBytes[29], recordBytes[30]);
+            UnkF = (short)numberEncoderService.DecodeNumber(recordBytes[31], recordBytes[32]);
+            UnkG = (short)numberEncoderService.DecodeNumber(recordBytes[33], recordBytes[34]);
+            UnkH = (byte)numberEncoderService.DecodeNumber(recordBytes[35]);
+
+            Exp = numberEncoderService.DecodeNumber(recordBytes[36], recordBytes[37], recordBytes[38]);
         }
     }
 }

--- a/EOLib.IO/Pub/ENFRecord.cs
+++ b/EOLib.IO/Pub/ENFRecord.cs
@@ -19,13 +19,13 @@ namespace EOLib.IO.Pub
 
         public int Graphic { get; set; }
 
-        public byte UnkA { get; set; }
+        public byte UnkByte2 { get; set; }
 
         public short Boss { get; set; }
         public short Child { get; set; }
         public NPCType Type { get; set; }
 
-        public short UnkB { get; set; }
+        public short UnkShort14 { get; set; }
 
         public short VendorID { get; set; }
 
@@ -38,12 +38,14 @@ namespace EOLib.IO.Pub
         public short Evade { get; set; }
         public short Armor { get; set; }
 
-        public byte UnkC { get; set; }
-        public short UnkD { get; set; }
-        public short UnkE { get; set; }
-        public short UnkF { get; set; }
-        public short UnkG { get; set; }
-        public byte UnkH { get; set; }
+        public byte UnkByte26 { get; set; }
+        public short UnkShort27 { get; set; }
+        public short UnkShort29 { get; set; }
+
+        public short ElementWeak { get; set; }
+        public short ElementWeakPower { get; set; }
+
+        public byte UnkByte35 { get; set; }
 
         public int Exp { get; set; }
 
@@ -76,7 +78,7 @@ namespace EOLib.IO.Pub
 
                 mem.Write(numberEncoderService.EncodeNumber(Graphic, 2), 0, 2);
 
-                mem.WriteByte(numberEncoderService.EncodeNumber(UnkA, 1)[0]);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkByte2, 1)[0]);
 
                 mem.Write(numberEncoderService.EncodeNumber(Boss, 2), 0, 2);
                 mem.Write(numberEncoderService.EncodeNumber(Child, 2), 0, 2);
@@ -84,7 +86,7 @@ namespace EOLib.IO.Pub
                 mem.Write(numberEncoderService.EncodeNumber(VendorID, 2), 0, 2);
                 mem.Write(numberEncoderService.EncodeNumber(HP, 3), 0, 3);
 
-                mem.Write(numberEncoderService.EncodeNumber(UnkB, 2), 0, 2);
+                mem.Write(numberEncoderService.EncodeNumber(UnkShort14, 2), 0, 2);
 
                 mem.Write(numberEncoderService.EncodeNumber(MinDam, 2), 0, 2);
                 mem.Write(numberEncoderService.EncodeNumber(MaxDam, 2), 0, 2);
@@ -92,12 +94,12 @@ namespace EOLib.IO.Pub
                 mem.Write(numberEncoderService.EncodeNumber(Evade, 2), 0, 2);
                 mem.Write(numberEncoderService.EncodeNumber(Armor, 2), 0, 2);
 
-                mem.WriteByte(numberEncoderService.EncodeNumber(UnkC, 1)[0]);
-                mem.Write(numberEncoderService.EncodeNumber(UnkD, 2), 0, 2);
-                mem.Write(numberEncoderService.EncodeNumber(UnkE, 2), 0, 2);
-                mem.Write(numberEncoderService.EncodeNumber(UnkF, 2), 0, 2);
-                mem.Write(numberEncoderService.EncodeNumber(UnkG, 2), 0, 2);
-                mem.WriteByte(numberEncoderService.EncodeNumber(UnkH, 1)[0]);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkByte26, 1)[0]);
+                mem.Write(numberEncoderService.EncodeNumber(UnkShort27, 2), 0, 2);
+                mem.Write(numberEncoderService.EncodeNumber(UnkShort29, 2), 0, 2);
+                mem.Write(numberEncoderService.EncodeNumber(ElementWeak, 2), 0, 2);
+                mem.Write(numberEncoderService.EncodeNumber(ElementWeakPower, 2), 0, 2);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkByte35, 1)[0]);
 
                 mem.Write(numberEncoderService.EncodeNumber(Exp, 3), 0, 3);
             }
@@ -110,16 +112,9 @@ namespace EOLib.IO.Pub
             if (recordBytes.Length != DATA_SIZE)
                 throw new ArgumentOutOfRangeException(nameof(recordBytes), "Data is not properly sized for correct deserialization");
 
-            Console.Write(this.Name + " [");
-            for (int i = 0; i < recordBytes.Length; i++)
-            {
-                Console.Write(recordBytes[i] + "[pos:" + i + "], ");
-            }
-            Console.Write("]\n");
-
             Graphic = numberEncoderService.DecodeNumber(recordBytes[0], recordBytes[1]);
 
-            UnkA = (byte)numberEncoderService.DecodeNumber(recordBytes[2]);
+            UnkByte2 = (byte)numberEncoderService.DecodeNumber(recordBytes[2]);
 
             Boss = (short)numberEncoderService.DecodeNumber(recordBytes[3], recordBytes[4]);
             Child = (short)numberEncoderService.DecodeNumber(recordBytes[5], recordBytes[6]);
@@ -127,7 +122,7 @@ namespace EOLib.IO.Pub
             VendorID = (short)numberEncoderService.DecodeNumber(recordBytes[9], recordBytes[10]);
             HP = numberEncoderService.DecodeNumber(recordBytes[11], recordBytes[12], recordBytes[13]);
 
-            UnkB = (short)numberEncoderService.DecodeNumber(recordBytes[14], recordBytes[15]);
+            UnkShort14 = (short)numberEncoderService.DecodeNumber(recordBytes[14], recordBytes[15]);
 
             MinDam = (short)numberEncoderService.DecodeNumber(recordBytes[16], recordBytes[17]);
             MaxDam = (short)numberEncoderService.DecodeNumber(recordBytes[18], recordBytes[19]);
@@ -136,12 +131,12 @@ namespace EOLib.IO.Pub
             Evade = (short)numberEncoderService.DecodeNumber(recordBytes[22], recordBytes[23]);
             Armor = (short)numberEncoderService.DecodeNumber(recordBytes[24], recordBytes[25]);
 
-            UnkC = (byte)numberEncoderService.DecodeNumber(recordBytes[26]);
-            UnkD = (short)numberEncoderService.DecodeNumber(recordBytes[27], recordBytes[28]);
-            UnkE = (short)numberEncoderService.DecodeNumber(recordBytes[29], recordBytes[30]);
-            UnkF = (short)numberEncoderService.DecodeNumber(recordBytes[31], recordBytes[32]);
-            UnkG = (short)numberEncoderService.DecodeNumber(recordBytes[33], recordBytes[34]);
-            UnkH = (byte)numberEncoderService.DecodeNumber(recordBytes[35]);
+            UnkByte26 = (byte)numberEncoderService.DecodeNumber(recordBytes[26]);
+            UnkShort27 = (short)numberEncoderService.DecodeNumber(recordBytes[27], recordBytes[28]);
+            UnkShort29 = (short)numberEncoderService.DecodeNumber(recordBytes[29], recordBytes[30]);
+            ElementWeak = (short)numberEncoderService.DecodeNumber(recordBytes[31], recordBytes[32]);
+            ElementWeakPower = (short)numberEncoderService.DecodeNumber(recordBytes[33], recordBytes[34]);
+            UnkByte35 = (byte)numberEncoderService.DecodeNumber(recordBytes[35]);
 
             Exp = numberEncoderService.DecodeNumber(recordBytes[36], recordBytes[37], recordBytes[38]);
         }

--- a/EOLib.IO/Pub/ESFRecord.cs
+++ b/EOLib.IO/Pub/ESFRecord.cs
@@ -99,7 +99,7 @@ namespace EOLib.IO.Pub
                 mem.WriteByte(numberEncoderService.EncodeNumber(UnkA, 1)[0]);
                 mem.WriteByte(numberEncoderService.EncodeNumber(UnkB, 1)[0]);
 
-                mem.Write(numberEncoderService.EncodeNumber((byte)Type, 3), 0, 3); //This is documented as a 3 byte int.
+                mem.Write(numberEncoderService.EncodeNumber((int)Type, 3), 0, 3); //This is documented as a 3 byte int.
 
                 mem.WriteByte(numberEncoderService.EncodeNumber(UnkC, 1)[0]);
                 mem.Write(numberEncoderService.EncodeNumber(UnkD, 2), 0, 2);

--- a/EOLib.IO/Pub/ESFRecord.cs
+++ b/EOLib.IO/Pub/ESFRecord.cs
@@ -26,39 +26,39 @@ namespace EOLib.IO.Pub
 
         public byte CastTime { get; set; }
 
-        public byte UnkA { get; set; }
-        public byte UnkB { get; set; }
+        public byte UnkByte9 { get; set; }
+        public byte UnkByte10 { get; set; }
 
         public SpellType Type { get; set; }
 
-        public byte UnkC { get; set; }
-        public short UnkD { get; set; }
+        public byte UnkByte14 { get; set; }
+        public short UnkShort15 { get; set; }
 
         public SpellTargetRestrict TargetRestrict { get; set; }
         public SpellTarget Target { get; set; }
 
-        public byte UnkE { get; set; }
-        public byte UnkF { get; set; }
-        public short UnkG { get; set; }
+        public byte UnkByte19 { get; set; }
+        public byte UnkByte20 { get; set; }
+        public short UnkShort21 { get; set; }
 
         public short MinDam { get; set; }
         public short MaxDam { get; set; }
         public short Accuracy { get; set; }
 
-        public short UnkH { get; set; }
-        public short UnkI { get; set; }
-        public byte UnkJ { get; set; }
+        public short UnkShort29 { get; set; }
+        public short UnkShort31 { get; set; }
+        public byte UnkByte33 { get; set; }
 
         public short HP { get; set; }
 
-        public short UnkK { get; set; }
-        public byte UnkL { get; set; }
-        public short UnkM { get; set; }
-        public short UnkN { get; set; }
-        public short UnkO { get; set; }
-        public short UnkP { get; set; }
-        public short UnkQ { get; set; }
-        public short UnkR { get; set; }
+        public short UnkShort36 { get; set; }
+        public byte UnkByte38 { get; set; }
+        public short UnkShort39 { get; set; }
+        public short UnkShort41 { get; set; }
+        public short UnkShort43 { get; set; }
+        public short UnkShort45 { get; set; }
+        public short UnkShort47 { get; set; }
+        public short UnkShort49 { get; set; }
 
         public TValue Get<TValue>(PubRecordProperty type)
         {
@@ -96,39 +96,39 @@ namespace EOLib.IO.Pub
                 mem.Write(numberEncoderService.EncodeNumber(SP, 2), 0, 2);
                 mem.WriteByte(numberEncoderService.EncodeNumber(CastTime, 1)[0]);
 
-                mem.WriteByte(numberEncoderService.EncodeNumber(UnkA, 1)[0]);
-                mem.WriteByte(numberEncoderService.EncodeNumber(UnkB, 1)[0]);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkByte9, 1)[0]);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkByte10, 1)[0]);
 
                 mem.Write(numberEncoderService.EncodeNumber((int)Type, 3), 0, 3); //This is documented as a 3 byte int.
 
-                mem.WriteByte(numberEncoderService.EncodeNumber(UnkC, 1)[0]);
-                mem.Write(numberEncoderService.EncodeNumber(UnkD, 2), 0, 2);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkByte14, 1)[0]);
+                mem.Write(numberEncoderService.EncodeNumber(UnkShort15, 2), 0, 2);
 
                 mem.WriteByte(numberEncoderService.EncodeNumber((byte)TargetRestrict, 1)[0]);
                 mem.WriteByte(numberEncoderService.EncodeNumber((byte)Target, 1)[0]);
 
-                mem.WriteByte(numberEncoderService.EncodeNumber(UnkE, 1)[0]);
-                mem.WriteByte(numberEncoderService.EncodeNumber(UnkF, 1)[0]);
-                mem.Write(numberEncoderService.EncodeNumber(UnkG, 2), 0, 2);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkByte19, 1)[0]);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkByte20, 1)[0]);
+                mem.Write(numberEncoderService.EncodeNumber(UnkShort21, 2), 0, 2);
 
                 mem.Write(numberEncoderService.EncodeNumber(MinDam, 2), 0, 2);
                 mem.Write(numberEncoderService.EncodeNumber(MaxDam, 2), 0, 2);
                 mem.Write(numberEncoderService.EncodeNumber(Accuracy, 2), 0, 2);
 
-                mem.Write(numberEncoderService.EncodeNumber(UnkH, 2), 0, 2);
-                mem.Write(numberEncoderService.EncodeNumber(UnkI, 2), 0, 2);
-                mem.WriteByte(numberEncoderService.EncodeNumber(UnkJ, 1)[0]);
+                mem.Write(numberEncoderService.EncodeNumber(UnkShort29, 2), 0, 2);
+                mem.Write(numberEncoderService.EncodeNumber(UnkShort31, 2), 0, 2);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkByte33, 1)[0]);
 
                 mem.Write(numberEncoderService.EncodeNumber(HP, 2), 0, 2);
 
-                mem.Write(numberEncoderService.EncodeNumber(UnkK, 2), 0, 2);
-                mem.WriteByte(numberEncoderService.EncodeNumber(UnkL, 1)[0]);
-                mem.Write(numberEncoderService.EncodeNumber(UnkM, 2), 0, 2);
-                mem.Write(numberEncoderService.EncodeNumber(UnkN, 2), 0, 2);
-                mem.Write(numberEncoderService.EncodeNumber(UnkO, 2), 0, 2);
-                mem.Write(numberEncoderService.EncodeNumber(UnkP, 2), 0, 2);
-                mem.Write(numberEncoderService.EncodeNumber(UnkQ, 2), 0, 2);
-                mem.Write(numberEncoderService.EncodeNumber(UnkR, 2), 0, 2);
+                mem.Write(numberEncoderService.EncodeNumber(UnkShort36, 2), 0, 2);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkByte38, 1)[0]);
+                mem.Write(numberEncoderService.EncodeNumber(UnkShort39, 2), 0, 2);
+                mem.Write(numberEncoderService.EncodeNumber(UnkShort41, 2), 0, 2);
+                mem.Write(numberEncoderService.EncodeNumber(UnkShort43, 2), 0, 2);
+                mem.Write(numberEncoderService.EncodeNumber(UnkShort45, 2), 0, 2);
+                mem.Write(numberEncoderService.EncodeNumber(UnkShort47, 2), 0, 2);
+                mem.Write(numberEncoderService.EncodeNumber(UnkShort49, 2), 0, 2);
             }
 
             return ret;
@@ -139,52 +139,45 @@ namespace EOLib.IO.Pub
             if (recordBytes.Length != DATA_SIZE)
                 throw new ArgumentOutOfRangeException(nameof(recordBytes), "Data is not properly sized for correct deserialization");
 
-            Console.Write(this.Name + " [");
-            for (int i = 0; i < recordBytes.Length; i++)
-            {
-                Console.Write(recordBytes[i] + "[pos:" + i + "], ");
-            }
-            Console.Write("]\n");
-
             Icon = (short)numberEncoderService.DecodeNumber(recordBytes[0], recordBytes[1]);
             Graphic = (short)numberEncoderService.DecodeNumber(recordBytes[2], recordBytes[3]);
             TP = (short)numberEncoderService.DecodeNumber(recordBytes[4], recordBytes[5]);
             SP = (short)numberEncoderService.DecodeNumber(recordBytes[6], recordBytes[7]);
             CastTime = (byte)numberEncoderService.DecodeNumber(recordBytes[8]);
 
-            UnkA = (byte)numberEncoderService.DecodeNumber(recordBytes[9]);
-            UnkB = (byte)numberEncoderService.DecodeNumber(recordBytes[10]);
+            UnkByte9 = (byte)numberEncoderService.DecodeNumber(recordBytes[9]);
+            UnkByte10 = (byte)numberEncoderService.DecodeNumber(recordBytes[10]);
 
             Type = (SpellType)numberEncoderService.DecodeNumber(recordBytes[11], recordBytes[12], recordBytes[13]);
 
-            UnkC = (byte)numberEncoderService.DecodeNumber(recordBytes[14]);
-            UnkD = (short)numberEncoderService.DecodeNumber(recordBytes[15], recordBytes[16]);
+            UnkByte14 = (byte)numberEncoderService.DecodeNumber(recordBytes[14]);
+            UnkShort15 = (short)numberEncoderService.DecodeNumber(recordBytes[15], recordBytes[16]);
 
             TargetRestrict = (SpellTargetRestrict)numberEncoderService.DecodeNumber(recordBytes[17]);
             Target = (SpellTarget)numberEncoderService.DecodeNumber(recordBytes[18]);
 
-            UnkE = (byte)numberEncoderService.DecodeNumber(recordBytes[19]);
-            UnkF = (byte)numberEncoderService.DecodeNumber(recordBytes[20]);
-            UnkG = (short)numberEncoderService.DecodeNumber(recordBytes[21], recordBytes[22]);
+            UnkByte19 = (byte)numberEncoderService.DecodeNumber(recordBytes[19]);
+            UnkByte20 = (byte)numberEncoderService.DecodeNumber(recordBytes[20]);
+            UnkShort21 = (short)numberEncoderService.DecodeNumber(recordBytes[21], recordBytes[22]);
 
             MinDam = (short)numberEncoderService.DecodeNumber(recordBytes[23], recordBytes[24]);
             MaxDam = (short)numberEncoderService.DecodeNumber(recordBytes[25], recordBytes[26]);
             Accuracy = (short)numberEncoderService.DecodeNumber(recordBytes[27], recordBytes[28]);
 
-            UnkH = (short)numberEncoderService.DecodeNumber(recordBytes[29], recordBytes[30]);
-            UnkI = (short)numberEncoderService.DecodeNumber(recordBytes[31], recordBytes[32]);
-            UnkJ = (byte)numberEncoderService.DecodeNumber(recordBytes[33]);
+            UnkShort29 = (short)numberEncoderService.DecodeNumber(recordBytes[29], recordBytes[30]);
+            UnkShort31 = (short)numberEncoderService.DecodeNumber(recordBytes[31], recordBytes[32]);
+            UnkByte33 = (byte)numberEncoderService.DecodeNumber(recordBytes[33]);
 
             HP = (short)numberEncoderService.DecodeNumber(recordBytes[34], recordBytes[35]);
 
-            UnkK = (short)numberEncoderService.DecodeNumber(recordBytes[36], recordBytes[37]);
-            UnkL = (byte)numberEncoderService.DecodeNumber(recordBytes[38]);
-            UnkM = (short)numberEncoderService.DecodeNumber(recordBytes[39], recordBytes[40]);
-            UnkN = (short)numberEncoderService.DecodeNumber(recordBytes[41], recordBytes[42]);
-            UnkO = (short)numberEncoderService.DecodeNumber(recordBytes[43], recordBytes[44]);
-            UnkP = (short)numberEncoderService.DecodeNumber(recordBytes[45], recordBytes[46]);
-            UnkQ = (short)numberEncoderService.DecodeNumber(recordBytes[47], recordBytes[48]);
-            UnkR = (short)numberEncoderService.DecodeNumber(recordBytes[49], recordBytes[50]);
+            UnkShort36 = (short)numberEncoderService.DecodeNumber(recordBytes[36], recordBytes[37]);
+            UnkByte38 = (byte)numberEncoderService.DecodeNumber(recordBytes[38]);
+            UnkShort39 = (short)numberEncoderService.DecodeNumber(recordBytes[39], recordBytes[40]);
+            UnkShort41 = (short)numberEncoderService.DecodeNumber(recordBytes[41], recordBytes[42]);
+            UnkShort43 = (short)numberEncoderService.DecodeNumber(recordBytes[43], recordBytes[44]);
+            UnkShort45 = (short)numberEncoderService.DecodeNumber(recordBytes[45], recordBytes[46]);
+            UnkShort47 = (short)numberEncoderService.DecodeNumber(recordBytes[47], recordBytes[48]);
+            UnkShort49 = (short)numberEncoderService.DecodeNumber(recordBytes[49], recordBytes[50]);
         }
     }
 }

--- a/EOLib.IO/Pub/ESFRecord.cs
+++ b/EOLib.IO/Pub/ESFRecord.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -26,14 +26,39 @@ namespace EOLib.IO.Pub
 
         public byte CastTime { get; set; }
 
+        public byte UnkA { get; set; }
+        public byte UnkB { get; set; }
+
         public SpellType Type { get; set; }
+
+        public byte UnkC { get; set; }
+        public short UnkD { get; set; }
+
         public SpellTargetRestrict TargetRestrict { get; set; }
         public SpellTarget Target { get; set; }
+
+        public byte UnkE { get; set; }
+        public byte UnkF { get; set; }
+        public short UnkG { get; set; }
 
         public short MinDam { get; set; }
         public short MaxDam { get; set; }
         public short Accuracy { get; set; }
+
+        public short UnkH { get; set; }
+        public short UnkI { get; set; }
+        public byte UnkJ { get; set; }
+
         public short HP { get; set; }
+
+        public short UnkK { get; set; }
+        public byte UnkL { get; set; }
+        public short UnkM { get; set; }
+        public short UnkN { get; set; }
+        public short UnkO { get; set; }
+        public short UnkP { get; set; }
+        public short UnkQ { get; set; }
+        public short UnkR { get; set; }
 
         public TValue Get<TValue>(PubRecordProperty type)
         {
@@ -71,20 +96,39 @@ namespace EOLib.IO.Pub
                 mem.Write(numberEncoderService.EncodeNumber(SP, 2), 0, 2);
                 mem.WriteByte(numberEncoderService.EncodeNumber(CastTime, 1)[0]);
 
-                mem.Seek(13 + Name.Length + Shout.Length, SeekOrigin.Begin);
-                mem.WriteByte(numberEncoderService.EncodeNumber((byte)Type, 1)[0]);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkA, 1)[0]);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkB, 1)[0]);
 
-                mem.Seek(19 + Name.Length + Shout.Length, SeekOrigin.Begin);
+                mem.Write(numberEncoderService.EncodeNumber((byte)Type, 3), 0, 3); //This is documented as a 3 byte int.
+
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkC, 1)[0]);
+                mem.Write(numberEncoderService.EncodeNumber(UnkD, 2), 0, 2);
+
                 mem.WriteByte(numberEncoderService.EncodeNumber((byte)TargetRestrict, 1)[0]);
                 mem.WriteByte(numberEncoderService.EncodeNumber((byte)Target, 1)[0]);
 
-                mem.Seek(25 + Name.Length + Shout.Length, SeekOrigin.Begin);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkE, 1)[0]);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkF, 1)[0]);
+                mem.Write(numberEncoderService.EncodeNumber(UnkG, 2), 0, 2);
+
                 mem.Write(numberEncoderService.EncodeNumber(MinDam, 2), 0, 2);
                 mem.Write(numberEncoderService.EncodeNumber(MaxDam, 2), 0, 2);
                 mem.Write(numberEncoderService.EncodeNumber(Accuracy, 2), 0, 2);
 
-                mem.Seek(36 + Name.Length + Shout.Length, SeekOrigin.Begin);
+                mem.Write(numberEncoderService.EncodeNumber(UnkH, 2), 0, 2);
+                mem.Write(numberEncoderService.EncodeNumber(UnkI, 2), 0, 2);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkJ, 1)[0]);
+
                 mem.Write(numberEncoderService.EncodeNumber(HP, 2), 0, 2);
+
+                mem.Write(numberEncoderService.EncodeNumber(UnkK, 2), 0, 2);
+                mem.WriteByte(numberEncoderService.EncodeNumber(UnkL, 1)[0]);
+                mem.Write(numberEncoderService.EncodeNumber(UnkM, 2), 0, 2);
+                mem.Write(numberEncoderService.EncodeNumber(UnkN, 2), 0, 2);
+                mem.Write(numberEncoderService.EncodeNumber(UnkO, 2), 0, 2);
+                mem.Write(numberEncoderService.EncodeNumber(UnkP, 2), 0, 2);
+                mem.Write(numberEncoderService.EncodeNumber(UnkQ, 2), 0, 2);
+                mem.Write(numberEncoderService.EncodeNumber(UnkR, 2), 0, 2);
             }
 
             return ret;
@@ -95,20 +139,52 @@ namespace EOLib.IO.Pub
             if (recordBytes.Length != DATA_SIZE)
                 throw new ArgumentOutOfRangeException(nameof(recordBytes), "Data is not properly sized for correct deserialization");
 
+            Console.Write(this.Name + " [");
+            for (int i = 0; i < recordBytes.Length; i++)
+            {
+                Console.Write(recordBytes[i] + "[pos:" + i + "], ");
+            }
+            Console.Write("]\n");
+
             Icon = (short)numberEncoderService.DecodeNumber(recordBytes[0], recordBytes[1]);
             Graphic = (short)numberEncoderService.DecodeNumber(recordBytes[2], recordBytes[3]);
             TP = (short)numberEncoderService.DecodeNumber(recordBytes[4], recordBytes[5]);
             SP = (short)numberEncoderService.DecodeNumber(recordBytes[6], recordBytes[7]);
             CastTime = (byte)numberEncoderService.DecodeNumber(recordBytes[8]);
 
-            Type = (SpellType)numberEncoderService.DecodeNumber(recordBytes[11]);
+            UnkA = (byte)numberEncoderService.DecodeNumber(recordBytes[9]);
+            UnkB = (byte)numberEncoderService.DecodeNumber(recordBytes[10]);
+
+            Type = (SpellType)numberEncoderService.DecodeNumber(recordBytes[11], recordBytes[12], recordBytes[13]);
+
+            UnkC = (byte)numberEncoderService.DecodeNumber(recordBytes[14]);
+            UnkD = (short)numberEncoderService.DecodeNumber(recordBytes[15], recordBytes[16]);
+
             TargetRestrict = (SpellTargetRestrict)numberEncoderService.DecodeNumber(recordBytes[17]);
             Target = (SpellTarget)numberEncoderService.DecodeNumber(recordBytes[18]);
+
+            UnkE = (byte)numberEncoderService.DecodeNumber(recordBytes[19]);
+            UnkF = (byte)numberEncoderService.DecodeNumber(recordBytes[20]);
+            UnkG = (short)numberEncoderService.DecodeNumber(recordBytes[21], recordBytes[22]);
 
             MinDam = (short)numberEncoderService.DecodeNumber(recordBytes[23], recordBytes[24]);
             MaxDam = (short)numberEncoderService.DecodeNumber(recordBytes[25], recordBytes[26]);
             Accuracy = (short)numberEncoderService.DecodeNumber(recordBytes[27], recordBytes[28]);
+
+            UnkH = (short)numberEncoderService.DecodeNumber(recordBytes[29], recordBytes[30]);
+            UnkI = (short)numberEncoderService.DecodeNumber(recordBytes[31], recordBytes[32]);
+            UnkJ = (byte)numberEncoderService.DecodeNumber(recordBytes[33]);
+
             HP = (short)numberEncoderService.DecodeNumber(recordBytes[34], recordBytes[35]);
+
+            UnkK = (short)numberEncoderService.DecodeNumber(recordBytes[36], recordBytes[37]);
+            UnkL = (byte)numberEncoderService.DecodeNumber(recordBytes[38]);
+            UnkM = (short)numberEncoderService.DecodeNumber(recordBytes[39], recordBytes[40]);
+            UnkN = (short)numberEncoderService.DecodeNumber(recordBytes[41], recordBytes[42]);
+            UnkO = (short)numberEncoderService.DecodeNumber(recordBytes[43], recordBytes[44]);
+            UnkP = (short)numberEncoderService.DecodeNumber(recordBytes[45], recordBytes[46]);
+            UnkQ = (short)numberEncoderService.DecodeNumber(recordBytes[47], recordBytes[48]);
+            UnkR = (short)numberEncoderService.DecodeNumber(recordBytes[49], recordBytes[50]);
         }
     }
 }

--- a/EOLib.IO/PubRecordProperty.cs
+++ b/EOLib.IO/PubRecordProperty.cs
@@ -29,7 +29,7 @@ namespace EOLib.IO
         ItemEvade,
         ItemArmor,
 
-        ItemUnkB,
+        ItemUnkByte19,
 
         ItemStr,
         ItemInt,
@@ -67,12 +67,12 @@ namespace EOLib.IO
         ItemConReq,
         ItemChaReq,
 
-        ItemUnkD,
-        ItemUnkE,
+        ItemUnkElement,
+        ItemUnkElementPower,
 
         ItemWeight,
 
-        ItemUnkF,
+        ItemUnkByte56,
 
         ItemSize,
 
@@ -82,13 +82,13 @@ namespace EOLib.IO
 
         NPCGraphic,
 
-        NPCUnkA,
+        NPCUnkByte2,
 
         NPCBoss,
         NPCChild,
         NPCType,
 
-        NPCUnkB,
+        NPCUnkShort14,
 
         NPCVendorID,
 
@@ -101,12 +101,12 @@ namespace EOLib.IO
         NPCEvade,
         NPCArmor,
 
-        NPCUnkC,
-        NPCUnkD,
-        NPCUnkE,
-        NPCUnkF,
-        NPCUnkG,
-        NPCUnkH,
+        NPCUnkByte26,
+        NPCUnkShort27,
+        NPCUnkShort29,
+        NPCElementWeak,
+        NPCElementWeakPower,
+        NPCUnkByte35,
 
         #endregion
 
@@ -122,39 +122,39 @@ namespace EOLib.IO
 
         SpellCastTime,
 
-        SpellUnkA,
-        SpellUnkB,
+        SpellUnkByte9,
+        SpellUnkByte10,
 
         SpellType,
 
-        SpellUnkC,
-        SpellUnkD,
+        SpellUnkByte14,
+        SpellUnkShort15,
 
         SpellTargetRestrict,
         SpellTarget,
 
-        SpellUnkE,
-        SpellUnkF,
-        SpellUnkG,
+        SpellUnkByte19,
+        SpellUnkByte20,
+        SpellUnkShort21,
 
         SpellMinDam,
         SpellMaxDam,
         SpellAccuracy,
 
-        SpellUnkH,
-        SpellUnkI,
-        SpellUnkJ,
+        SpellUnkShort29,
+        SpellUnkShort31,
+        SpellUnkByte33,
 
         SpellHP,
 
-        SpellUnkK,
-        SpellUnkL,
-        SpellUnkM,
-        SpellUnkN,
-        SpellUnkO,
-        SpellUnkP,
-        SpellUnkQ,
-        SpellUnkR,
+        SpellUnkShort36,
+        SpellUnkByte38,
+        SpellUnkShort39,
+        SpellUnkShort41,
+        SpellUnkShort43,
+        SpellUnkShort45,
+        SpellUnkShort47,
+        SpellUnkShort49,
 
         #endregion
 

--- a/EOLib.IO/PubRecordProperty.cs
+++ b/EOLib.IO/PubRecordProperty.cs
@@ -67,8 +67,8 @@ namespace EOLib.IO
         ItemConReq,
         ItemChaReq,
 
-        ItemUnkElement,
-        ItemUnkElementPower,
+        ItemElement,
+        ItemElementPower,
 
         ItemWeight,
 

--- a/EOLib.IO/PubRecordProperty.cs
+++ b/EOLib.IO/PubRecordProperty.cs
@@ -1,4 +1,4 @@
-﻿namespace EOLib.IO
+namespace EOLib.IO
 {
     /// <summary>
     /// Enum representing the different properties that exist within the pub records
@@ -28,6 +28,8 @@
         ItemAccuracy,
         ItemEvade,
         ItemArmor,
+
+        ItemUnkB,
 
         ItemStr,
         ItemInt,
@@ -65,7 +67,12 @@
         ItemConReq,
         ItemChaReq,
 
+        ItemUnkD,
+        ItemUnkE,
+
         ItemWeight,
+
+        ItemUnkF,
 
         ItemSize,
 
@@ -75,9 +82,13 @@
 
         NPCGraphic,
 
+        NPCUnkA,
+
         NPCBoss,
         NPCChild,
         NPCType,
+
+        NPCUnkB,
 
         NPCVendorID,
 
@@ -89,6 +100,13 @@
         NPCAccuracy,
         NPCEvade,
         NPCArmor,
+
+        NPCUnkC,
+        NPCUnkD,
+        NPCUnkE,
+        NPCUnkF,
+        NPCUnkG,
+        NPCUnkH,
 
         #endregion
 
@@ -104,14 +122,39 @@
 
         SpellCastTime,
 
+        SpellUnkA,
+        SpellUnkB,
+
         SpellType,
+
+        SpellUnkC,
+        SpellUnkD,
+
         SpellTargetRestrict,
         SpellTarget,
+
+        SpellUnkE,
+        SpellUnkF,
+        SpellUnkG,
 
         SpellMinDam,
         SpellMaxDam,
         SpellAccuracy,
+
+        SpellUnkH,
+        SpellUnkI,
+        SpellUnkJ,
+
         SpellHP,
+
+        SpellUnkK,
+        SpellUnkL,
+        SpellUnkM,
+        SpellUnkN,
+        SpellUnkO,
+        SpellUnkP,
+        SpellUnkQ,
+        SpellUnkR,
 
         #endregion
 


### PR DESCRIPTION
Finishes the full pub spec.
Also corrects ESFRecord SpellType and ENFRecord Exp to read and write as three byte ints instead of 2 byte ints.
