### PR TITLE
Introduced fixed update timer for characters

### DIFF
--- a/EndlessClient/ControlSets/ControlSetFactory.cs
+++ b/EndlessClient/ControlSets/ControlSetFactory.cs
@@ -7,6 +7,7 @@ using EndlessClient.Dialogs.Factories;
 using EndlessClient.GameExecution;
 using EndlessClient.HUD.Controls;
 using EndlessClient.Input;
+using EndlessClient.Rendering;
 using EndlessClient.UIControls;
 using EOLib.Config;
 using EOLib.Domain.Login;
@@ -28,6 +29,7 @@ namespace EndlessClient.ControlSets
         private readonly IEndlessGameProvider _endlessGameProvider;
         private readonly IUserInputRepository _userInputRepository;
         private readonly IActiveDialogRepository _activeDialogRepository;
+        private readonly IFixedTimeStepRepository _fixedTimeStepRepository;
         private IMainButtonController _mainButtonController;
         private IAccountController _accountController;
         private ILoginController _loginController;
@@ -43,7 +45,8 @@ namespace EndlessClient.ControlSets
                                  ICharacterSelectorProvider characterSelectorProvider,
                                  IEndlessGameProvider endlessGameProvider,
                                  IUserInputRepository userInputRepository,
-                                 IActiveDialogRepository activeDialogRepository)
+                                 IActiveDialogRepository activeDialogRepository,
+                                 IFixedTimeStepRepository fixedTimeStepRepository)
         {
             _nativeGraphicsManager = nativeGraphicsManager;
             _messageBoxFactory = messageBoxFactory;
@@ -56,6 +59,7 @@ namespace EndlessClient.ControlSets
             _endlessGameProvider = endlessGameProvider;
             _userInputRepository = userInputRepository;
             _activeDialogRepository = activeDialogRepository;
+            _fixedTimeStepRepository = fixedTimeStepRepository;
         }
 
         public IControlSet CreateControlsForState(GameStates newState, IControlSet currentControlSet)
@@ -107,7 +111,8 @@ namespace EndlessClient.ControlSets
                         _characterManagementController,
                         _accountController,
                         _endlessGameProvider,
-                        _userInputRepository);
+                        _userInputRepository,
+                        _fixedTimeStepRepository);
                 case GameStates.PlayingTheGame:
                     return new InGameControlSet(_mainButtonController, _messageBoxFactory, _hudControlsFactory, _activeDialogRepository, _userInputRepository);
                 default: throw new ArgumentOutOfRangeException(nameof(newState), newState, null);

--- a/EndlessClient/ControlSets/LoggedInControlSet.cs
+++ b/EndlessClient/ControlSets/LoggedInControlSet.cs
@@ -1,6 +1,7 @@
 ﻿using EndlessClient.Controllers;
 using EndlessClient.GameExecution;
 using EndlessClient.Input;
+using EndlessClient.Rendering;
 using EndlessClient.UIControls;
 using EOLib.Domain.Login;
 using Microsoft.Xna.Framework;
@@ -19,6 +20,7 @@ namespace EndlessClient.ControlSets
         private readonly IAccountController _accountController;
         private readonly IEndlessGameProvider _endlessGameProvider;
         private readonly IUserInputRepository _userInputRepository;
+        private readonly IFixedTimeStepRepository _fixedTimeStepRepository;
         private readonly List<CharacterInfoPanel> _characterInfoPanels;
 
         private IXNAButton _changePasswordButton;
@@ -34,7 +36,8 @@ namespace EndlessClient.ControlSets
                                   ICharacterManagementController characterManagementController,
                                   IAccountController accountController,
                                   IEndlessGameProvider endlessGameProvider,
-                                  IUserInputRepository userInputRepository)
+                                  IUserInputRepository userInputRepository,
+                                  IFixedTimeStepRepository fixedTimeStepRepository)
             : base(dispatcher, mainButtonController)
         {
             _characterInfoPanelFactory = characterInfoPanelFactory;
@@ -43,6 +46,7 @@ namespace EndlessClient.ControlSets
             _accountController = accountController;
             _endlessGameProvider = endlessGameProvider;
             _userInputRepository = userInputRepository;
+            _fixedTimeStepRepository = fixedTimeStepRepository;
             _characterInfoPanels = new List<CharacterInfoPanel>();
         }
 
@@ -53,8 +57,8 @@ namespace EndlessClient.ControlSets
             _changePasswordButton = GetControl(currentControlSet, GameControlIdentifier.ChangePasswordButton, GetPasswordButton);
             _characterInfoPanels.AddRange(_characterInfoPanelFactory.CreatePanels(_characterSelectorProvider.Characters));
 
-            _allComponents.Add(new PreviousUserInputTracker(_endlessGameProvider, _userInputRepository));
             _allComponents.Add(new CurrentUserInputTracker(_endlessGameProvider, _userInputRepository));
+            _allComponents.Add(new PreviousUserInputTracker(_endlessGameProvider, _userInputRepository, _fixedTimeStepRepository));
             _allComponents.Add(_changePasswordButton);
             _allComponents.AddRange(_characterInfoPanels);
         }

--- a/EndlessClient/HUD/Controls/HudControlsFactory.cs
+++ b/EndlessClient/HUD/Controls/HudControlsFactory.cs
@@ -65,6 +65,7 @@ namespace EndlessClient.HUD.Controls
         private readonly ISfxPlayer _sfxPlayer;
         private readonly IMiniMapRendererFactory _miniMapRendererFactory;
         private readonly INewsProvider _newsProvider;
+        private readonly IFixedTimeStepRepository _fixedTimeStepRepository;
         private IChatController _chatController;
 
         public HudControlsFactory(IHudButtonController hudButtonController,
@@ -93,7 +94,8 @@ namespace EndlessClient.HUD.Controls
                                   ISpellSlotDataRepository spellSlotDataRepository,
                                   ISfxPlayer sfxPlayer,
                                   IMiniMapRendererFactory miniMapRendererFactory,
-                                  INewsProvider newsProvider)
+                                  INewsProvider newsProvider,
+                                  IFixedTimeStepRepository fixedTimeStepRepository)
         {
             _hudButtonController = hudButtonController;
             _hudPanelFactory = hudPanelFactory;
@@ -122,6 +124,7 @@ namespace EndlessClient.HUD.Controls
             _sfxPlayer = sfxPlayer;
             _miniMapRendererFactory = miniMapRendererFactory;
             _newsProvider = newsProvider;
+            _fixedTimeStepRepository = fixedTimeStepRepository;
         }
 
         public void InjectChatController(IChatController chatController)
@@ -449,12 +452,12 @@ namespace EndlessClient.HUD.Controls
 
         private ICharacterAnimator CreateCharacterAnimator()
         {
-            return new CharacterAnimator(_endlessGameProvider, _characterRepository, _currentMapStateRepository, _currentMapProvider, _spellSlotDataRepository, _userInputRepository, _characterActions, _walkValidationActions, _pathFinder);
+            return new CharacterAnimator(_endlessGameProvider, _characterRepository, _currentMapStateRepository, _currentMapProvider, _spellSlotDataRepository, _userInputRepository, _characterActions, _walkValidationActions, _pathFinder, _fixedTimeStepRepository);
         }
 
         private INPCAnimator CreateNPCAnimator()
         {
-            return new NPCAnimator(_endlessGameProvider, _currentMapStateRepository);
+            return new NPCAnimator(_endlessGameProvider, _currentMapStateRepository, _fixedTimeStepRepository);
         }
 
         private IPeriodicEmoteHandler CreatePeriodicEmoteHandler(ICharacterAnimator characterAnimator)
@@ -464,7 +467,7 @@ namespace EndlessClient.HUD.Controls
 
         private PreviousUserInputTracker CreatePreviousUserInputTracker()
         {
-            return new PreviousUserInputTracker(_endlessGameProvider, _userInputRepository);
+            return new PreviousUserInputTracker(_endlessGameProvider, _userInputRepository, _fixedTimeStepRepository);
         }
     }
 }

--- a/EndlessClient/HUD/Controls/HudControlsFactory.cs
+++ b/EndlessClient/HUD/Controls/HudControlsFactory.cs
@@ -457,7 +457,7 @@ namespace EndlessClient.HUD.Controls
 
         private INPCAnimator CreateNPCAnimator()
         {
-            return new NPCAnimator(_endlessGameProvider, _currentMapStateRepository, _fixedTimeStepRepository);
+            return new NPCAnimator(_endlessGameProvider, _currentMapStateRepository);
         }
 
         private IPeriodicEmoteHandler CreatePeriodicEmoteHandler(ICharacterAnimator characterAnimator)

--- a/EndlessClient/Input/PreviousUserInputTracker.cs
+++ b/EndlessClient/Input/PreviousUserInputTracker.cs
@@ -1,4 +1,5 @@
 ﻿using EndlessClient.GameExecution;
+using EndlessClient.Rendering;
 using Microsoft.Xna.Framework;
 
 namespace EndlessClient.Input
@@ -6,14 +7,16 @@ namespace EndlessClient.Input
     public class PreviousUserInputTracker : GameComponent
     {
         private readonly IUserInputRepository _userInputRepository;
+        private readonly IFixedTimeStepRepository _fixedTimeStepRepository;
 
         public PreviousUserInputTracker(
             IEndlessGameProvider endlessGameProvider,
-            IUserInputRepository userInputRepository)
+            IUserInputRepository userInputRepository,
+            IFixedTimeStepRepository fixedTimeStepRepository)
             : base((Game)endlessGameProvider.Game)
         {
             _userInputRepository = userInputRepository;
-
+            _fixedTimeStepRepository = fixedTimeStepRepository;
             UpdateOrder = int.MaxValue;
         }
 
@@ -23,6 +26,9 @@ namespace EndlessClient.Input
             _userInputRepository.PreviousMouseState = _userInputRepository.CurrentMouseState;
             _userInputRepository.ClickHandled = false;
             _userInputRepository.WalkClickHandled = false;
+
+            if (_fixedTimeStepRepository.IsUpdateFrame)
+                _fixedTimeStepRepository.RestartTimer();
 
             base.Update(gameTime);
         }

--- a/EndlessClient/Rendering/Character/CharacterAnimator.cs
+++ b/EndlessClient/Rendering/Character/CharacterAnimator.cs
@@ -20,7 +20,7 @@ namespace EndlessClient.Rendering.Character
 {
     public class CharacterAnimator : GameComponent, ICharacterAnimator
     {
-        public const int WALK_FRAME_TIME_MS = 95;
+        public const int WALK_FRAME_TIME_MS = 100;
         public const int ATTACK_FRAME_TIME_MS = 95;
         public const int EMOTE_FRAME_TIME_MS = 250;
 

--- a/EndlessClient/Rendering/Character/CharacterAnimator.cs
+++ b/EndlessClient/Rendering/Character/CharacterAnimator.cs
@@ -20,8 +20,8 @@ namespace EndlessClient.Rendering.Character
 {
     public class CharacterAnimator : GameComponent, ICharacterAnimator
     {
-        public const int WALK_FRAME_TIME_MS = 120;
-        public const int ATTACK_FRAME_TIME_MS = 100;
+        public const int WALK_FRAME_TIME_MS = 95;
+        public const int ATTACK_FRAME_TIME_MS = 95;
         public const int EMOTE_FRAME_TIME_MS = 250;
 
         private readonly ICharacterRepository _characterRepository;
@@ -50,7 +50,6 @@ namespace EndlessClient.Rendering.Character
         private Option<MapCoordinate> _targetCoordinate;
 
         private bool _clickHandled;
-        private bool _updateToggle;
 
         public CharacterAnimator(IEndlessGameProvider gameProvider,
                                  ICharacterRepository characterRepository,
@@ -89,18 +88,16 @@ namespace EndlessClient.Rendering.Character
             if (_userInputRepository.ClickHandled && !_userInputRepository.WalkClickHandled && _walkPath.Any())
                 _clickHandled = true;
 
-            // 8 updates per second
-            // fixes glitchy other character frame changes while main character is walking
             if (_fixedTimeStepRepository.IsUpdateFrame)
             {
-                if (_updateToggle)
+                if (_fixedTimeStepRepository.IsWalkUpdateFrame)
                 {
                     AnimateCharacterWalking();
-                    AnimateCharacterAttacking();
-                    AnimateCharacterSpells();
-                    AnimateCharacterEmotes();
                 }
-                _updateToggle = !_updateToggle;
+
+                AnimateCharacterAttacking();
+                AnimateCharacterSpells();
+                AnimateCharacterEmotes();
             }
 
             base.Update(gameTime);

--- a/EndlessClient/Rendering/Factories/CharacterRendererFactory.cs
+++ b/EndlessClient/Rendering/Factories/CharacterRendererFactory.cs
@@ -33,6 +33,7 @@ namespace EndlessClient.Rendering.Factories
         private readonly ICurrentMapProvider _currentMapProvider;
         private readonly IUserInputProvider _userInputProvider;
         private readonly ISfxPlayer _sfxPlayer;
+        private readonly IFixedTimeStepRepository _fixedTimeStepRepository;
 
         public CharacterRendererFactory(INativeGraphicsManager nativeGraphicsManager,
                                         IEndlessGameProvider gameProvider,
@@ -48,7 +49,8 @@ namespace EndlessClient.Rendering.Factories
                                         IGameStateProvider gameStateProvider,
                                         ICurrentMapProvider currentMapProvider,
                                         IUserInputProvider userInputProvider,
-                                        ISfxPlayer sfxPlayer)
+                                        ISfxPlayer sfxPlayer,
+                                        IFixedTimeStepRepository fixedTimeStepRepository)
         {
             _nativeGraphicsManager = nativeGraphicsManager;
             _gameProvider = gameProvider;
@@ -65,6 +67,7 @@ namespace EndlessClient.Rendering.Factories
             _currentMapProvider = currentMapProvider;
             _userInputProvider = userInputProvider;
             _sfxPlayer = sfxPlayer;
+            _fixedTimeStepRepository = fixedTimeStepRepository;
         }
 
         public ICharacterRenderer CreateCharacterRenderer(EOLib.Domain.Character.Character character)
@@ -85,7 +88,8 @@ namespace EndlessClient.Rendering.Factories
                 _gameStateProvider,
                 _currentMapProvider,
                 _userInputProvider,
-                _sfxPlayer);
+                _sfxPlayer,
+                _fixedTimeStepRepository);
         }
     }
 }

--- a/EndlessClient/Rendering/Factories/MapRendererFactory.cs
+++ b/EndlessClient/Rendering/Factories/MapRendererFactory.cs
@@ -25,6 +25,7 @@ namespace EndlessClient.Rendering.Factories
         private readonly IMouseCursorRendererFactory _mouseCursorRendererFactory;
         private readonly IRenderOffsetCalculator _renderOffsetCalculator;
         private readonly IMapGridEffectTargetFactory _mapGridEffectTargetFactory;
+        private readonly IFixedTimeStepRepository _fixedTimeStepRepository;
         private readonly INPCRendererUpdater _npcRendererUpdater;
         private readonly IDynamicMapObjectUpdater _dynamicMapObjectUpdater;
 
@@ -40,7 +41,8 @@ namespace EndlessClient.Rendering.Factories
             IConfigurationProvider configurationProvider,
             IMouseCursorRendererFactory mouseCursorRendererFactory,
             IRenderOffsetCalculator renderOffsetCalculator,
-            IMapGridEffectTargetFactory mapGridEffectTargetFactory)
+            IMapGridEffectTargetFactory mapGridEffectTargetFactory,
+            IFixedTimeStepRepository fixedTimeStepRepository)
         {
             _endlessGameProvider = endlessGameProvider;
             _renderTargetFactory = renderTargetFactory;
@@ -55,6 +57,7 @@ namespace EndlessClient.Rendering.Factories
             _mouseCursorRendererFactory = mouseCursorRendererFactory;
             _renderOffsetCalculator = renderOffsetCalculator;
             _mapGridEffectTargetFactory = mapGridEffectTargetFactory;
+            _fixedTimeStepRepository = fixedTimeStepRepository;
         }
 
         public IMapRenderer CreateMapRenderer()
@@ -71,7 +74,8 @@ namespace EndlessClient.Rendering.Factories
                                    _configurationProvider,
                                    _mouseCursorRendererFactory.Create(),
                                    _renderOffsetCalculator,
-                                   _mapGridEffectTargetFactory);
+                                   _mapGridEffectTargetFactory,
+                                   _fixedTimeStepRepository);
         }
     }
 }

--- a/EndlessClient/Rendering/Factories/MapRendererFactory.cs
+++ b/EndlessClient/Rendering/Factories/MapRendererFactory.cs
@@ -23,7 +23,6 @@ namespace EndlessClient.Rendering.Factories
         private readonly IConfigurationProvider _configurationProvider;
         private readonly IMouseCursorRendererFactory _mouseCursorRendererFactory;
         private readonly IGridDrawCoordinateCalculator _gridDrawCoordinateCalculator;
-        private readonly IRenderOffsetCalculator _renderOffsetCalculator;
         private readonly IMapGridEffectTargetFactory _mapGridEffectTargetFactory;
         private readonly IFixedTimeStepRepository _fixedTimeStepRepository;
         private readonly INPCRendererUpdater _npcRendererUpdater;

--- a/EndlessClient/Rendering/Factories/MapRendererFactory.cs
+++ b/EndlessClient/Rendering/Factories/MapRendererFactory.cs
@@ -1,7 +1,6 @@
 using AutomaticTypeMapper;
 using EndlessClient.GameExecution;
 using EndlessClient.Rendering.Character;
-using EndlessClient.Rendering.Chat;
 using EndlessClient.Rendering.Map;
 using EndlessClient.Rendering.MapEntityRenderers;
 using EndlessClient.Rendering.NPC;
@@ -23,6 +22,7 @@ namespace EndlessClient.Rendering.Factories
         private readonly ICharacterRendererUpdater _characterRendererUpdater;
         private readonly IConfigurationProvider _configurationProvider;
         private readonly IMouseCursorRendererFactory _mouseCursorRendererFactory;
+        private readonly IGridDrawCoordinateCalculator _gridDrawCoordinateCalculator;
         private readonly IRenderOffsetCalculator _renderOffsetCalculator;
         private readonly IMapGridEffectTargetFactory _mapGridEffectTargetFactory;
         private readonly IFixedTimeStepRepository _fixedTimeStepRepository;
@@ -40,7 +40,7 @@ namespace EndlessClient.Rendering.Factories
             IDynamicMapObjectUpdater dynamicMapObjectUpdater,
             IConfigurationProvider configurationProvider,
             IMouseCursorRendererFactory mouseCursorRendererFactory,
-            IRenderOffsetCalculator renderOffsetCalculator,
+            IGridDrawCoordinateCalculator gridDrawCoordinateCalculator,
             IMapGridEffectTargetFactory mapGridEffectTargetFactory,
             IFixedTimeStepRepository fixedTimeStepRepository)
         {
@@ -55,7 +55,7 @@ namespace EndlessClient.Rendering.Factories
             _dynamicMapObjectUpdater = dynamicMapObjectUpdater;
             _configurationProvider = configurationProvider;
             _mouseCursorRendererFactory = mouseCursorRendererFactory;
-            _renderOffsetCalculator = renderOffsetCalculator;
+            _gridDrawCoordinateCalculator = gridDrawCoordinateCalculator;
             _mapGridEffectTargetFactory = mapGridEffectTargetFactory;
             _fixedTimeStepRepository = fixedTimeStepRepository;
         }
@@ -73,7 +73,7 @@ namespace EndlessClient.Rendering.Factories
                                    _dynamicMapObjectUpdater,
                                    _configurationProvider,
                                    _mouseCursorRendererFactory.Create(),
-                                   _renderOffsetCalculator,
+                                   _gridDrawCoordinateCalculator,
                                    _mapGridEffectTargetFactory,
                                    _fixedTimeStepRepository);
         }

--- a/EndlessClient/Rendering/Factories/MouseCursorRendererFactory.cs
+++ b/EndlessClient/Rendering/Factories/MouseCursorRendererFactory.cs
@@ -17,8 +17,7 @@ namespace EndlessClient.Rendering.Factories
     {
         private readonly INativeGraphicsManager _nativeGraphicsManager;
         private readonly ICharacterProvider _characterProvider;
-        private readonly ICharacterRendererProvider _characterRendererProvider;
-        private readonly IRenderOffsetCalculator _renderOffsetCalculator;
+        private readonly IGridDrawCoordinateCalculator _gridDrawCoordinateCalculator;
         private readonly IMapCellStateProvider _mapCellStateProvider;
         private readonly IItemStringService _itemStringService;
         private readonly IItemNameColorService _itemNameColorService;
@@ -31,8 +30,7 @@ namespace EndlessClient.Rendering.Factories
 
         public MouseCursorRendererFactory(INativeGraphicsManager nativeGraphicsManager,
                                           ICharacterProvider characterProvider,
-                                          ICharacterRendererProvider characterRendererProvider,
-                                          IRenderOffsetCalculator renderOffsetCalculator,
+                                          IGridDrawCoordinateCalculator gridDrawCoordinateCalculator,
                                           IMapCellStateProvider mapCellStateProvider,
                                           IItemStringService itemStringService,
                                           IItemNameColorService itemNameColorService,
@@ -45,8 +43,7 @@ namespace EndlessClient.Rendering.Factories
         {
             _nativeGraphicsManager = nativeGraphicsManager;
             _characterProvider = characterProvider;
-            _characterRendererProvider = characterRendererProvider;
-            _renderOffsetCalculator = renderOffsetCalculator;
+            _gridDrawCoordinateCalculator = gridDrawCoordinateCalculator;
             _mapCellStateProvider = mapCellStateProvider;
             _itemStringService = itemStringService;
             _itemNameColorService = itemNameColorService;
@@ -62,8 +59,7 @@ namespace EndlessClient.Rendering.Factories
         {
             return new MouseCursorRenderer(_nativeGraphicsManager,
                                            _characterProvider,
-                                           _characterRendererProvider,
-                                           _renderOffsetCalculator,
+                                           _gridDrawCoordinateCalculator,
                                            _mapCellStateProvider,
                                            _itemStringService,
                                            _itemNameColorService,

--- a/EndlessClient/Rendering/FixedTimeStepRepository.cs
+++ b/EndlessClient/Rendering/FixedTimeStepRepository.cs
@@ -6,15 +6,23 @@ namespace EndlessClient.Rendering
     [AutoMappedType(IsSingleton = true)]
     public class FixedTimeStepRepository : IFixedTimeStepRepository
     {
-        private const int FIXED_UPDATE_TIME_MS = 62;
+        private const int FIXED_UPDATE_TIME_MS = 48; // ~21 FPS
+
+        private bool _isWalkUpdate;
 
         public Stopwatch FixedUpdateTimer { get; set; }
 
         public bool IsUpdateFrame => FixedUpdateTimer.ElapsedMilliseconds > FIXED_UPDATE_TIME_MS;
 
+        public bool IsWalkUpdateFrame => IsUpdateFrame && _isWalkUpdate;
+
         public FixedTimeStepRepository() => FixedUpdateTimer = Stopwatch.StartNew();
 
-        public void RestartTimer() => FixedUpdateTimer.Restart();
+        public void RestartTimer()
+        {
+            FixedUpdateTimer.Restart();
+            _isWalkUpdate = !_isWalkUpdate;
+        }
     }
 
     public interface IFixedTimeStepRepository
@@ -22,6 +30,8 @@ namespace EndlessClient.Rendering
         Stopwatch FixedUpdateTimer { get; set; }
 
         bool IsUpdateFrame { get; }
+
+        bool IsWalkUpdateFrame { get; }
 
         void RestartTimer();
     }

--- a/EndlessClient/Rendering/FixedTimeStepRepository.cs
+++ b/EndlessClient/Rendering/FixedTimeStepRepository.cs
@@ -6,7 +6,7 @@ namespace EndlessClient.Rendering
     [AutoMappedType(IsSingleton = true)]
     public class FixedTimeStepRepository : IFixedTimeStepRepository
     {
-        private const int FIXED_UPDATE_TIME_MS = 48; // ~21 FPS
+        private const int FIXED_UPDATE_TIME_MS = 51; // ~21 FPS
 
         private bool _isWalkUpdate;
 

--- a/EndlessClient/Rendering/FixedTimeStepRepository.cs
+++ b/EndlessClient/Rendering/FixedTimeStepRepository.cs
@@ -1,0 +1,28 @@
+﻿using AutomaticTypeMapper;
+using System.Diagnostics;
+
+namespace EndlessClient.Rendering
+{
+    [AutoMappedType(IsSingleton = true)]
+    public class FixedTimeStepRepository : IFixedTimeStepRepository
+    {
+        private const int FIXED_UPDATE_TIME_MS = 62;
+
+        public Stopwatch FixedUpdateTimer { get; set; }
+
+        public bool IsUpdateFrame => FixedUpdateTimer.ElapsedMilliseconds > FIXED_UPDATE_TIME_MS;
+
+        public FixedTimeStepRepository() => FixedUpdateTimer = Stopwatch.StartNew();
+
+        public void RestartTimer() => FixedUpdateTimer.Restart();
+    }
+
+    public interface IFixedTimeStepRepository
+    {
+        Stopwatch FixedUpdateTimer { get; set; }
+
+        bool IsUpdateFrame { get; }
+
+        void RestartTimer();
+    }
+}

--- a/EndlessClient/Rendering/FixedTimeStepRepository.cs
+++ b/EndlessClient/Rendering/FixedTimeStepRepository.cs
@@ -6,7 +6,7 @@ namespace EndlessClient.Rendering
     [AutoMappedType(IsSingleton = true)]
     public class FixedTimeStepRepository : IFixedTimeStepRepository
     {
-        private const int FIXED_UPDATE_TIME_MS = 51; // ~21 FPS
+        private const int FIXED_UPDATE_TIME_MS = 51; // ~19 FPS
 
         private bool _isWalkUpdate;
 

--- a/EndlessClient/Rendering/GridDrawCoordinateCalculator.cs
+++ b/EndlessClient/Rendering/GridDrawCoordinateCalculator.cs
@@ -1,11 +1,8 @@
 ﻿using AutomaticTypeMapper;
-using EndlessClient.Input;
-using EOLib;
 using EOLib.Domain.Character;
 using EOLib.Domain.Extensions;
 using EOLib.Domain.Map;
 using Microsoft.Xna.Framework;
-using System.Windows.Controls;
 using System;
 
 namespace EndlessClient.Rendering

--- a/EndlessClient/Rendering/GridDrawCoordinateCalculator.cs
+++ b/EndlessClient/Rendering/GridDrawCoordinateCalculator.cs
@@ -68,6 +68,32 @@ namespace EndlessClient.Rendering
                                ViewportHeightFactor - (props.MapY * 16) - (props.MapX * 16)) - CalculateGroundLayerCharacterOffsets();
         }
 
+        public MapCoordinate CalculateGridCoordinatesFromDrawLocation(Vector2 drawLocation)
+        {
+            //need to solve this system of equations to get x, y on the grid
+            //(x * 32) - (y * 32) + 288 - c.OffsetX, => pixX = 32x - 32y + 288 - c.OffsetX
+            //(y * 16) + (x * 16) + 144 - c.OffsetY  => 2pixY = 32y + 32x + 288 - 2c.OffsetY
+            //                                         => 2pixY + pixX = 64x + 576 - c.OffsetX - 2c.OffsetY
+            //                                         => 2pixY + pixX - 576 + c.OffsetX + 2c.OffsetY = 64x
+            //                                         => _gridX = (pixX + 2pixY - 576 + c.OffsetX + 2c.OffsetY) / 64; <=
+            //pixY = (_gridX * 16) + (_gridY * 16) + 144 - c.OffsetY =>
+            //(pixY - (_gridX * 16) - 144 + c.OffsetY) / 16 = _gridY
+
+            const int GridSpaceWidth = 64;
+            const int GridSpaceHeight = 32;
+
+            var msX = drawLocation.X - GridSpaceWidth / 2;
+            var msY = drawLocation.Y - GridSpaceHeight / 2;
+
+            var offsetX = _renderOffsetCalculator.CalculateOffsetX(_characterProvider.MainCharacter.RenderProperties);
+            var offsetY = _renderOffsetCalculator.CalculateOffsetY(_characterProvider.MainCharacter.RenderProperties);
+
+            var gridX = (int)Math.Round((msX + 2 * msY - 576 + offsetX + 2 * offsetY) / 64.0);
+            var gridY = (int)Math.Round((msY - gridX * 16 - 144 + offsetY) / 16.0);
+
+            return new MapCoordinate(gridX, gridY);
+        }
+
         private Vector2 CalculateCharacterOffsets()
         {
             var props = _characterProvider.MainCharacter.RenderProperties;
@@ -98,32 +124,6 @@ namespace EndlessClient.Rendering
 
             return new Vector2(_renderOffsetCalculator.CalculateWalkAdjustX(props),
                                _renderOffsetCalculator.CalculateWalkAdjustY(props));
-        }
-
-        public MapCoordinate CalculateGridCoordinatesFromDrawLocation(Vector2 drawLocation)
-        {
-            //need to solve this system of equations to get x, y on the grid
-            //(x * 32) - (y * 32) + 288 - c.OffsetX, => pixX = 32x - 32y + 288 - c.OffsetX
-            //(y * 16) + (x * 16) + 144 - c.OffsetY  => 2pixY = 32y + 32x + 288 - 2c.OffsetY
-            //                                         => 2pixY + pixX = 64x + 576 - c.OffsetX - 2c.OffsetY
-            //                                         => 2pixY + pixX - 576 + c.OffsetX + 2c.OffsetY = 64x
-            //                                         => _gridX = (pixX + 2pixY - 576 + c.OffsetX + 2c.OffsetY) / 64; <=
-            //pixY = (_gridX * 16) + (_gridY * 16) + 144 - c.OffsetY =>
-            //(pixY - (_gridX * 16) - 144 + c.OffsetY) / 16 = _gridY
-
-            const int GridSpaceWidth = 64;
-            const int GridSpaceHeight = 32;
-
-            var msX = drawLocation.X - GridSpaceWidth/2;
-            var msY = drawLocation.Y - GridSpaceHeight/2;
-
-            var offsetX = _renderOffsetCalculator.CalculateOffsetX(_characterProvider.MainCharacter.RenderProperties);
-            var offsetY = _renderOffsetCalculator.CalculateOffsetY(_characterProvider.MainCharacter.RenderProperties);
-
-            var gridX = (int)Math.Round((msX + 2 * msY - 576 + offsetX + 2 * offsetY) / 64.0);
-            var gridY = (int)Math.Round((msY - gridX * 16 - 144 + offsetY) / 16.0);
-
-            return new MapCoordinate(gridX, gridY);
         }
     }
 

--- a/EndlessClient/Rendering/GridDrawCoordinateCalculator.cs
+++ b/EndlessClient/Rendering/GridDrawCoordinateCalculator.cs
@@ -1,0 +1,144 @@
+﻿using AutomaticTypeMapper;
+using EndlessClient.Input;
+using EOLib;
+using EOLib.Domain.Character;
+using EOLib.Domain.Extensions;
+using EOLib.Domain.Map;
+using Microsoft.Xna.Framework;
+using System.Windows.Controls;
+using System;
+
+namespace EndlessClient.Rendering
+{
+    [AutoMappedType]
+    public class GridDrawCoordinateCalculator : IGridDrawCoordinateCalculator
+    {
+        private readonly ICharacterProvider _characterProvider;
+        private readonly ICurrentMapProvider _currentMapProvider;
+        private readonly IRenderOffsetCalculator _renderOffsetCalculator;
+
+        public GridDrawCoordinateCalculator(ICharacterProvider characterProvider,
+                                            ICurrentMapProvider currentMapProvider,
+                                            IRenderOffsetCalculator renderOffsetCalculator)
+        {
+            _characterProvider = characterProvider;
+            _currentMapProvider = currentMapProvider;
+            _renderOffsetCalculator = renderOffsetCalculator;
+        }
+
+        public Vector2 CalculateDrawCoordinatesFromGridUnits(int gridX, int gridY)
+        {
+            const int ViewportWidthFactor = 320; // 640 * (1/2)
+            const int ViewportHeightFactor = 144; // 480 * (3/10)
+
+            return new Vector2(ViewportWidthFactor + (gridX * 32) - (gridY * 32),
+                               ViewportHeightFactor + (gridY * 16) + (gridX * 16)) - CalculateCharacterOffsets();
+        }
+
+        public Vector2 CalculateDrawCoordinatesFromGridUnits(MapCoordinate mapCoordinate)
+        {
+            return CalculateDrawCoordinatesFromGridUnits(mapCoordinate.X, mapCoordinate.Y);
+        }
+
+        public Vector2 CalculateBaseLayerDrawCoordinatesFromGridUnits(int gridX, int gridY)
+        {
+            const int ViewportWidthFactor = 288; // ???
+            const int ViewportHeightFactor = 144; // 480 * (3/10)
+
+            return new Vector2(ViewportWidthFactor + (gridX * 32) - (gridY * 32),
+                               ViewportHeightFactor + (gridY * 16) + (gridX * 16)) - CalculateBaseLayerOffsets();
+        }
+
+        public Vector2 CalculateBaseLayerDrawCoordinatesFromGridUnits(MapCoordinate mapCoordinate)
+        {
+            return CalculateBaseLayerDrawCoordinatesFromGridUnits(mapCoordinate.X, mapCoordinate.Y);
+        }
+
+        public Vector2 CalculateGroundLayerDrawCoordinatesFromGridUnits()
+        {
+            const int ViewportWidthFactor = 320; // 640 * (1/2)
+            const int ViewportHeightFactor = 144; // 480 * (3/10)
+
+            var props = _characterProvider.MainCharacter.RenderProperties;
+
+            var mapHeightPlusOne = _currentMapProvider.CurrentMap.Properties.Height + 1;
+
+            // opposite of the algorithm for rendering the base layers
+            return new Vector2(ViewportWidthFactor - (mapHeightPlusOne * 32) + (props.MapY * 32) - (props.MapX * 32),
+                               ViewportHeightFactor - (props.MapY * 16) - (props.MapX * 16)) - CalculateGroundLayerCharacterOffsets();
+        }
+
+        private Vector2 CalculateCharacterOffsets()
+        {
+            var props = _characterProvider.MainCharacter.RenderProperties;
+            return new Vector2(_renderOffsetCalculator.CalculateOffsetX(props),
+                               _renderOffsetCalculator.CalculateOffsetY(props));
+        }
+
+        private Vector2 CalculateBaseLayerOffsets()
+        {
+            var props = _characterProvider.MainCharacter.RenderProperties;
+            props = props.IsActing(CharacterActionState.Walking)
+                ? props.WithActualWalkFrame(props.ActualWalkFrame - 1)
+                : props;
+
+            return new Vector2(_renderOffsetCalculator.CalculateOffsetX(props),
+                               _renderOffsetCalculator.CalculateOffsetY(props));
+        }
+
+        private Vector2 CalculateGroundLayerCharacterOffsets()
+        {
+            // todo: WTF
+            // this fixes the weird shifting issue with the base layers
+            // not sure why they're weirdly offset in the first place
+            var props = _characterProvider.MainCharacter.RenderProperties;
+            props = props.IsActing(CharacterActionState.Walking)
+                ? props.WithActualWalkFrame(props.ActualWalkFrame - 1)
+                : props;
+
+            return new Vector2(_renderOffsetCalculator.CalculateWalkAdjustX(props),
+                               _renderOffsetCalculator.CalculateWalkAdjustY(props));
+        }
+
+        public MapCoordinate CalculateGridCoordinatesFromDrawLocation(Vector2 drawLocation)
+        {
+            //need to solve this system of equations to get x, y on the grid
+            //(x * 32) - (y * 32) + 288 - c.OffsetX, => pixX = 32x - 32y + 288 - c.OffsetX
+            //(y * 16) + (x * 16) + 144 - c.OffsetY  => 2pixY = 32y + 32x + 288 - 2c.OffsetY
+            //                                         => 2pixY + pixX = 64x + 576 - c.OffsetX - 2c.OffsetY
+            //                                         => 2pixY + pixX - 576 + c.OffsetX + 2c.OffsetY = 64x
+            //                                         => _gridX = (pixX + 2pixY - 576 + c.OffsetX + 2c.OffsetY) / 64; <=
+            //pixY = (_gridX * 16) + (_gridY * 16) + 144 - c.OffsetY =>
+            //(pixY - (_gridX * 16) - 144 + c.OffsetY) / 16 = _gridY
+
+            const int GridSpaceWidth = 64;
+            const int GridSpaceHeight = 32;
+
+            var msX = drawLocation.X - GridSpaceWidth/2;
+            var msY = drawLocation.Y - GridSpaceHeight/2;
+
+            var offsetX = _renderOffsetCalculator.CalculateOffsetX(_characterProvider.MainCharacter.RenderProperties);
+            var offsetY = _renderOffsetCalculator.CalculateOffsetY(_characterProvider.MainCharacter.RenderProperties);
+
+            var gridX = (int)Math.Round((msX + 2 * msY - 576 + offsetX + 2 * offsetY) / 64.0);
+            var gridY = (int)Math.Round((msY - gridX * 16 - 144 + offsetY) / 16.0);
+
+            return new MapCoordinate(gridX, gridY);
+        }
+    }
+
+    public interface IGridDrawCoordinateCalculator
+    {
+        Vector2 CalculateDrawCoordinatesFromGridUnits(int gridX, int gridY);
+
+        Vector2 CalculateDrawCoordinatesFromGridUnits(MapCoordinate mapCoordinate);
+
+        Vector2 CalculateBaseLayerDrawCoordinatesFromGridUnits(int gridX, int gridY);
+
+        Vector2 CalculateBaseLayerDrawCoordinatesFromGridUnits(MapCoordinate mapCoordinate);
+
+        Vector2 CalculateGroundLayerDrawCoordinatesFromGridUnits();
+
+        MapCoordinate CalculateGridCoordinatesFromDrawLocation(Vector2 drawLocation);
+    }
+}

--- a/EndlessClient/Rendering/Map/MapEntityRendererProvider.cs
+++ b/EndlessClient/Rendering/Map/MapEntityRendererProvider.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using AutomaticTypeMapper;
 using EndlessClient.Rendering.Character;
-using EndlessClient.Rendering.Chat;
 using EndlessClient.Rendering.MapEntityRenderers;
 using EndlessClient.Rendering.NPC;
 using EOLib.Config;
@@ -25,7 +24,7 @@ namespace EndlessClient.Rendering.Map
                                          ICharacterProvider characterProvider,
                                          ICurrentMapStateProvider currentMapStateProvider,
                                          IMapItemGraphicProvider mapItemGraphicProvider,
-                                         IRenderOffsetCalculator renderOffsetCalculator,
+                                         IGridDrawCoordinateCalculator gridDrawCoordinateCalculator,
                                          IConfigurationProvider configurationProvider,
                                          ICharacterRendererProvider characterRendererProvider,
                                          INPCRendererProvider npcRendererProvider,
@@ -35,16 +34,16 @@ namespace EndlessClient.Rendering.Map
                 new GroundLayerRenderer(nativeGraphicsManager,
                                         currentMapProvider,
                                         characterProvider,
-                                        renderOffsetCalculator);
+                                        gridDrawCoordinateCalculator);
 
             BaseRenderers = new List<IMapEntityRenderer>
             {
                 new AnimatedGroundLayerRenderer(nativeGraphicsManager,
                                                 currentMapProvider,
                                                 characterProvider,
-                                                renderOffsetCalculator),
+                                                gridDrawCoordinateCalculator),
                 new MapItemLayerRenderer(characterProvider,
-                                         renderOffsetCalculator,
+                                         gridDrawCoordinateCalculator,
                                          currentMapStateProvider,
                                          mapItemGraphicProvider)
             };
@@ -54,53 +53,53 @@ namespace EndlessClient.Rendering.Map
                 new ShadowLayerRenderer(nativeGraphicsManager,
                                         currentMapProvider,
                                         characterProvider,
-                                        renderOffsetCalculator,
+                                        gridDrawCoordinateCalculator,
                                         configurationProvider),
                 new OverlayLayerRenderer(nativeGraphicsManager,
                                          currentMapProvider,
                                          characterProvider,
-                                         renderOffsetCalculator),
+                                         gridDrawCoordinateCalculator),
                 new MapObjectLayerRenderer(nativeGraphicsManager,
                                            currentMapProvider,
                                            characterProvider,
-                                           renderOffsetCalculator,
+                                           gridDrawCoordinateCalculator,
                                            currentMapStateProvider),
                 new MainCharacterEntityRenderer(characterProvider,
                                                 characterRendererProvider,
-                                                renderOffsetCalculator,
+                                                gridDrawCoordinateCalculator,
                                                 transparent: false),
                 new DownWallLayerRenderer(nativeGraphicsManager,
                                           currentMapProvider,
                                           characterProvider,
-                                          renderOffsetCalculator,
+                                          gridDrawCoordinateCalculator,
                                           currentMapStateProvider),
                 new RightWallLayerRenderer(nativeGraphicsManager,
                                            currentMapProvider,
                                            characterProvider,
-                                           renderOffsetCalculator,
+                                           gridDrawCoordinateCalculator,
                                            currentMapStateProvider),
                 new OtherCharacterEntityRenderer(characterProvider,
                                                  characterRendererProvider,
                                                  characterStateCache,
-                                                 renderOffsetCalculator),
+                                                 gridDrawCoordinateCalculator),
                 new NPCEntityRenderer(characterProvider,
-                                      renderOffsetCalculator,
+                                      gridDrawCoordinateCalculator,
                                       npcRendererProvider),
                 new Overlay2LayerRenderer(nativeGraphicsManager,
                                       currentMapProvider,
                                       characterProvider,
-                                      renderOffsetCalculator),
+                                      gridDrawCoordinateCalculator),
                 new RoofLayerRenderer(nativeGraphicsManager,
                                          currentMapProvider,
                                          characterProvider,
-                                         renderOffsetCalculator),
+                                         gridDrawCoordinateCalculator),
                 new OnTopLayerRenderer(nativeGraphicsManager,
                                        currentMapProvider,
                                        characterProvider,
-                                       renderOffsetCalculator),
+                                       gridDrawCoordinateCalculator),
                 new MainCharacterEntityRenderer(characterProvider,
                                                 characterRendererProvider,
-                                                renderOffsetCalculator,
+                                                gridDrawCoordinateCalculator,
                                                 transparent: true)
             };
         }

--- a/EndlessClient/Rendering/Map/MapObjectBoundsCalculator.cs
+++ b/EndlessClient/Rendering/Map/MapObjectBoundsCalculator.cs
@@ -13,24 +13,23 @@ namespace EndlessClient.Rendering.Map
         private readonly INativeGraphicsManager _nativeGraphicsManager;
         private readonly ICharacterProvider _characterProvider;
         private readonly IRenderOffsetCalculator _renderOffsetCalculator;
-        private readonly MapObjectLayerRenderer _objectRenderer;
-
+        private readonly IGridDrawCoordinateCalculator _gridDrawCoordinateCalculator;
+        
         public MapObjectBoundsCalculator(INativeGraphicsManager nativeGraphicsManager,
-                                      ICharacterProvider characterProvider,
-                                      IRenderOffsetCalculator renderOffsetCalculator,
-                                      IMapEntityRendererProvider mapEntityRendererProvider)
+                                         ICharacterProvider characterProvider,
+                                         IRenderOffsetCalculator renderOffsetCalculator,
+                                         IGridDrawCoordinateCalculator gridDrawCoordinateCalculator)
         {
             _nativeGraphicsManager = nativeGraphicsManager;
             _characterProvider = characterProvider;
             _renderOffsetCalculator = renderOffsetCalculator;
-
-            _objectRenderer = mapEntityRendererProvider.MapEntityRenderers.OfType<MapObjectLayerRenderer>().Single();
+            _gridDrawCoordinateCalculator = gridDrawCoordinateCalculator;
         }
 
         public Rectangle GetMapObjectBounds(int gridX, int gridY, int gfxNum)
         {
             var gfx = _nativeGraphicsManager.TextureFromResource(GFXTypes.MapObjects, gfxNum, transparent: true);
-            var drawPosition = _objectRenderer.GetDrawCoordinatesFromGridUnits(gridX, gridY);
+            var drawPosition = _gridDrawCoordinateCalculator.CalculateDrawCoordinatesFromGridUnits(gridX, gridY);
             // see: MapObjectLayerRenderer
             // todo: more centralized way of representing this
             drawPosition -= new Vector2(gfx.Width / 2, gfx.Height - 32);

--- a/EndlessClient/Rendering/MapEntityRenderers/BaseMapEntityRenderer.cs
+++ b/EndlessClient/Rendering/MapEntityRenderers/BaseMapEntityRenderer.cs
@@ -33,7 +33,7 @@ namespace EndlessClient.Rendering.MapEntityRenderers
         }
 
         protected readonly ICharacterProvider _characterProvider;
-        private readonly IRenderOffsetCalculator _renderOffsetCalculator;
+        protected readonly IGridDrawCoordinateCalculator _gridDrawCoordinateCalculator;
 
         public abstract MapRenderLayer RenderLayer { get; }
 
@@ -42,10 +42,10 @@ namespace EndlessClient.Rendering.MapEntityRenderers
         protected abstract int RenderDistance { get; }
 
         protected BaseMapEntityRenderer(ICharacterProvider characterProvider,
-                                        IRenderOffsetCalculator renderOffsetCalculator)
+                                        IGridDrawCoordinateCalculator gridDrawCoordinateCalculator)
         {
             _characterProvider = characterProvider;
-            _renderOffsetCalculator = renderOffsetCalculator;
+            _gridDrawCoordinateCalculator = gridDrawCoordinateCalculator;
         }
 
         public virtual bool CanRender(int row, int col)
@@ -72,17 +72,9 @@ namespace EndlessClient.Rendering.MapEntityRenderers
             }
         }
 
-        // todo: this shouldn't be public, move to another service that's responsible for calculating the offsets for map entities
-        public virtual Vector2 GetDrawCoordinatesFromGridUnits(int gridX, int gridY)
+        protected virtual Vector2 GetDrawCoordinatesFromGridUnits(int gridX, int gridY)
         {
-            const int ViewportWidthFactor = 320; // 640 * (1/2)
-            const int ViewportHeightFactor = 144; // 480 * (3/10)
-
-            var charOffX = _renderOffsetCalculator.CalculateOffsetX(_characterProvider.MainCharacter.RenderProperties);
-            var charOffY = _renderOffsetCalculator.CalculateOffsetY(_characterProvider.MainCharacter.RenderProperties);
-
-            return new Vector2(ViewportWidthFactor + (gridX * 32) - (gridY * 32) - charOffX + _layerOffsets[RenderLayer].X,
-                               ViewportHeightFactor + (gridY * 16) + (gridX * 16) - charOffY + _layerOffsets[RenderLayer].Y);
+            return _gridDrawCoordinateCalculator.CalculateDrawCoordinatesFromGridUnits(gridX, gridY) + _layerOffsets[RenderLayer].ToVector2();
         }
     }
 }

--- a/EndlessClient/Rendering/MapEntityRenderers/GroundLayerRenderer.cs
+++ b/EndlessClient/Rendering/MapEntityRenderers/GroundLayerRenderer.cs
@@ -22,14 +22,14 @@ namespace EndlessClient.Rendering.MapEntityRenderers
         public GroundLayerRenderer(INativeGraphicsManager nativeGraphicsManager,
                                    ICurrentMapProvider currentMapProvider,
                                    ICharacterProvider characterProvider,
-                                   IRenderOffsetCalculator renderOffsetCalculator)
-            : base(characterProvider, renderOffsetCalculator)
+                                   IGridDrawCoordinateCalculator gridDrawCoordinateCalculator)
+            : base(characterProvider, gridDrawCoordinateCalculator)
         {
             _nativeGraphicsManager = nativeGraphicsManager;
             _currentMapProvider = currentMapProvider;
         }
 
-        public override Vector2 GetDrawCoordinatesFromGridUnits(int gridX, int gridY)
+        protected override Vector2 GetDrawCoordinatesFromGridUnits(int gridX, int gridY)
         {
             // the height is used to offset the 0 point of the grid, which is 32 units per tile in the height of the map
             var height = CurrentMap.Properties.Height;
@@ -77,15 +77,12 @@ namespace EndlessClient.Rendering.MapEntityRenderers
 
     public class AnimatedGroundLayerRenderer : GroundLayerRenderer
     {
-        private readonly IRenderOffsetCalculator _renderOffsetCalculator;
-
         public AnimatedGroundLayerRenderer(INativeGraphicsManager nativeGraphicsManager,
                                            ICurrentMapProvider currentMapProvider,
                                            ICharacterProvider characterProvider,
-                                           IRenderOffsetCalculator renderOffsetCalculator)
-            : base(nativeGraphicsManager, currentMapProvider, characterProvider, renderOffsetCalculator)
+                                           IGridDrawCoordinateCalculator gridDrawCoordinateCalculator)
+            : base(nativeGraphicsManager, currentMapProvider, characterProvider, gridDrawCoordinateCalculator)
         {
-            _renderOffsetCalculator = renderOffsetCalculator;
         }
 
         protected override bool ElementExistsAt(int row, int col)
@@ -97,11 +94,9 @@ namespace EndlessClient.Rendering.MapEntityRenderers
             return tileExists && _nativeGraphicsManager.TextureFromResource(GFXTypes.MapTiles, tileId, true).Width >= ANIMATED_TILE_MIN_WIDTH;
         }
 
-        public override Vector2 GetDrawCoordinatesFromGridUnits(int gridX, int gridY)
+        protected override Vector2 GetDrawCoordinatesFromGridUnits(int gridX, int gridY)
         {
-            var offsetX = _renderOffsetCalculator.CalculateOffsetX(_characterProvider.MainCharacter.RenderProperties) - 288;
-            var offsetY = _renderOffsetCalculator.CalculateOffsetY(_characterProvider.MainCharacter.RenderProperties) - 144;
-            return base.GetDrawCoordinatesFromGridUnits(gridX, gridY) - new Vector2(offsetX + CurrentMap.Properties.Height*32, offsetY);
+            return _gridDrawCoordinateCalculator.CalculateBaseLayerDrawCoordinatesFromGridUnits(gridX, gridY);
         }
     }
 }

--- a/EndlessClient/Rendering/MapEntityRenderers/MainCharacterEntityRenderer.cs
+++ b/EndlessClient/Rendering/MapEntityRenderers/MainCharacterEntityRenderer.cs
@@ -14,9 +14,9 @@ namespace EndlessClient.Rendering.MapEntityRenderers
 
         public MainCharacterEntityRenderer(ICharacterProvider characterProvider,
                                            ICharacterRendererProvider characterRendererProvider,
-                                           IRenderOffsetCalculator renderOffsetCalculator,
+                                           IGridDrawCoordinateCalculator gridDrawCoordinateCalculator,
                                            bool transparent)
-            : base(characterProvider, renderOffsetCalculator)
+            : base(characterProvider, gridDrawCoordinateCalculator)
         {
             _characterRendererProvider = characterRendererProvider;
             _transparent = transparent;

--- a/EndlessClient/Rendering/MapEntityRenderers/MapItemLayerRenderer.cs
+++ b/EndlessClient/Rendering/MapEntityRenderers/MapItemLayerRenderer.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Linq;
 using EndlessClient.Rendering.Map;
+using EOLib;
 using EOLib.Domain.Character;
+using EOLib.Domain.Extensions;
 using EOLib.Domain.Map;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;

--- a/EndlessClient/Rendering/MapEntityRenderers/MapItemLayerRenderer.cs
+++ b/EndlessClient/Rendering/MapEntityRenderers/MapItemLayerRenderer.cs
@@ -20,10 +20,10 @@ namespace EndlessClient.Rendering.MapEntityRenderers
         protected override int RenderDistance => 16;
 
         public MapItemLayerRenderer(ICharacterProvider characterProvider,
-                                    IRenderOffsetCalculator renderOffsetCalculator,
+                                    IGridDrawCoordinateCalculator gridDrawCoordinateCalculator,
                                     ICurrentMapStateProvider currentMapStateProvider,
                                     IMapItemGraphicProvider mapItemGraphicProvider)
-            : base(characterProvider, renderOffsetCalculator)
+            : base(characterProvider, gridDrawCoordinateCalculator)
         {
             _currentMapStateProvider = currentMapStateProvider;
             _mapItemGraphicProvider = mapItemGraphicProvider;
@@ -44,7 +44,7 @@ namespace EndlessClient.Rendering.MapEntityRenderers
             foreach (var item in items)
             {
                 //note: col is offset by 1. I'm not sure why this is needed. Maybe I did something wrong when translating the packets...
-                var itemPos = GetDrawCoordinatesFromGridUnits(col, row);
+                var itemPos = GetDrawCoordinatesFromGridUnits(col + 1, row);
                 var itemTexture = _mapItemGraphicProvider.GetItemGraphic(item.ItemID, item.Amount);
 
                 spriteBatch.Draw(itemTexture,
@@ -52,6 +52,11 @@ namespace EndlessClient.Rendering.MapEntityRenderers
                                              itemPos.Y - (int) Math.Round(itemTexture.Height/2.0)) + additionalOffset,
                                  Color.FromNonPremultiplied(255, 255, 255, alpha));
             }
+        }
+
+        protected override Vector2 GetDrawCoordinatesFromGridUnits(int gridX, int gridY)
+        {
+            return _gridDrawCoordinateCalculator.CalculateBaseLayerDrawCoordinatesFromGridUnits(gridX, gridY);
         }
     }
 }

--- a/EndlessClient/Rendering/MapEntityRenderers/MapObjectLayerRenderer.cs
+++ b/EndlessClient/Rendering/MapEntityRenderers/MapObjectLayerRenderer.cs
@@ -23,9 +23,9 @@ namespace EndlessClient.Rendering.MapEntityRenderers
         public MapObjectLayerRenderer(INativeGraphicsManager nativeGraphicsManager,
                                       ICurrentMapProvider currentMapProvider,
                                       ICharacterProvider characterProvider,
-                                      IRenderOffsetCalculator renderOffsetCalculator,
+                                      IGridDrawCoordinateCalculator gridDrawCoordinateCalculator,
                                       ICurrentMapStateProvider currentMapStateProvider)
-            : base(characterProvider, renderOffsetCalculator)
+            : base(characterProvider, gridDrawCoordinateCalculator)
         {
             _nativeGraphicsManager = nativeGraphicsManager;
             _currentMapProvider = currentMapProvider;

--- a/EndlessClient/Rendering/MapEntityRenderers/NPCEntityRenderer.cs
+++ b/EndlessClient/Rendering/MapEntityRenderers/NPCEntityRenderer.cs
@@ -15,9 +15,9 @@ namespace EndlessClient.Rendering.MapEntityRenderers
         private readonly INPCRendererProvider _npcRendererProvider;
 
         public NPCEntityRenderer(ICharacterProvider characterProvider,
-                                 IRenderOffsetCalculator renderOffsetCalculator,
+                                 IGridDrawCoordinateCalculator gridDrawCoordinateCalculator,
                                  INPCRendererProvider npcRendererProvider)
-            : base(characterProvider, renderOffsetCalculator)
+            : base(characterProvider, gridDrawCoordinateCalculator)
         {
             _npcRendererProvider = npcRendererProvider;
         }

--- a/EndlessClient/Rendering/MapEntityRenderers/OnTopLayerRenderer.cs
+++ b/EndlessClient/Rendering/MapEntityRenderers/OnTopLayerRenderer.cs
@@ -20,8 +20,8 @@ namespace EndlessClient.Rendering.MapEntityRenderers
         public OnTopLayerRenderer(INativeGraphicsManager nativeGraphicsManager,
                                   ICurrentMapProvider currentMapProvider,
                                   ICharacterProvider characterProvider,
-                                  IRenderOffsetCalculator renderOffsetCalculator)
-            : base(characterProvider, renderOffsetCalculator)
+                                  IGridDrawCoordinateCalculator gridDrawCoordinateCalculator)
+            : base(characterProvider, gridDrawCoordinateCalculator)
         {
             _nativeGraphicsManager = nativeGraphicsManager;
             _currentMapProvider = currentMapProvider;

--- a/EndlessClient/Rendering/MapEntityRenderers/OtherCharacterEntityRenderer.cs
+++ b/EndlessClient/Rendering/MapEntityRenderers/OtherCharacterEntityRenderer.cs
@@ -16,8 +16,8 @@ namespace EndlessClient.Rendering.MapEntityRenderers
         public OtherCharacterEntityRenderer(ICharacterProvider characterProvider,
                                             ICharacterRendererProvider characterRendererProvider,
                                             ICharacterStateCache characterStateCache,
-                                            IRenderOffsetCalculator renderOffsetCalculator)
-            : base(characterProvider, renderOffsetCalculator)
+                                            IGridDrawCoordinateCalculator gridDrawCoordinateCalculator)
+            : base(characterProvider, gridDrawCoordinateCalculator)
         {
             _characterRendererProvider = characterRendererProvider;
             _characterStateCache = characterStateCache;

--- a/EndlessClient/Rendering/MapEntityRenderers/Overlay2LayerRenderer.cs
+++ b/EndlessClient/Rendering/MapEntityRenderers/Overlay2LayerRenderer.cs
@@ -20,8 +20,8 @@ namespace EndlessClient.Rendering.MapEntityRenderers
         public Overlay2LayerRenderer(INativeGraphicsManager nativeGraphicsManager,
                                      ICurrentMapProvider currentMapProvider,
                                      ICharacterProvider characterProvider,
-                                     IRenderOffsetCalculator renderOffsetCalculator)
-            : base(characterProvider, renderOffsetCalculator)
+                                     IGridDrawCoordinateCalculator gridDrawCoordinateCalculator)
+            : base(characterProvider, gridDrawCoordinateCalculator)
         {
             _nativeGraphicsManager = nativeGraphicsManager;
             _currentMapProvider = currentMapProvider;

--- a/EndlessClient/Rendering/MapEntityRenderers/OverlayLayerRenderer.cs
+++ b/EndlessClient/Rendering/MapEntityRenderers/OverlayLayerRenderer.cs
@@ -20,8 +20,8 @@ namespace EndlessClient.Rendering.MapEntityRenderers
         public OverlayLayerRenderer(INativeGraphicsManager nativeGraphicsManager,
                                     ICurrentMapProvider currentMapProvider,
                                     ICharacterProvider characterProvider,
-                                    IRenderOffsetCalculator renderOffsetCalculator)
-            : base(characterProvider, renderOffsetCalculator)
+                                    IGridDrawCoordinateCalculator gridDrawCoordinateCalculator)
+            : base(characterProvider, gridDrawCoordinateCalculator)
         {
             _nativeGraphicsManager = nativeGraphicsManager;
             _currentMapProvider = currentMapProvider;

--- a/EndlessClient/Rendering/MapEntityRenderers/RoofLayerRenderer.cs
+++ b/EndlessClient/Rendering/MapEntityRenderers/RoofLayerRenderer.cs
@@ -20,8 +20,8 @@ namespace EndlessClient.Rendering.MapEntityRenderers
         public RoofLayerRenderer(INativeGraphicsManager nativeGraphicsManager,
                                  ICurrentMapProvider currentMapProvider,
                                  ICharacterProvider characterProvider,
-                                 IRenderOffsetCalculator renderOffsetCalculator)
-            : base(characterProvider, renderOffsetCalculator)
+                                 IGridDrawCoordinateCalculator gridDrawCoordinateCalculator)
+            : base(characterProvider, gridDrawCoordinateCalculator)
         {
             _nativeGraphicsManager = nativeGraphicsManager;
             _currentMapProvider = currentMapProvider;

--- a/EndlessClient/Rendering/MapEntityRenderers/ShadowLayerRenderer.cs
+++ b/EndlessClient/Rendering/MapEntityRenderers/ShadowLayerRenderer.cs
@@ -22,9 +22,9 @@ namespace EndlessClient.Rendering.MapEntityRenderers
         public ShadowLayerRenderer(INativeGraphicsManager nativeGraphicsManager,
                                    ICurrentMapProvider currentMapProvider,
                                    ICharacterProvider characterProvider,
-                                   IRenderOffsetCalculator renderOffsetCalculator,
+                                   IGridDrawCoordinateCalculator gridDrawCoordinateCalculator,
                                    IConfigurationProvider configurationProvider)
-            : base(characterProvider, renderOffsetCalculator)
+            : base(characterProvider, gridDrawCoordinateCalculator)
         {
             _nativeGraphicsManager = nativeGraphicsManager;
             _currentMapProvider = currentMapProvider;

--- a/EndlessClient/Rendering/MapEntityRenderers/WallLayerRenderer.cs
+++ b/EndlessClient/Rendering/MapEntityRenderers/WallLayerRenderer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using EndlessClient.Rendering.Map;
 using EOLib.Domain.Character;
 using EOLib.Domain.Map;
@@ -23,9 +22,9 @@ namespace EndlessClient.Rendering.MapEntityRenderers
         protected WallLayerRendererBase(INativeGraphicsManager nativeGraphicsManager,
                                         ICurrentMapProvider currentMapProvider,
                                         ICharacterProvider characterProvider,
-                                        IRenderOffsetCalculator renderOffsetCalculator,
+                                        IGridDrawCoordinateCalculator gridDrawCoordinateCalculator,
                                         ICurrentMapStateProvider currentMapStateProvider)
-            : base(characterProvider, renderOffsetCalculator)
+            : base(characterProvider, gridDrawCoordinateCalculator)
         {
             _nativeGraphicsManager = nativeGraphicsManager;
             _currentMapProvider = currentMapProvider;
@@ -60,9 +59,9 @@ namespace EndlessClient.Rendering.MapEntityRenderers
         public DownWallLayerRenderer(INativeGraphicsManager nativeGraphicsManager,
                                     ICurrentMapProvider currentMapProvider,
                                     ICharacterProvider characterProvider,
-                                    IRenderOffsetCalculator renderOffsetCalculator,
+                                    IGridDrawCoordinateCalculator gridDrawCoordinateCalculator,
                                     ICurrentMapStateProvider currentMapStateProvider)
-            : base(nativeGraphicsManager, currentMapProvider, characterProvider, renderOffsetCalculator, currentMapStateProvider)
+            : base(nativeGraphicsManager, currentMapProvider, characterProvider, gridDrawCoordinateCalculator, currentMapStateProvider)
         {
         }
 
@@ -87,9 +86,9 @@ namespace EndlessClient.Rendering.MapEntityRenderers
         public RightWallLayerRenderer(INativeGraphicsManager nativeGraphicsManager,
                                       ICurrentMapProvider currentMapProvider,
                                       ICharacterProvider characterProvider,
-                                      IRenderOffsetCalculator renderOffsetCalculator,
+                                      IGridDrawCoordinateCalculator gridDrawCoordinateCalculator,
                                       ICurrentMapStateProvider currentMapStateProvider)
-            : base(nativeGraphicsManager, currentMapProvider, characterProvider, renderOffsetCalculator, currentMapStateProvider)
+            : base(nativeGraphicsManager, currentMapProvider, characterProvider, gridDrawCoordinateCalculator, currentMapStateProvider)
         {
         }
 

--- a/EndlessClient/Rendering/MouseCursorRenderer.cs
+++ b/EndlessClient/Rendering/MouseCursorRenderer.cs
@@ -5,6 +5,7 @@ using EndlessClient.Input;
 using EndlessClient.Rendering.Character;
 using EOLib;
 using EOLib.Domain.Character;
+using EOLib.Domain.Extensions;
 using EOLib.Domain.Item;
 using EOLib.Domain.Map;
 using EOLib.Graphics;
@@ -216,9 +217,14 @@ namespace EndlessClient.Rendering
         }
 
         //todo: this same logic is in a base map entity renderer. Maybe extract a service out.
-        private static Vector2 GetDrawCoordinatesFromGridUnits(int x, int y, int cOffX, int cOffY)
+        private Vector2 GetDrawCoordinatesFromGridUnits(int x, int y, int cOffX, int cOffY)
         {
-            return new Vector2(x*32 - y*32 + 288 - cOffX, y*16 + x*16 + 144 - cOffY);
+            var isWalking = _characterProvider.MainCharacter.RenderProperties.CurrentAction == CharacterActionState.Walking;
+            var isUpOrLeft = _characterProvider.MainCharacter.RenderProperties.IsFacing(EODirection.Up, EODirection.Left) ? -1 : 1;
+            var isDownOrLeft = _characterProvider.MainCharacter.RenderProperties.IsFacing(EODirection.Down, EODirection.Left) ? -1 : 1;
+            var walkOffset = new Vector2(isWalking ? isDownOrLeft * 8 : 0, isWalking ? isUpOrLeft * 4 : 0);
+
+            return new Vector2(x*32 - y*32 + 288 - cOffX, y*16 + x*16 + 144 - cOffY) + walkOffset;
         }
 
         private void UpdateMapItemLabel(Option<MapItem> item)

--- a/EndlessClient/Rendering/NPC/NPCAnimator.cs
+++ b/EndlessClient/Rendering/NPC/NPCAnimator.cs
@@ -11,34 +11,26 @@ namespace EndlessClient.Rendering.NPC
 {
     public class NPCAnimator : GameComponent, INPCAnimator
     {
-        private const int ACTION_FRAME_TIME_MS = 80;
+        private const int ACTION_FRAME_TIME_MS = 70;
 
         private readonly List<RenderFrameActionTime> _npcStartWalkingTimes;
         private readonly List<RenderFrameActionTime> _npcStartAttackingTimes;
         private readonly ICurrentMapStateRepository _currentMapStateRepository;
-        private readonly IFixedTimeStepRepository _fixedTimeStepRepository;
 
         public NPCAnimator(IEndlessGameProvider gameProvider,
-                           ICurrentMapStateRepository currentMapStateRepository,
-                           IFixedTimeStepRepository fixedTimeStepRepository)
+                           ICurrentMapStateRepository currentMapStateRepository)
             : base((Game)gameProvider.Game)
         {
             _currentMapStateRepository = currentMapStateRepository;
-            _fixedTimeStepRepository = fixedTimeStepRepository;
             _npcStartWalkingTimes = new List<RenderFrameActionTime>();
             _npcStartAttackingTimes = new List<RenderFrameActionTime>();
         }
 
         public override void Update(GameTime gameTime)
         {
-            if (_fixedTimeStepRepository.IsUpdateFrame)
-            {
-                if (_fixedTimeStepRepository.IsWalkUpdateFrame)
-                    AnimateNPCWalking();
-
-                AnimateNPCAttacking();
-            }
-
+            AnimateNPCWalking();
+            AnimateNPCAttacking();
+            
             base.Update(gameTime);
         }
 

--- a/EndlessClient/Rendering/NPC/NPCAnimator.cs
+++ b/EndlessClient/Rendering/NPC/NPCAnimator.cs
@@ -11,25 +11,33 @@ namespace EndlessClient.Rendering.NPC
 {
     public class NPCAnimator : GameComponent, INPCAnimator
     {
-        private const int ACTION_FRAME_TIME_MS = 90;
+        private const int ACTION_FRAME_TIME_MS = 80;
 
         private readonly List<RenderFrameActionTime> _npcStartWalkingTimes;
         private readonly List<RenderFrameActionTime> _npcStartAttackingTimes;
         private readonly ICurrentMapStateRepository _currentMapStateRepository;
+        private readonly IFixedTimeStepRepository _fixedTimeStepRepository;
 
         public NPCAnimator(IEndlessGameProvider gameProvider,
-                           ICurrentMapStateRepository currentMapStateRepository)
+                           ICurrentMapStateRepository currentMapStateRepository,
+                           IFixedTimeStepRepository fixedTimeStepRepository)
             : base((Game)gameProvider.Game)
         {
             _currentMapStateRepository = currentMapStateRepository;
+            _fixedTimeStepRepository = fixedTimeStepRepository;
             _npcStartWalkingTimes = new List<RenderFrameActionTime>();
             _npcStartAttackingTimes = new List<RenderFrameActionTime>();
         }
 
         public override void Update(GameTime gameTime)
         {
-            AnimateNPCWalking();
-            AnimateNPCAttacking();
+            // 8 updates per second
+            // see CharacterAnimator
+            if (_fixedTimeStepRepository.IsUpdateFrame)
+            {
+                AnimateNPCWalking();
+                AnimateNPCAttacking();
+            }
 
             base.Update(gameTime);
         }

--- a/EndlessClient/Rendering/NPC/NPCAnimator.cs
+++ b/EndlessClient/Rendering/NPC/NPCAnimator.cs
@@ -31,11 +31,11 @@ namespace EndlessClient.Rendering.NPC
 
         public override void Update(GameTime gameTime)
         {
-            // 8 updates per second
-            // see CharacterAnimator
             if (_fixedTimeStepRepository.IsUpdateFrame)
             {
-                AnimateNPCWalking();
+                if (_fixedTimeStepRepository.IsWalkUpdateFrame)
+                    AnimateNPCWalking();
+
                 AnimateNPCAttacking();
             }
 

--- a/EndlessClient/Rendering/NPC/NPCRenderer.cs
+++ b/EndlessClient/Rendering/NPC/NPCRenderer.cs
@@ -153,7 +153,7 @@ namespace EndlessClient.Rendering.NPC
             var currentMousePosition = _userInputProvider.CurrentMouseState.Position - DrawArea.Location;
             var currentFrame = _npcSpriteSheet.GetNPCTexture(_enfFileProvider.ENFFile[NPC.ID].Graphic, NPC.Frame, NPC.Direction);
 
-            if (currentFrame.Bounds.Contains(currentMousePosition))
+            if (currentFrame != null && currentFrame.Bounds.Contains(currentMousePosition))
             {
                 var colorData = new Color[1];
                 currentFrame.GetData(0, new Rectangle(currentMousePosition.X, currentMousePosition.Y, 1, 1), colorData, 0, 1);
@@ -199,8 +199,13 @@ namespace EndlessClient.Rendering.NPC
             var effects = NPC.IsFacing(EODirection.Left, EODirection.Down) ? SpriteEffects.None : SpriteEffects.FlipHorizontally;
 
             _effectRenderer.DrawBehindTarget(spriteBatch);
-            spriteBatch.Draw(_npcSpriteSheet.GetNPCTexture(data.Graphic, NPC.Frame, NPC.Direction),
-                             DrawArea, null, color, 0f, Vector2.Zero, effects, 1f);
+
+            var texture = _npcSpriteSheet.GetNPCTexture(data.Graphic, NPC.Frame, NPC.Direction);
+            if (texture != null)
+            {
+                spriteBatch.Draw(texture, DrawArea, null, color, 0f, Vector2.Zero, effects, 1f);
+            }
+
             _effectRenderer.DrawInFrontOfTarget(spriteBatch);
 
             _healthBarRenderer.DrawToSpriteBatch(spriteBatch);


### PR DESCRIPTION
Closes Issue #226 

Characters, NPCs, and map updates for rendering purposes now happen on a fixed time step. This resolves flickering issues when the main character was walking at the same time as another character/NPC (see linked issue).

Additionally, adjusted timings for character/NPC animations so they look a little more accurate now. NPCs that move fast no longer jump around because they're still trying to animate the previous action when a new one comes in. Characters walk a little bit now because walk timings were a bit too slow previously.

Also refactored code that calculates draw position from grid units into a single service so it isn't scattered all over the place anymore.