### PR TITLE
Improve rendering offset accuracy for all rendered entities

### DIFF
--- a/EOLib.Graphics/EOLib.Graphics.csproj
+++ b/EOLib.Graphics/EOLib.Graphics.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutomaticTypeMapper" Version="1.4.1" />
-    <PackageReference Include="PELoaderLib" Version="1.4.0" />
+    <PackageReference Include="PELoaderLib" Version="1.5.0" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.0.0" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta14" />

--- a/EOLib/Domain/Extensions/NPCExtensions.cs
+++ b/EOLib/Domain/Extensions/NPCExtensions.cs
@@ -50,21 +50,18 @@ namespace EOLib.Domain.Extensions
             return npc.WithFrame(npc.Frame + 1);
         }
 
-        public static int GetAttackFrame(this NPC.NPC npc)
-        {
-            if (!npc.IsActing(NPCActionState.Attacking))
-                return 0;
-            return npc.Frame - NPCFrame.Attack1 + 1;
-        }
-
         public static NPC.NPC WithNextAttackFrame(this NPC.NPC npc)
         {
-            if (npc.Frame == NPCFrame.Attack2)
-                return npc.WithFrame(NPCFrame.Standing);
-            if (npc.Frame == NPCFrame.Standing)
-                return npc.WithFrame(NPCFrame.Attack1);
+            var retNpc = npc.WithActualAttackFrame((npc.ActualAttackFrame + 1) % 5);
 
-            return npc.WithFrame(npc.Frame + 1);
+            if (npc.ActualAttackFrame == 0)
+                retNpc = retNpc.WithFrame(NPCFrame.Standing);
+            else if (npc.Frame == NPCFrame.Standing)
+                retNpc = retNpc.WithFrame(NPCFrame.Attack1);
+            else if (npc.Frame == NPCFrame.Attack1)
+                retNpc = retNpc.WithFrame(NPCFrame.Attack2);
+
+            return retNpc;
         }
 
         public static int GetDestinationX(this NPC.NPC npc)

--- a/EOLib/Domain/NPC/NPC.cs
+++ b/EOLib/Domain/NPC/NPC.cs
@@ -19,6 +19,8 @@ namespace EOLib.Domain.NPC
 
         public NPCFrame Frame { get; }
 
+        public int ActualAttackFrame { get; }
+
         public Option<short> OpponentID { get; }
     }
 }

--- a/EndlessClient/EndlessClient.csproj
+++ b/EndlessClient/EndlessClient.csproj
@@ -57,9 +57,10 @@
   <PropertyGroup />
   <ItemGroup>
     <PackageReference Include="Amadevus.RecordGenerator" Version="0.6.0" />
-    <PackageReference Include="EndlessClient.Binaries" Version="1.2.0.2" />
+    <PackageReference Include="EndlessClient.Binaries" Version="1.3.0.2" />
     <PackageReference Include="managed-midi" Version="1.9.14" />
     <PackageReference Include="Monogame.Content.Builder.Task" Version="3.8.0.1641" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.0" />
     <PackageReference Include="XNAControls" Version="1.6.0" />

--- a/EndlessClient/EndlessClient.csproj
+++ b/EndlessClient/EndlessClient.csproj
@@ -56,6 +56,7 @@
   </ItemGroup>
   <PropertyGroup />
   <ItemGroup>
+    <PackageReference Include="Amadevus.RecordGenerator" Version="0.6.0" />
     <PackageReference Include="EndlessClient.Binaries" Version="1.2.0.2" />
     <PackageReference Include="managed-midi" Version="1.9.14" />
     <PackageReference Include="Monogame.Content.Builder.Task" Version="3.8.0.1641" />

--- a/EndlessClient/Rendering/Character/CharacterRenderer.cs
+++ b/EndlessClient/Rendering/Character/CharacterRenderer.cs
@@ -76,12 +76,12 @@ namespace EndlessClient.Rendering.Character
 
         public Rectangle DrawArea { get; private set; }
 
-        public Rectangle MapProjectedDrawArea => DrawArea;
-
         private int? _topPixel;
         public int TopPixel => _topPixel.HasValue ? _topPixel.Value : 0;
 
         public int TopPixelWithOffset => TopPixel + DrawArea.Y;
+
+        public int HorizontalCenter { get; private set; }
 
         public bool MouseOver => DrawArea.Contains(_userInputProvider.CurrentMouseState.Position);
 
@@ -314,7 +314,6 @@ namespace EndlessClient.Rendering.Character
                 _sb.Draw(_outline, DrawArea.WithSize(1, DrawArea.Height), Color.Black);
 
                 _sb.Draw(_outline, DrawArea, Color.FromNonPremultiplied(255, 0, 0, 64));
-                _sb.Draw(_outline, MapProjectedDrawArea, Color.FromNonPremultiplied(0, 255, 0, 64));
             }
 
             _sb.End();
@@ -348,6 +347,7 @@ namespace EndlessClient.Rendering.Character
             {
                 // size of standing still skin texture
                 DrawArea = new Rectangle(xPosition, yPosition, 18, 58);
+                HorizontalCenter = xPosition + 9;
                 _textureUpdateRequired = true;
             }
         }

--- a/EndlessClient/Rendering/Character/CharacterRenderer.cs
+++ b/EndlessClient/Rendering/Character/CharacterRenderer.cs
@@ -253,10 +253,10 @@ namespace EndlessClient.Rendering.Character
 
         public void SetToCenterScreenPosition()
         {
-            const int x = 314; // 618 / 2.0
+            const int x = 310; // 620 / 2.0
 
             var skinRect = new Rectangle(0, 0, 18, 58);
-            var y = (298 - skinRect.Height)/2 - skinRect.Height/4;
+            var y = (298 - skinRect.Height)/2 - skinRect.Height/4 - 3;
             SetAbsoluteScreenPosition(x, y);
         }
 

--- a/EndlessClient/Rendering/Character/CharacterRenderer.cs
+++ b/EndlessClient/Rendering/Character/CharacterRenderer.cs
@@ -336,8 +336,8 @@ namespace EndlessClient.Rendering.Character
         private void SetGridCoordinatePosition()
         {
             //todo: the constants here should be dynamically configurable to support window resizing
-            var screenX = _renderOffsetCalculator.CalculateOffsetX(_character.RenderProperties) + 312 - GetMainCharacterOffsetX();
-            var screenY = _renderOffsetCalculator.CalculateOffsetY(_character.RenderProperties) + 106 - GetMainCharacterOffsetY();
+            var screenX = _renderOffsetCalculator.CalculateOffsetX(_character.RenderProperties) + 310 - GetMainCharacterOffsetX();
+            var screenY = _renderOffsetCalculator.CalculateOffsetY(_character.RenderProperties) + 104 - GetMainCharacterOffsetY();
 
             SetScreenCoordinates(screenX, screenY);
         }

--- a/EndlessClient/Rendering/Chat/ChatBubble.cs
+++ b/EndlessClient/Rendering/Chat/ChatBubble.cs
@@ -155,7 +155,7 @@ namespace EndlessClient.Rendering.Chat
         private void SetLabelDrawPosition()
         {
             _textLabel.DrawPosition = new Vector2(
-                _parent.DrawArea.X + _parent.DrawArea.Width / 2.0f - _textLabel.ActualWidth / 2.0f,
+                _parent.HorizontalCenter - _textLabel.ActualWidth / 2.0f,
                 _parent.TopPixelWithOffset - _textLabel.ActualHeight - (GetTexture(ChatBubbleTexture.TopMiddle).Height * 5));
         }
 

--- a/EndlessClient/Rendering/GridDrawCoordinateCalculator.cs
+++ b/EndlessClient/Rendering/GridDrawCoordinateCalculator.cs
@@ -5,6 +5,8 @@ using EOLib.Domain.Map;
 using Microsoft.Xna.Framework;
 using System;
 
+using DomainNPC = EOLib.Domain.NPC.NPC;
+
 namespace EndlessClient.Rendering
 {
     [AutoMappedType]
@@ -25,8 +27,8 @@ namespace EndlessClient.Rendering
 
         public Vector2 CalculateDrawCoordinatesFromGridUnits(int gridX, int gridY)
         {
-            const int ViewportWidthFactor = 320; // 640 * (1/2)
-            const int ViewportHeightFactor = 144; // 480 * (3/10)
+            const int ViewportWidthFactor = 319; // 640 * (1/2)
+            const int ViewportHeightFactor = 142; // 480 * (3/10) - 2
 
             return new Vector2(ViewportWidthFactor + (gridX * 32) - (gridY * 32),
                                ViewportHeightFactor + (gridY * 16) + (gridX * 16)) - CalculateCharacterOffsets();
@@ -39,8 +41,8 @@ namespace EndlessClient.Rendering
 
         public Vector2 CalculateBaseLayerDrawCoordinatesFromGridUnits(int gridX, int gridY)
         {
-            const int ViewportWidthFactor = 288; // ???
-            const int ViewportHeightFactor = 144; // 480 * (3/10)
+            const int ViewportWidthFactor = 288; // 640 * (1/2) - 32
+            const int ViewportHeightFactor = 142; // 480 * (3/10) - 2
 
             return new Vector2(ViewportWidthFactor + (gridX * 32) - (gridY * 32),
                                ViewportHeightFactor + (gridY * 16) + (gridX * 16)) - CalculateBaseLayerOffsets();
@@ -53,8 +55,8 @@ namespace EndlessClient.Rendering
 
         public Vector2 CalculateGroundLayerDrawCoordinatesFromGridUnits()
         {
-            const int ViewportWidthFactor = 320; // 640 * (1/2)
-            const int ViewportHeightFactor = 144; // 480 * (3/10)
+            const int ViewportWidthFactor = 319; // 640 * (1/2) - 1
+            const int ViewportHeightFactor = 142; // 480 * (3/10) - 2
 
             var props = _characterProvider.MainCharacter.RenderProperties;
 
@@ -65,8 +67,26 @@ namespace EndlessClient.Rendering
                                ViewportHeightFactor - (props.MapY * 16) - (props.MapX * 16)) - CalculateGroundLayerCharacterOffsets();
         }
 
+        public Vector2 CalculateDrawCoordinates(DomainNPC npc)
+        {
+            const int ViewportWidthFactor = 319; // 640 * (1/2) - 1
+            const int ViewportHeightFactor = 143; // 480 * (3/10) - 1 // ???
+
+            var npcOffsetX = _renderOffsetCalculator.CalculateOffsetX(npc);
+            var npcOffsetY = _renderOffsetCalculator.CalculateOffsetY(npc);
+
+            var mainOffsetX = _renderOffsetCalculator.CalculateOffsetX(_characterProvider.MainCharacter.RenderProperties);
+            var mainOffsetY = _renderOffsetCalculator.CalculateOffsetY(_characterProvider.MainCharacter.RenderProperties);
+
+            return new Vector2(ViewportWidthFactor + npcOffsetX - mainOffsetX,
+                               ViewportHeightFactor + npcOffsetY - mainOffsetY + 16);
+        }
+
         public MapCoordinate CalculateGridCoordinatesFromDrawLocation(Vector2 drawLocation)
         {
+            const int ViewportWidthFactor = 288; // 640 * (1/2) - 32
+            const int ViewportHeightFactor = 142; // 480 * (3/10) - 2
+
             //need to solve this system of equations to get x, y on the grid
             //(x * 32) - (y * 32) + 288 - c.OffsetX, => pixX = 32x - 32y + 288 - c.OffsetX
             //(y * 16) + (x * 16) + 144 - c.OffsetY  => 2pixY = 32y + 32x + 288 - 2c.OffsetY
@@ -85,8 +105,8 @@ namespace EndlessClient.Rendering
             var offsetX = _renderOffsetCalculator.CalculateOffsetX(_characterProvider.MainCharacter.RenderProperties);
             var offsetY = _renderOffsetCalculator.CalculateOffsetY(_characterProvider.MainCharacter.RenderProperties);
 
-            var gridX = (int)Math.Round((msX + 2 * msY - 576 + offsetX + 2 * offsetY) / 64.0);
-            var gridY = (int)Math.Round((msY - gridX * 16 - 144 + offsetY) / 16.0);
+            var gridX = (int)Math.Round((msX + 2 * msY - (ViewportWidthFactor*2) + offsetX + 2 * offsetY) / 64.0);
+            var gridY = (int)Math.Round((msY - gridX * 16 - ViewportHeightFactor + offsetY) / 16.0);
 
             return new MapCoordinate(gridX, gridY);
         }
@@ -135,6 +155,8 @@ namespace EndlessClient.Rendering
         Vector2 CalculateBaseLayerDrawCoordinatesFromGridUnits(MapCoordinate mapCoordinate);
 
         Vector2 CalculateGroundLayerDrawCoordinatesFromGridUnits();
+
+        Vector2 CalculateDrawCoordinates(DomainNPC npc);
 
         MapCoordinate CalculateGridCoordinatesFromDrawLocation(Vector2 drawLocation);
     }

--- a/EndlessClient/Rendering/HealthBarRenderer.cs
+++ b/EndlessClient/Rendering/HealthBarRenderer.cs
@@ -84,20 +84,20 @@ namespace EndlessClient.Rendering
             if (_frameOffset > 4)
                 Visible = false;
 
-            _healthBarPosition = _parentReference.DrawArea.Location.ToVector2() +
-                new Vector2((_parentReference.DrawArea.Width - _healthBarBackgroundSource.Width) / 2f,
-                            _parentReference.TopPixel - 26);
+            _healthBarPosition = new Vector2(
+                _parentReference.HorizontalCenter - _healthBarBackgroundSource.Width / 2f,
+                _parentReference.TopPixelWithOffset - 26);
 
             if (_isMiss)
             {
-                var xPos = _parentReference.DrawArea.X + (_parentReference.DrawArea.Width - _numberSourceRectangles[0].Width) / 2f;
+                var xPos = _parentReference.HorizontalCenter - (_numberSourceRectangles[0].Width / 2f);
                 var yPos = _parentReference.TopPixelWithOffset - _frameOffset - DamageCounterAdditionalOffset;
                 _damageCounterPosition = new Vector2(xPos, yPos);
             }
             else
             {
                 var digitCount = _numberSourceRectangles.Count;
-                var xPos = _parentReference.DrawArea.X + (_parentReference.DrawArea.Width - (digitCount * DigitWidth)) / 2f;
+                var xPos = _parentReference.HorizontalCenter - (digitCount * DigitWidth / 2f);
                 var yPos = _parentReference.TopPixelWithOffset - _frameOffset - DamageCounterAdditionalOffset;
                 _damageCounterPosition = new Vector2(xPos, yPos);
             }

--- a/EndlessClient/Rendering/IMapActor.cs
+++ b/EndlessClient/Rendering/IMapActor.cs
@@ -8,9 +8,9 @@ namespace EndlessClient.Rendering
 
         int TopPixelWithOffset { get; }
 
-        Rectangle DrawArea { get; }
+        int HorizontalCenter { get; }
 
-        Rectangle MapProjectedDrawArea { get; }
+        Rectangle DrawArea { get; }
 
         bool MouseOver { get; }
 

--- a/EndlessClient/Rendering/NPC/NPCFrameMetadata.cs
+++ b/EndlessClient/Rendering/NPC/NPCFrameMetadata.cs
@@ -1,18 +1,27 @@
 ﻿using Amadevus.RecordGenerator;
+using Newtonsoft.Json;
 
 namespace EndlessClient.Rendering.NPC
 {
     [Record]
     public sealed partial class NPCFrameMetadata
     {
+        [JsonProperty("xOffset")]
         public int OffsetX { get; }
+
+        [JsonProperty("yOffset")]
         public int OffsetY { get; }
 
+        [JsonProperty("xAttackOffset")]
         public int AttackOffsetX { get; }
+
+        [JsonProperty("yAttackOffset")]
         public int AttackOffsetY { get; }
 
+        [JsonProperty("hasAnimation")]
         public bool HasStandingFrameAnimation { get; }
 
+        [JsonProperty("nameHeight")]
         public int NameLabelOffset { get; }
     }
 }

--- a/EndlessClient/Rendering/NPC/NPCFrameMetadata.cs
+++ b/EndlessClient/Rendering/NPC/NPCFrameMetadata.cs
@@ -1,0 +1,18 @@
+﻿using Amadevus.RecordGenerator;
+
+namespace EndlessClient.Rendering.NPC
+{
+    [Record]
+    public sealed partial class NPCFrameMetadata
+    {
+        public int OffsetX { get; }
+        public int OffsetY { get; }
+
+        public int AttackOffsetX { get; }
+        public int AttackOffsetY { get; }
+
+        public bool HasStandingFrameAnimation { get; }
+
+        public int NameLabelOffset { get; }
+    }
+}

--- a/EndlessClient/Rendering/NPC/NPCFrameMetadataLoader.cs
+++ b/EndlessClient/Rendering/NPC/NPCFrameMetadataLoader.cs
@@ -1,0 +1,47 @@
+﻿using AutomaticTypeMapper;
+using EOLib.Graphics;
+using Newtonsoft.Json;
+using Optional;
+using PELoaderLib;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EndlessClient.Rendering.NPC
+{
+    [AutoMappedType(IsSingleton = true)]
+    public class NPCMetadataLoader : INPCMetadataLoader
+    {
+        private readonly IPEFileCollection _peFileCollection;
+        private readonly Dictionary<int, NPCFrameMetadata> _cache;
+
+        public NPCMetadataLoader(IPEFileCollection peFileCollection)
+        {
+            _peFileCollection = peFileCollection;
+            _cache = new Dictionary<int, NPCFrameMetadata>();
+        }
+
+        public Option<NPCFrameMetadata> GetMetadata(int graphic)
+        {
+            if (_cache.ContainsKey(graphic))
+                return Option.Some(_cache[graphic]);
+
+            try
+            {
+                var rawMetadata = _peFileCollection[GFXTypes.NPC].GetResourceByID(ResourceType.RCData, graphic);
+                var metadataString = Encoding.Unicode.GetString(rawMetadata);
+                _cache.Add(graphic, JsonConvert.DeserializeObject<NPCFrameMetadata>(metadataString));
+
+                return _cache[graphic].SomeNotNull();
+            }
+            catch
+            {
+                return Option.None<NPCFrameMetadata>();
+            }
+        }
+    }
+
+    public interface INPCMetadataLoader
+    {
+        Option<NPCFrameMetadata> GetMetadata(int graphic);
+    }
+}

--- a/EndlessClient/Rendering/NPC/NPCRenderer.cs
+++ b/EndlessClient/Rendering/NPC/NPCRenderer.cs
@@ -18,7 +18,6 @@ using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using Optional;
 using System;
-using System.Windows.Markup;
 using XNAControls;
 
 namespace EndlessClient.Rendering.NPC
@@ -57,11 +56,11 @@ namespace EndlessClient.Rendering.NPC
 
         public int TopPixelWithOffset => _readonlyTopPixel + DrawArea.Y;
 
+        public int HorizontalCenter { get; private set; }
+
         public int BottomPixelWithOffset => _readonlyBottomPixel + DrawArea.Y;
 
         public Rectangle DrawArea { get; private set; }
-
-        public Rectangle MapProjectedDrawArea { get; private set; }
 
         public bool MouseOver => DrawArea.Contains(_userInputProvider.CurrentMouseState.Position);
 
@@ -308,13 +307,8 @@ namespace EndlessClient.Rendering.NPC
                         new Vector2(metaDataOffsetX - frameTexture.Width / 2, metaDataOffsetY - (frameTexture.Height - 23));
                     DrawArea = frameTexture.Bounds.WithPosition(renderCoordinates);
 
-                    var oneGridSize = new Vector2(mainRenderer.DrawArea.Width,
-                                                  mainRenderer.DrawArea.Height);
-                    MapProjectedDrawArea = new Rectangle(
-                        (int)renderCoordinates.X + (frameTexture.Width - (int)oneGridSize.X) / 2,
-                        BottomPixelWithOffset - (int)oneGridSize.Y,
-                        (int)oneGridSize.X,
-                        (int)oneGridSize.Y);
+                    var horizontalOffset = _npcSpriteSheet.GetNPCMetadata(data.Graphic).OffsetX * (NPC.IsFacing(EODirection.Down, EODirection.Left) ? -1 : 1);
+                    HorizontalCenter = DrawArea.X + (DrawArea.Width / 2) + horizontalOffset;
                 });
         }
 

--- a/EndlessClient/Rendering/NPC/NPCRenderer.cs
+++ b/EndlessClient/Rendering/NPC/NPCRenderer.cs
@@ -285,17 +285,26 @@ namespace EndlessClient.Rendering.NPC
                     var frameTexture = _npcSpriteSheet.GetNPCTexture(data.Graphic, NPC.Frame, NPC.Direction);
                     var metaData = _npcSpriteSheet.GetNPCMetadata(data.Graphic);
 
-                    var metaDataOffsetX = NPC.Frame == NPCFrame.Attack2 ? metaData.AttackOffsetX : metaData.OffsetX;
-                    var metaDataOffsetY = NPC.Frame == NPCFrame.Attack2 ? metaData.AttackOffsetY - metaData.OffsetY : -metaData.OffsetY;
+                    int metaDataOffsetX, metaDataOffsetY;
+                    if (NPC.Frame == NPCFrame.Attack2)
+                    {
+                        metaDataOffsetX = metaData.AttackOffsetX * (NPC.IsFacing(EODirection.Up, EODirection.Right) ? -1 : 1);
+                        metaDataOffsetY = (metaData.AttackOffsetY * (NPC.IsFacing(EODirection.Down, EODirection.Right) ? -1 : 1)) - metaData.OffsetY;
+                    }
+                    else
+                    {
+                        metaDataOffsetX = metaData.OffsetX;
+                        metaDataOffsetY = -metaData.OffsetY;
+                    }
 
                     var renderCoordinates = _gridDrawCoordinateCalculator.CalculateDrawCoordinates(NPC) +
-                        new Vector2(metaDataOffsetX - frameTexture.Width / 2, metaDataOffsetY);
+                        new Vector2(metaDataOffsetX - frameTexture.Width / 2, metaDataOffsetY - (frameTexture.Height - 23));
                     DrawArea = frameTexture.Bounds.WithPosition(renderCoordinates);
 
                     var oneGridSize = new Vector2(mainRenderer.DrawArea.Width,
                                                   mainRenderer.DrawArea.Height);
                     MapProjectedDrawArea = new Rectangle(
-                        (int)renderCoordinates.X + (frameTexture.Width / 2) - (int)oneGridSize.X,
+                        (int)renderCoordinates.X + (frameTexture.Width - (int)oneGridSize.X) / 2,
                         BottomPixelWithOffset - (int)oneGridSize.Y,
                         (int)oneGridSize.X,
                         (int)oneGridSize.Y);
@@ -330,9 +339,8 @@ namespace EndlessClient.Rendering.NPC
         private Vector2 GetNameLabelPosition()
         {
             var data = _enfFileProvider.ENFFile[NPC.ID];
-            var offset = _npcSpriteSheet.GetNPCMetadata(data.Graphic).NameLabelOffset;
             return new Vector2(DrawArea.X + (DrawArea.Width - _nameLabel.ActualWidth) / 2f,
-                               TopPixelWithOffset - _nameLabel.ActualHeight - offset);
+                               DrawArea.Y - _nameLabel.ActualHeight);
 
         }
 

--- a/EndlessClient/Rendering/NPC/NPCRenderer.cs
+++ b/EndlessClient/Rendering/NPC/NPCRenderer.cs
@@ -70,7 +70,7 @@ namespace EndlessClient.Rendering.NPC
 
         public bool IsDead { get; private set; }
 
-        public Rectangle EffectTargetArea => DrawArea;
+        public Rectangle EffectTargetArea { get; private set; }
 
         public NPCRenderer(INativeGraphicsManager nativeGraphicsManager,
                            IEndlessGameProvider endlessGameProvider,
@@ -309,6 +309,8 @@ namespace EndlessClient.Rendering.NPC
 
                     var horizontalOffset = _npcSpriteSheet.GetNPCMetadata(data.Graphic).OffsetX * (NPC.IsFacing(EODirection.Down, EODirection.Left) ? -1 : 1);
                     HorizontalCenter = DrawArea.X + (DrawArea.Width / 2) + horizontalOffset;
+
+                    EffectTargetArea = DrawArea.WithSize(DrawArea.Width + horizontalOffset * 2, DrawArea.Height);
                 });
         }
 

--- a/EndlessClient/Rendering/NPC/NPCRenderer.cs
+++ b/EndlessClient/Rendering/NPC/NPCRenderer.cs
@@ -289,15 +289,18 @@ namespace EndlessClient.Rendering.NPC
                     var frameTexture = _npcSpriteSheet.GetNPCTexture(data.Graphic, NPC.Frame, NPC.Direction);
                     var metaData = _npcSpriteSheet.GetNPCMetadata(data.Graphic);
 
+                    var isUpOrRight = NPC.IsFacing(EODirection.Up, EODirection.Right) ? -1 : 1;
+                    var isDownOrRight = NPC.IsFacing(EODirection.Down, EODirection.Right) ? -1 : 1;
+
                     int metaDataOffsetX, metaDataOffsetY;
                     if (NPC.Frame == NPCFrame.Attack2)
                     {
-                        metaDataOffsetX = metaData.AttackOffsetX * (NPC.IsFacing(EODirection.Up, EODirection.Right) ? -1 : 1);
-                        metaDataOffsetY = (metaData.AttackOffsetY * (NPC.IsFacing(EODirection.Down, EODirection.Right) ? -1 : 1)) - metaData.OffsetY;
+                        metaDataOffsetX = metaData.AttackOffsetX * isUpOrRight + (metaData.OffsetX * isUpOrRight);
+                        metaDataOffsetY = metaData.AttackOffsetY * isDownOrRight - metaData.OffsetY;
                     }
                     else
                     {
-                        metaDataOffsetX = metaData.OffsetX * (NPC.IsFacing(EODirection.Up, EODirection.Right) ? -1 : 1);
+                        metaDataOffsetX = metaData.OffsetX * isUpOrRight;
                         metaDataOffsetY = -metaData.OffsetY;
                     }
 

--- a/EndlessClient/Rendering/NPC/NPCRenderer.cs
+++ b/EndlessClient/Rendering/NPC/NPCRenderer.cs
@@ -3,7 +3,6 @@ using EndlessClient.Controllers;
 using EndlessClient.GameExecution;
 using EndlessClient.HUD.Spells;
 using EndlessClient.Input;
-using EndlessClient.Rendering.Character;
 using EndlessClient.Rendering.Chat;
 using EndlessClient.Rendering.Effects;
 using EndlessClient.Rendering.Factories;
@@ -24,7 +23,6 @@ namespace EndlessClient.Rendering.NPC
 {
     public class NPCRenderer : DrawableGameComponent, INPCRenderer
     {
-        private readonly ICharacterRendererProvider _characterRendererProvider;
         private readonly IENFFileProvider _enfFileProvider;
         private readonly INPCSpriteSheet _npcSpriteSheet;
         private readonly IGridDrawCoordinateCalculator _gridDrawCoordinateCalculator;
@@ -74,7 +72,6 @@ namespace EndlessClient.Rendering.NPC
 
         public NPCRenderer(INativeGraphicsManager nativeGraphicsManager,
                            IEndlessGameProvider endlessGameProvider,
-                           ICharacterRendererProvider characterRendererProvider,
                            IENFFileProvider enfFileProvider,
                            INPCSpriteSheet npcSpriteSheet,
                            IGridDrawCoordinateCalculator gridDrawCoordinateCalculator,
@@ -91,7 +88,6 @@ namespace EndlessClient.Rendering.NPC
         {
             NPC = initialNPC;
 
-            _characterRendererProvider = characterRendererProvider;
             _enfFileProvider = enfFileProvider;
             _npcSpriteSheet = npcSpriteSheet;
             _gridDrawCoordinateCalculator = gridDrawCoordinateCalculator;
@@ -281,37 +277,33 @@ namespace EndlessClient.Rendering.NPC
 
         private void UpdateDrawAreas()
         {
-            _characterRendererProvider.MainCharacterRenderer
-                .MatchSome(mainRenderer =>
-                {
-                    var data = _enfFileProvider.ENFFile[NPC.ID];
-                    var frameTexture = _npcSpriteSheet.GetNPCTexture(data.Graphic, NPC.Frame, NPC.Direction);
-                    var metaData = _npcSpriteSheet.GetNPCMetadata(data.Graphic);
+            var data = _enfFileProvider.ENFFile[NPC.ID];
+            var frameTexture = _npcSpriteSheet.GetNPCTexture(data.Graphic, NPC.Frame, NPC.Direction);
+            var metaData = _npcSpriteSheet.GetNPCMetadata(data.Graphic);
 
-                    var isUpOrRight = NPC.IsFacing(EODirection.Up, EODirection.Right) ? -1 : 1;
-                    var isDownOrRight = NPC.IsFacing(EODirection.Down, EODirection.Right) ? -1 : 1;
+            var isUpOrRight = NPC.IsFacing(EODirection.Up, EODirection.Right) ? -1 : 1;
+            var isDownOrRight = NPC.IsFacing(EODirection.Down, EODirection.Right) ? -1 : 1;
 
-                    int metaDataOffsetX, metaDataOffsetY;
-                    if (NPC.Frame == NPCFrame.Attack2)
-                    {
-                        metaDataOffsetX = metaData.AttackOffsetX * isUpOrRight + (metaData.OffsetX * isUpOrRight);
-                        metaDataOffsetY = metaData.AttackOffsetY * isDownOrRight - metaData.OffsetY;
-                    }
-                    else
-                    {
-                        metaDataOffsetX = metaData.OffsetX * isUpOrRight;
-                        metaDataOffsetY = -metaData.OffsetY;
-                    }
+            int metaDataOffsetX, metaDataOffsetY;
+            if (NPC.Frame == NPCFrame.Attack2)
+            {
+                metaDataOffsetX = metaData.AttackOffsetX * isUpOrRight + (metaData.OffsetX * isUpOrRight);
+                metaDataOffsetY = metaData.AttackOffsetY * isDownOrRight - metaData.OffsetY;
+            }
+            else
+            {
+                metaDataOffsetX = metaData.OffsetX * isUpOrRight;
+                metaDataOffsetY = -metaData.OffsetY;
+            }
 
-                    var renderCoordinates = _gridDrawCoordinateCalculator.CalculateDrawCoordinates(NPC) +
-                        new Vector2(metaDataOffsetX - frameTexture.Width / 2, metaDataOffsetY - (frameTexture.Height - 23));
-                    DrawArea = frameTexture.Bounds.WithPosition(renderCoordinates);
+            var renderCoordinates = _gridDrawCoordinateCalculator.CalculateDrawCoordinates(NPC) +
+                new Vector2(metaDataOffsetX - frameTexture.Width / 2, metaDataOffsetY - (frameTexture.Height - 23));
+            DrawArea = frameTexture.Bounds.WithPosition(renderCoordinates);
 
-                    var horizontalOffset = _npcSpriteSheet.GetNPCMetadata(data.Graphic).OffsetX * (NPC.IsFacing(EODirection.Down, EODirection.Left) ? -1 : 1);
-                    HorizontalCenter = DrawArea.X + (DrawArea.Width / 2) + horizontalOffset;
+            var horizontalOffset = _npcSpriteSheet.GetNPCMetadata(data.Graphic).OffsetX * (NPC.IsFacing(EODirection.Down, EODirection.Left) ? -1 : 1);
+            HorizontalCenter = DrawArea.X + (DrawArea.Width / 2) + horizontalOffset;
 
-                    EffectTargetArea = DrawArea.WithSize(DrawArea.Width + horizontalOffset * 2, DrawArea.Height);
-                });
+            EffectTargetArea = DrawArea.WithSize(DrawArea.Width + horizontalOffset * 2, DrawArea.Height);
         }
 
         private void UpdateStandingFrameAnimation()

--- a/EndlessClient/Rendering/NPC/NPCRendererFactory.cs
+++ b/EndlessClient/Rendering/NPC/NPCRendererFactory.cs
@@ -4,7 +4,6 @@ using EndlessClient.Controllers;
 using EndlessClient.GameExecution;
 using EndlessClient.HUD.Spells;
 using EndlessClient.Input;
-using EndlessClient.Rendering.Character;
 using EndlessClient.Rendering.Chat;
 using EndlessClient.Rendering.Factories;
 using EndlessClient.Rendering.Sprites;
@@ -18,7 +17,6 @@ namespace EndlessClient.Rendering.NPC
     {
         private readonly INativeGraphicsManager _nativeGraphicsManager;
         private readonly IEndlessGameProvider _endlessGameProvider;
-        private readonly ICharacterRendererProvider _characterRendererProvider;
         private readonly IENFFileProvider _enfFileProvider;
         private readonly INPCSpriteSheet _npcSpriteSheet;
         private readonly IGridDrawCoordinateCalculator _gridDrawCoordinateCalculator;
@@ -33,7 +31,6 @@ namespace EndlessClient.Rendering.NPC
 
         public NPCRendererFactory(INativeGraphicsManager nativeGraphicsManager,
                                   IEndlessGameProvider endlessGameProvider,
-                                  ICharacterRendererProvider characterRendererProvider,
                                   IENFFileProvider enfFileProvider,
                                   INPCSpriteSheet npcSpriteSheet,
                                   IGridDrawCoordinateCalculator gridDrawCoordinateCalculator,
@@ -48,7 +45,6 @@ namespace EndlessClient.Rendering.NPC
         {
             _nativeGraphicsManager = nativeGraphicsManager;
             _endlessGameProvider = endlessGameProvider;
-            _characterRendererProvider = characterRendererProvider;
             _enfFileProvider = enfFileProvider;
             _npcSpriteSheet = npcSpriteSheet;
             _gridDrawCoordinateCalculator = gridDrawCoordinateCalculator;
@@ -66,7 +62,6 @@ namespace EndlessClient.Rendering.NPC
         {
             return new NPCRenderer(_nativeGraphicsManager,
                                    _endlessGameProvider,
-                                   _characterRendererProvider,
                                    _enfFileProvider,
                                    _npcSpriteSheet,
                                    _gridDrawCoordinateCalculator,

--- a/EndlessClient/Rendering/NPC/NPCRendererFactory.cs
+++ b/EndlessClient/Rendering/NPC/NPCRendererFactory.cs
@@ -24,6 +24,7 @@ namespace EndlessClient.Rendering.NPC
         private readonly IGridDrawCoordinateCalculator _gridDrawCoordinateCalculator;
         private readonly IHealthBarRendererFactory _healthBarRendererFactory;
         private readonly IChatBubbleFactory _chatBubbleFactory;
+        private readonly IRenderTargetFactory _renderTargetFactory;
         private readonly INPCInteractionController _npcInteractionController;
         private readonly IMapInteractionController _mapInteractionController;
         private readonly IUserInputProvider _userInputProvider;
@@ -38,6 +39,7 @@ namespace EndlessClient.Rendering.NPC
                                   IGridDrawCoordinateCalculator gridDrawCoordinateCalculator,
                                   IHealthBarRendererFactory healthBarRendererFactory,
                                   IChatBubbleFactory chatBubbleFactory,
+                                  IRenderTargetFactory renderTargetFactory,
                                   INPCInteractionController npcInteractionController,
                                   IMapInteractionController mapInteractionController,
                                   IUserInputProvider userInputProvider,
@@ -52,6 +54,7 @@ namespace EndlessClient.Rendering.NPC
             _gridDrawCoordinateCalculator = gridDrawCoordinateCalculator;
             _healthBarRendererFactory = healthBarRendererFactory;
             _chatBubbleFactory = chatBubbleFactory;
+            _renderTargetFactory = renderTargetFactory;
             _npcInteractionController = npcInteractionController;
             _mapInteractionController = mapInteractionController;
             _userInputProvider = userInputProvider;
@@ -69,6 +72,7 @@ namespace EndlessClient.Rendering.NPC
                                    _gridDrawCoordinateCalculator,
                                    _healthBarRendererFactory,
                                    _chatBubbleFactory,
+                                   _renderTargetFactory,
                                    _npcInteractionController,
                                    _mapInteractionController,
                                    _userInputProvider,

--- a/EndlessClient/Rendering/NPC/NPCRendererFactory.cs
+++ b/EndlessClient/Rendering/NPC/NPCRendererFactory.cs
@@ -21,7 +21,7 @@ namespace EndlessClient.Rendering.NPC
         private readonly ICharacterRendererProvider _characterRendererProvider;
         private readonly IENFFileProvider _enfFileProvider;
         private readonly INPCSpriteSheet _npcSpriteSheet;
-        private readonly IRenderOffsetCalculator _renderOffsetCalculator;
+        private readonly IGridDrawCoordinateCalculator _gridDrawCoordinateCalculator;
         private readonly IHealthBarRendererFactory _healthBarRendererFactory;
         private readonly IChatBubbleFactory _chatBubbleFactory;
         private readonly INPCInteractionController _npcInteractionController;
@@ -35,7 +35,7 @@ namespace EndlessClient.Rendering.NPC
                                   ICharacterRendererProvider characterRendererProvider,
                                   IENFFileProvider enfFileProvider,
                                   INPCSpriteSheet npcSpriteSheet,
-                                  IRenderOffsetCalculator renderOffsetCalculator,
+                                  IGridDrawCoordinateCalculator gridDrawCoordinateCalculator,
                                   IHealthBarRendererFactory healthBarRendererFactory,
                                   IChatBubbleFactory chatBubbleFactory,
                                   INPCInteractionController npcInteractionController,
@@ -49,7 +49,7 @@ namespace EndlessClient.Rendering.NPC
             _characterRendererProvider = characterRendererProvider;
             _enfFileProvider = enfFileProvider;
             _npcSpriteSheet = npcSpriteSheet;
-            _renderOffsetCalculator = renderOffsetCalculator;
+            _gridDrawCoordinateCalculator = gridDrawCoordinateCalculator;
             _healthBarRendererFactory = healthBarRendererFactory;
             _chatBubbleFactory = chatBubbleFactory;
             _npcInteractionController = npcInteractionController;
@@ -66,7 +66,7 @@ namespace EndlessClient.Rendering.NPC
                                    _characterRendererProvider,
                                    _enfFileProvider,
                                    _npcSpriteSheet,
-                                   _renderOffsetCalculator,
+                                   _gridDrawCoordinateCalculator,
                                    _healthBarRendererFactory,
                                    _chatBubbleFactory,
                                    _npcInteractionController,

--- a/EndlessClient/Rendering/Sprites/NPCSpriteOffsetRepository.cs
+++ b/EndlessClient/Rendering/Sprites/NPCSpriteOffsetRepository.cs
@@ -1,0 +1,199 @@
+﻿using AutomaticTypeMapper;
+using EndlessClient.Rendering.NPC;
+using System.Collections.Generic;
+
+namespace EndlessClient.Rendering.Sprites
+{
+    public interface INPCSpriteOffsetProvider
+    {
+        IReadOnlyDictionary<int, NPCFrameMetadata> DefaultMetadata { get; }
+    }
+
+    [AutoMappedType(IsSingleton = true)]
+    public class NPCSpriteOffsetRepository : INPCSpriteOffsetProvider
+    {
+        public IReadOnlyDictionary<int, NPCFrameMetadata> DefaultMetadata => _metadata;
+
+        private Dictionary<int, NPCFrameMetadata> _metadata;
+
+        public NPCSpriteOffsetRepository()
+        {
+            // source: https://docs.google.com/spreadsheets/d/1GMo3c2xcPW5Uv3pOsaIS2EwtVA_N0Qfwo9TCTDibUoI/edit#gid=0
+            _metadata = new Dictionary<int, NPCFrameMetadata>
+            {
+                { 1, new NPCFrameMetadata(0, 16, 0, 0, false, 4) }, // crow
+                { 2, new NPCFrameMetadata(0, 18, -6, -3, false, 0) }, // rat
+                { 3, new NPCFrameMetadata(0, 16, -8, -4, false, 0) }, // slime
+                { 4, new NPCFrameMetadata(0, 18, -8, -4, false, 50) }, // mummy
+                { 5, new NPCFrameMetadata(-2, 7, -8, -4, false, 20) }, // fox
+                { 6, new NPCFrameMetadata(0, 8, -6, -3, false, 10) }, // snake
+                { 7, new NPCFrameMetadata(-2, 6, -4, -2, false, 12) }, // goat
+                { 8, new NPCFrameMetadata(0, 0, -2, -1, false, 75) }, // centaur
+                { 9, new NPCFrameMetadata(-4, 6, -4, -2, false, 30) }, // undeath
+                { 10, new NPCFrameMetadata(1, -1, -6, -3, false, 8) }, // spider
+                { 11, new NPCFrameMetadata(0, 5, -4, -2, false, 40) }, // barbarian
+                { 12, new NPCFrameMetadata(0, 15, -6, -3, false, 33) }, // cactus
+                { 13, new NPCFrameMetadata(0, 13, 2, -2, false, 10) }, // penguin
+                { 14, new NPCFrameMetadata(-4, 10, -2, -4, false, 53) }, // cyclops
+                { 15, new NPCFrameMetadata(-1, 17, 0, 0, false, 40) }, // shop bob
+                { 16, new NPCFrameMetadata(0, 14, -6, -3, false, 45) }, // skeleton
+                { 17, new NPCFrameMetadata(0, 14, -6, -3, false, 45) }, // skeleton captain
+                { 18, new NPCFrameMetadata(0, 14, -6, -3, false, 45) }, // skeleton sword
+                { 19, new NPCFrameMetadata(0, 11, -6, -3, false, 49) }, // wingo
+                { 20, new NPCFrameMetadata(0, 7, 0, 0, false, 40) }, // juweller
+                { 21, new NPCFrameMetadata(-2, 17, -10, -5, false, 40) }, // pirate npc 1
+                { 22, new NPCFrameMetadata(0, 11, 0, 0, true, 45) }, // witch
+                { 23, new NPCFrameMetadata(0, 17, 0, 0, false, 40) }, // babs
+                { 24, new NPCFrameMetadata(0, 17, 0, 0, false, 40) }, // pirate npc 2
+                { 25, new NPCFrameMetadata(0, 6, 0, 0, true, 50) }, // blacksmith
+                { 26, new NPCFrameMetadata(-2, 11, -6, -3, false, 0) }, // crab🦀
+                { 27, new NPCFrameMetadata(0, 9, 0, 0, true, 12) }, // remi
+                { 28, new NPCFrameMetadata(-4, 16, 0, 0, true, 42) }, // guild bob
+                { 29, new NPCFrameMetadata(0, 7, -6, -3, false, 0) }, // vyercil
+                { 30, new NPCFrameMetadata(-10, 13, -8, -4, false, 42) }, // reaper
+                { 31, new NPCFrameMetadata(0, 13, -8, -4, false, 42) }, // chaos spawn
+                { 32, new NPCFrameMetadata(0, 17, 0, 0, false, 40) }, // blue hair npc
+                { 33, new NPCFrameMetadata(0, 17, 0, 0, false, 40) }, // beard npc
+                { 34, new NPCFrameMetadata(0, 17, 0, 0, false, 40) }, // long hair npc
+                { 35, new NPCFrameMetadata(-5, 17, -6, -3, false, 40) }, // aeven guard red
+                { 36, new NPCFrameMetadata(-5, 17, -6, -3, false, 40) }, // aeven guard purple
+                { 37, new NPCFrameMetadata(-5, 17, -6, -3, false, 40) }, // aeven guard green
+                { 38, new NPCFrameMetadata(-1, 12, -6, -3, false, 0) }, // green blob
+                { 39, new NPCFrameMetadata(-1, 12, -6, -3, false, 0) }, // pink blob
+                { 40, new NPCFrameMetadata(-1, 12, -6, -3, false, 0) }, // red blob
+                { 41, new NPCFrameMetadata(-1, 12, -6, -3, false, 0) }, // cyan blob
+                { 42, new NPCFrameMetadata(-1, 12, -6, -3, false, 0) }, // orange blob
+                { 43, new NPCFrameMetadata(-1, 12, -6, -3, false, 0) }, // yellow blob
+                { 44, new NPCFrameMetadata(-1, 12, -6, -3, false, 0) }, // blue blob
+                { 45, new NPCFrameMetadata(-1, 12, -6, -3, false, 40) }, // horse
+                { 46, new NPCFrameMetadata(-3, 10, -6, -3, false, 42) }, // unicorn
+                { 47, new NPCFrameMetadata(0, 10, -6, -3, false, 66) }, // birdman
+                { 48, new NPCFrameMetadata(6, 10, -6, -3, false, 66) }, // birdman winged
+                { 49, new NPCFrameMetadata(-9, 13, -6, -3, false, 68) }, // birdman captain
+                { 50, new NPCFrameMetadata(4, 10, -6, -3, true, 82) }, // flying birdman
+                { 51, new NPCFrameMetadata(0, 13, -10, -5, true, 59) }, // hell guardian
+                { 52, new NPCFrameMetadata(0, 1, -4, -2, true, 48) }, // wolfman
+                { 53, new NPCFrameMetadata(-2, 17, 0, 0, false, 40) }, // mommy npc
+                { 54, new NPCFrameMetadata(0, 14, 0, 0, false, 28) }, // kid npc
+                { 55, new NPCFrameMetadata(-3, 4, -3, -2, true, 13) }, // bullfrog green
+                { 56, new NPCFrameMetadata(-3, 4, -3, -2, true, 13) }, // bullfrog turqoise
+                { 57, new NPCFrameMetadata(-3, 4, -3, -2, true, 13) }, // bullfrog red
+                { 58, new NPCFrameMetadata(0, 18, -8, -4, true, 42) }, // hornet
+                { 59, new NPCFrameMetadata(0, 16, -8, -4, true, 44) }, // bat
+                { 60, new NPCFrameMetadata(-3, 6, -6, -3, false, 10) }, // wurm
+                { 61, new NPCFrameMetadata(0, 0, -12, -6, false, 10) }, // worm
+                { 62, new NPCFrameMetadata(-3, 11, -8, -4, false, 10) }, // ant
+                { 63, new NPCFrameMetadata(-3, 11, -8, -4, false, 10) }, // ant soldier
+                { 64, new NPCFrameMetadata(0, 15, -12, -6, true, 41) }, // teawk
+                { 65, new NPCFrameMetadata(3, 12, -8, -4, false, 23) }, // batmaso
+                { 66, new NPCFrameMetadata(-1, 8, -10, -5, false, 53) }, // jesaur
+                { 67, new NPCFrameMetadata(0, 12, -4, -2, false, 28) }, // hedgehog
+                { 68, new NPCFrameMetadata(0, 6, -4, -2, false, 93) }, // ice golem
+                { 69, new NPCFrameMetadata(0, 20, 0, 0, true, 48) }, // ice gem
+                { 70, new NPCFrameMetadata(-1, 17, -8, -4, false, 18) }, // gnome
+                { 71, new NPCFrameMetadata(-2, 10, -6, -3, false, 24) }, // gnome rider
+                { 72, new NPCFrameMetadata(1, 14, 0, 0, false, 20) }, // rock
+                { 73, new NPCFrameMetadata(-3, 13, -8, -4, false, 55) }, // golem
+                { 74, new NPCFrameMetadata(0, 16, -4, -2, false, 22) }, // mushroom
+                { 75, new NPCFrameMetadata(-1, 17, -6, -3, true, 37) }, // teawcus
+                { 76, new NPCFrameMetadata(-1, 16, -4, -2, false, 41) }, // hula man
+                { 77, new NPCFrameMetadata(-2, 10, 0, 0, false, 14) }, // snail
+                { 78, new NPCFrameMetadata(-2, 10, 0, 0, false, 14) }, // bowtie snail
+                { 79, new NPCFrameMetadata(0, 15, 0, 0, true, 41) }, // geggime
+                { 80, new NPCFrameMetadata(0, 5, -8, -4, false, 31) }, // ewak
+                { 81, new NPCFrameMetadata(-3, 15, -6, -3, true, 44) }, // azuorph
+                { 82, new NPCFrameMetadata(-2, 18, 0, 0, false, 40) }, // sword guy npc
+                { 83, new NPCFrameMetadata(-2, 17, 0, 0, false, 40) }, // purple hair npc
+                { 84, new NPCFrameMetadata(-2, 18, 0, 0, false, 40) }, // green hair girl npc
+                { 85, new NPCFrameMetadata(0, 18, -10, -5, true, 50) }, // wraith
+                { 86, new NPCFrameMetadata(-2, 14, 0, 0, true, 43) }, // priest
+                { 87, new NPCFrameMetadata(-4, 11, -8, -4, false, 40) }, // ninja
+                { 88, new NPCFrameMetadata(1, 12, -10, -5, false, 54) }, // orc
+                { 89, new NPCFrameMetadata(0, -4, 0, 0, true, 43) }, // octo
+                { 90, new NPCFrameMetadata(1, 6, -8, -4, true, 54) }, // octo tentacle
+                { 91, new NPCFrameMetadata(-14, 14, -3, -2, false, 64) }, // anundo leader
+                { 92, new NPCFrameMetadata(0, 13, -6, -4, false, 21) }, // carnivo
+                { 93, new NPCFrameMetadata(-9, 14, 0, 0, true, 55) }, // old king
+                { 94, new NPCFrameMetadata(-9, 14, 0, 0, true, 50) }, // green hair king
+                { 95, new NPCFrameMetadata(-7, 9, 0, 0, false, 32) }, // goblin
+                { 96, new NPCFrameMetadata(-1, 18, -6, -3, true, 46) }, // optica
+                { 97, new NPCFrameMetadata(-2, 14, -4, -2, false, 46) }, // bogo man
+                { 98, new NPCFrameMetadata(-1, 20, -8, -4, true, 50) }, // butterfly
+                { 99, new NPCFrameMetadata(0, 17, -6, -3, true, 68) }, // cursed mask
+                { 100, new NPCFrameMetadata(0, 17, -6, -3, false, 30) }, // red imp
+                { 101, new NPCFrameMetadata(0, 17, -6, -3, false, 30) }, // grey imp
+                { 102, new NPCFrameMetadata(0, 15, 0, 0, true, 84) }, // vine tentacle
+                { 103, new NPCFrameMetadata(0, 16, -10, -5, false, 48) }, // headless hunter
+                { 104, new NPCFrameMetadata(0, 15, -8, -4, false, 60) }, // swamp monster
+                { 105, new NPCFrameMetadata(0, 15, -8, -4, true, 70) }, // twin demons
+                { 106, new NPCFrameMetadata(0, 13, -6, -3, false, 30) }, // dwarf
+                { 107, new NPCFrameMetadata(-31, 4, -4, -2, false, 138) }, // apozen
+                { 108, new NPCFrameMetadata(0, 6, -10, -5, false, 12) }, // mimic
+                { 109, new NPCFrameMetadata(-2, 16, 0, 0, false, 43) }, // panda master npc
+                { 110, new NPCFrameMetadata(-2, 17, -6, -3, true, 59) }, // crane
+                { 111, new NPCFrameMetadata(0, 17, -6, -3, true, 17) }, // cyto 053
+                { 112, new NPCFrameMetadata(4, 6, -6, -3, true, 30) }, // sav 109
+                { 113, new NPCFrameMetadata(1, 7, 0, 0, false, 6) }, // robo tile
+                { 114, new NPCFrameMetadata(0, 17, -4, -2, true, 44) }, // proto
+                { 115, new NPCFrameMetadata(-6, 16, -6, -3, true, 42) }, // princess
+                { 116, new NPCFrameMetadata(0, 18, 0, 0, true, 40) }, // scientist npc
+                { 117, new NPCFrameMetadata(-2, 15, 0, 0, true, 32) }, // mechanic npc
+                { 118, new NPCFrameMetadata(-6, 15, -4, -2, true, 47) }, // wise man
+                { 119, new NPCFrameMetadata(-1, 13, -6, -3, false, 15) }, // sheep
+                { 120, new NPCFrameMetadata(-3, 19, -8, -4, false, 19) }, // biter
+                { 121, new NPCFrameMetadata(-1, 16, -2, -1, true, 10) }, // blocto
+                { 122, new NPCFrameMetadata(0, 18, -8, -4, true, 58) }, // puppet
+                { 123, new NPCFrameMetadata(0, 4, 0, 0, false, 65) }, // king wurm
+                { 124, new NPCFrameMetadata(-4, 9, -10, -5, false, 71) }, // gnoll
+                { 125, new NPCFrameMetadata(0, 0, 0, 0, false, 88) }, // bone spider
+                { 126, new NPCFrameMetadata(0, 20, -10, -5, true, 58) }, // hell flyer
+                { 127, new NPCFrameMetadata(-4, 12, -14, -5, true, 36) }, // shaman
+                { 128, new NPCFrameMetadata(-5, 17, -4, -2, false, 36) }, // war bear
+                { 129, new NPCFrameMetadata(0, 7, 0, 0, true, 32) }, // shark
+                { 130, new NPCFrameMetadata(0, 15, -10, -5, false, 5) }, // turtle
+                { 131, new NPCFrameMetadata(-1, 16, -8, -4, false, 16) }, // doll
+                { 132, new NPCFrameMetadata(-2, 5, -8, -4, false, 40) }, // dark magician
+                { 133, new NPCFrameMetadata(-2, 5, -6, -3, false, 47) }, // yeti
+                { 134, new NPCFrameMetadata(0, 18, -10, -5, true, 80) }, // banshee
+                { 135, new NPCFrameMetadata(0, 18, 0, 5, false, 41) }, // drone flyer
+                { 136, new NPCFrameMetadata(-2, 19, -4, -2, false, 22) }, // butter
+                { 137, new NPCFrameMetadata(0, 18, -8, -4, false, 45) }, // funky hair npc
+                { 138, new NPCFrameMetadata(0, 18, -6, -3, false, 26) }, // flombie
+                { 139, new NPCFrameMetadata(0, 17, -6, -3, false, 32) }, // gator
+                { 140, new NPCFrameMetadata(0, 18, -2, -1, true, 65) }, // phoenix
+                { 141, new NPCFrameMetadata(0, 16, -6, -3, false, 25) }, // bale
+                { 142, new NPCFrameMetadata(0, 18, -2, -1, true, 20) }, // espring
+                { 143, new NPCFrameMetadata(0, 16, -6, -3, false, 40) }, // old italian man npc
+                { 144, new NPCFrameMetadata(-3, 8, 0, 0, false, 52) }, // rotveig
+                { 145, new NPCFrameMetadata(0, 19, -6, -3, false, 48) }, // booba amazon npc
+                { 146, new NPCFrameMetadata(0, 19, -6, -3, false, 69) }, // cacadem
+                { 147, new NPCFrameMetadata(0, 10, 0, 0, false, 32) }, // flowie
+                { 148, new NPCFrameMetadata(-4, 16, -6, -3, true, 37) }, // nutviper
+                { 149, new NPCFrameMetadata(2, 6, 0, 0, false, 98) }, // dragon
+                { 150, new NPCFrameMetadata(-1, 18, -6, -3, false, 48) }, // flyman
+                { 151, new NPCFrameMetadata(-2, 1, -2, 1, false, 18) }, // vitamin
+                { 152, new NPCFrameMetadata(0, 10, -8, -2, false, 27) }, // onigiri
+                { 153, new NPCFrameMetadata(-2, 13, -6, -9, false, 39) }, // rabther
+                { 154, new NPCFrameMetadata(0, 15, -6, -3, false, 13) }, // piglet
+                { 155, new NPCFrameMetadata(0, 16, -6, -3, false, 18) }, // piglet with baby
+                { 156, new NPCFrameMetadata(0, 15, -6, -3, false, 32) }, // tenba
+                { 157, new NPCFrameMetadata(0, 6, -8, -4, true, 58) }, // funky hair cyborg
+                { 158, new NPCFrameMetadata(0, 15, 0, 0, true, 74) }, // drummer
+                { 159, new NPCFrameMetadata(-11, 18, 0, 0, true, 57) }, // guitarist
+                { 160, new NPCFrameMetadata(-4, 18, 0, 0, true, 45) }, // wise man guitar
+                { 161, new NPCFrameMetadata(0, 0, 0, 0, true, 65) }, // piano panda
+                { 162, new NPCFrameMetadata(-1, 10, -8, -4, false, 15) }, // mini army
+                { 163, new NPCFrameMetadata(0, 8, -6, -3, false, 12) }, // artist
+                { 164, new NPCFrameMetadata(0, 15, -8, -4, false, 10) }, // hamster
+                { 165, new NPCFrameMetadata(0, 13, 0, 0, false, 10) }, // mole
+                { 166, new NPCFrameMetadata(0, 18, 0, 0, true, 32) }, // fish
+                { 167, new NPCFrameMetadata(0, 14, -6, -3, false, 22) }, // lizzy
+                { 168, new NPCFrameMetadata(0, 15, -8, -4, false, 15) }, // ape
+                { 169, new NPCFrameMetadata(0, 4, -8, -4, false, 19) }, // taraduda
+                { 170, new NPCFrameMetadata(0, 19, -8, -4, false, 17) }, // monkey
+                { 171, new NPCFrameMetadata(0, 0, 0, 0, false, 0) }, // ancient wraith
+            };
+        }
+    }
+
+}

--- a/EndlessClient/Rendering/Sprites/NPCSpriteSheet.cs
+++ b/EndlessClient/Rendering/Sprites/NPCSpriteSheet.cs
@@ -11,10 +11,13 @@ namespace EndlessClient.Rendering.Sprites
     public class NPCSpriteSheet : INPCSpriteSheet
     {
         private readonly INativeGraphicsManager _gfxManager;
+        private readonly INPCSpriteOffsetProvider _npcSpriteOffsetProvider;
 
-        public NPCSpriteSheet(INativeGraphicsManager gfxManager)
+        public NPCSpriteSheet(INativeGraphicsManager gfxManager,
+                              INPCSpriteOffsetProvider npcSpriteOffsetProvider)
         {
             _gfxManager = gfxManager;
+            _npcSpriteOffsetProvider = npcSpriteOffsetProvider;
         }
 
         public Texture2D GetNPCTexture(int baseGraphic, NPCFrame whichFrame, EODirection direction)
@@ -57,102 +60,9 @@ namespace EndlessClient.Rendering.Sprites
         public NPCFrameMetadata GetNPCMetadata(int graphic)
         {
             // todo: load from GFX file RCData
-            switch (graphic)
-            {
-                case 1: // crow
-                    return new NPCFrameMetadata.Builder
-                    {
-                        OffsetX = 0,
-                        OffsetY = 16,
-                        AttackOffsetX = 0,
-                        AttackOffsetY = 0,
-                        HasStandingFrameAnimation = false,
-                        NameLabelOffset = 4,
-                    }.ToImmutable();
-                case 2: // rat
-                    return new NPCFrameMetadata.Builder
-                    {
-                        OffsetX = 0,
-                        OffsetY = 18,
-                        AttackOffsetX = -6,
-                        AttackOffsetY = -3,
-                        HasStandingFrameAnimation = false,
-                        NameLabelOffset = 0,
-                    }.ToImmutable();
-                case 3: // slime
-                    return new NPCFrameMetadata.Builder
-                    {
-                        OffsetX = 0,
-                        OffsetY = 16,
-                        AttackOffsetX = -8,
-                        AttackOffsetY = -4,
-                        HasStandingFrameAnimation = false,
-                        NameLabelOffset = 0,
-                    }.ToImmutable();
-                case 4: // mummy
-                    return new NPCFrameMetadata.Builder
-                    {
-                        OffsetX = 0,
-                        OffsetY = 18,
-                        AttackOffsetX = -8,
-                        AttackOffsetY = -4,
-                        HasStandingFrameAnimation = false,
-                        NameLabelOffset = 50,
-                    }.ToImmutable();
-                case 5: // fox
-                    return new NPCFrameMetadata.Builder
-                    {
-                        OffsetX = -2,
-                        OffsetY = 7,
-                        AttackOffsetX = -8,
-                        AttackOffsetY = -4,
-                        HasStandingFrameAnimation = false,
-                        NameLabelOffset = 20,
-                    }.ToImmutable();
-                case 8: // centaur
-                    return new NPCFrameMetadata.Builder
-                    {
-                        OffsetX = 0,
-                        OffsetY = 0,
-                        AttackOffsetX = -2,
-                        AttackOffsetY = -1,
-                        HasStandingFrameAnimation = false,
-                        NameLabelOffset = 75,
-                    }.ToImmutable();
-                case 16: // doot doot skeltal
-                case 17:
-                case 18:
-                    return new NPCFrameMetadata.Builder
-                    {
-                        OffsetX = 0,
-                        OffsetY = 14,
-                        AttackOffsetX = -6,
-                        AttackOffsetY = -3,
-                        HasStandingFrameAnimation = false,
-                        NameLabelOffset = 45,
-                    }.ToImmutable();
-                case 107: // apozen
-                    return new NPCFrameMetadata.Builder
-                    {
-                        OffsetX = -31,
-                        OffsetY = 4,
-                        AttackOffsetX = -4,
-                        AttackOffsetY = -2,
-                        HasStandingFrameAnimation = false,
-                        NameLabelOffset = 138,
-                    }.ToImmutable();
-                case 113: // robo tile
-                    return new NPCFrameMetadata.Builder
-                    {
-                        OffsetX = 1,
-                        OffsetY = 7,
-                        AttackOffsetX = 0,
-                        AttackOffsetY = 0,
-                        HasStandingFrameAnimation = false,
-                        NameLabelOffset = 6
-                    }.ToImmutable();
-                default: return new NPCFrameMetadata.Builder().ToImmutable();
-            }
+            return _npcSpriteOffsetProvider.DefaultMetadata.TryGetValue(graphic, out var ret)
+                ? ret
+                : new NPCFrameMetadata.Builder().ToImmutable();
         }
     }
 

--- a/EndlessClient/Rendering/Sprites/NPCSpriteSheet.cs
+++ b/EndlessClient/Rendering/Sprites/NPCSpriteSheet.cs
@@ -7,17 +7,20 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace EndlessClient.Rendering.Sprites
 {
-    [MappedType(BaseType = typeof(INPCSpriteSheet))]
+    [AutoMappedType]
     public class NPCSpriteSheet : INPCSpriteSheet
     {
         private readonly INativeGraphicsManager _gfxManager;
         private readonly INPCSpriteOffsetProvider _npcSpriteOffsetProvider;
+        private readonly INPCMetadataLoader _npcMetadataLoader;
 
         public NPCSpriteSheet(INativeGraphicsManager gfxManager,
-                              INPCSpriteOffsetProvider npcSpriteOffsetProvider)
+                              INPCSpriteOffsetProvider npcSpriteOffsetProvider,
+                              INPCMetadataLoader npcMetadataLoader)
         {
             _gfxManager = gfxManager;
             _npcSpriteOffsetProvider = npcSpriteOffsetProvider;
+            _npcMetadataLoader = npcMetadataLoader;
         }
 
         public Texture2D GetNPCTexture(int baseGraphic, NPCFrame whichFrame, EODirection direction)
@@ -59,10 +62,10 @@ namespace EndlessClient.Rendering.Sprites
 
         public NPCFrameMetadata GetNPCMetadata(int graphic)
         {
-            // todo: load from GFX file RCData
-            return _npcSpriteOffsetProvider.DefaultMetadata.TryGetValue(graphic, out var ret)
-                ? ret
-                : new NPCFrameMetadata.Builder().ToImmutable();
+            var emptyMetadata = new NPCFrameMetadata.Builder().ToImmutable();
+
+            return _npcMetadataLoader.GetMetadata(graphic)
+                .ValueOr(_npcSpriteOffsetProvider.DefaultMetadata.TryGetValue(graphic, out var ret) ? ret : emptyMetadata);
         }
     }
 

--- a/EndlessClient/Rendering/Sprites/NPCSpriteSheet.cs
+++ b/EndlessClient/Rendering/Sprites/NPCSpriteSheet.cs
@@ -79,7 +79,47 @@ namespace EndlessClient.Rendering.Sprites
                         HasStandingFrameAnimation = false,
                         NameLabelOffset = 0,
                     }.ToImmutable();
-                case 16: // doot doot bois
+                case 3: // slime
+                    return new NPCFrameMetadata.Builder
+                    {
+                        OffsetX = 0,
+                        OffsetY = 16,
+                        AttackOffsetX = -8,
+                        AttackOffsetY = -4,
+                        HasStandingFrameAnimation = false,
+                        NameLabelOffset = 0,
+                    }.ToImmutable();
+                case 4: // mummy
+                    return new NPCFrameMetadata.Builder
+                    {
+                        OffsetX = 0,
+                        OffsetY = 18,
+                        AttackOffsetX = -8,
+                        AttackOffsetY = -4,
+                        HasStandingFrameAnimation = false,
+                        NameLabelOffset = 50,
+                    }.ToImmutable();
+                case 5: // fox
+                    return new NPCFrameMetadata.Builder
+                    {
+                        OffsetX = -2,
+                        OffsetY = 7,
+                        AttackOffsetX = -8,
+                        AttackOffsetY = -4,
+                        HasStandingFrameAnimation = false,
+                        NameLabelOffset = 20,
+                    }.ToImmutable();
+                case 8: // centaur
+                    return new NPCFrameMetadata.Builder
+                    {
+                        OffsetX = 0,
+                        OffsetY = 0,
+                        AttackOffsetX = -2,
+                        AttackOffsetY = -1,
+                        HasStandingFrameAnimation = false,
+                        NameLabelOffset = 75,
+                    }.ToImmutable();
+                case 16: // doot doot skeltal
                 case 17:
                 case 18:
                     return new NPCFrameMetadata.Builder

--- a/EndlessClient/Rendering/Sprites/NPCSpriteSheet.cs
+++ b/EndlessClient/Rendering/Sprites/NPCSpriteSheet.cs
@@ -1,4 +1,5 @@
 using AutomaticTypeMapper;
+using EndlessClient.Rendering.NPC;
 using EOLib;
 using EOLib.Domain.NPC;
 using EOLib.Graphics;
@@ -52,10 +53,73 @@ namespace EndlessClient.Rendering.Sprites
             var baseGfx = (baseGraphic - 1) * 40;
             return _gfxManager.TextureFromResource(GFXTypes.NPC, baseGfx + offset, true);
         }
+
+        public NPCFrameMetadata GetNPCMetadata(int graphic)
+        {
+            // todo: load from GFX file RCData
+            switch (graphic)
+            {
+                case 1: // crow
+                    return new NPCFrameMetadata.Builder
+                    {
+                        OffsetX = 0,
+                        OffsetY = 16,
+                        AttackOffsetX = 0,
+                        AttackOffsetY = 0,
+                        HasStandingFrameAnimation = false,
+                        NameLabelOffset = 4,
+                    }.ToImmutable();
+                case 2: // rat
+                    return new NPCFrameMetadata.Builder
+                    {
+                        OffsetX = 0,
+                        OffsetY = 18,
+                        AttackOffsetX = -6,
+                        AttackOffsetY = -3,
+                        HasStandingFrameAnimation = false,
+                        NameLabelOffset = 0,
+                    }.ToImmutable();
+                case 16: // doot doot bois
+                case 17:
+                case 18:
+                    return new NPCFrameMetadata.Builder
+                    {
+                        OffsetX = 0,
+                        OffsetY = 14,
+                        AttackOffsetX = -6,
+                        AttackOffsetY = -3,
+                        HasStandingFrameAnimation = false,
+                        NameLabelOffset = 45,
+                    }.ToImmutable();
+                case 107: // apozen
+                    return new NPCFrameMetadata.Builder
+                    {
+                        OffsetX = -31,
+                        OffsetY = 4,
+                        AttackOffsetX = -4,
+                        AttackOffsetY = -2,
+                        HasStandingFrameAnimation = false,
+                        NameLabelOffset = 138,
+                    }.ToImmutable();
+                case 113: // robo tile
+                    return new NPCFrameMetadata.Builder
+                    {
+                        OffsetX = 1,
+                        OffsetY = 7,
+                        AttackOffsetX = 0,
+                        AttackOffsetY = 0,
+                        HasStandingFrameAnimation = false,
+                        NameLabelOffset = 6
+                    }.ToImmutable();
+                default: return new NPCFrameMetadata.Builder().ToImmutable();
+            }
+        }
     }
 
     public interface INPCSpriteSheet
     {
         Texture2D GetNPCTexture(int baseGraphic, NPCFrame whichFrame, EODirection direction);
+
+        NPCFrameMetadata GetNPCMetadata(int graphic);
     }
 }


### PR DESCRIPTION
Updates to rendering accuracy for all areas, including hard-coded NPC offset metadata. NPC offsets are attempted to be read from the RCData resources of the GFX file (gfx021.egf), if not found a hard-coded lookup table will be used, otherwise a default of zero will be used.

Also includes updates to character/map rendering offsets. Offset calculation is now highly consistent for all types of offsets (see `GridDrawCoordinateCalculator`), and represents a 1:1 accuracy with the original EO client.

Health bars/chat bubbles are drawn using the center axis of the NPC graphic now, which solves some issues with NPC graphics that are not centered (Reaper, Apozen).

Effect rendering is not fully accurate, but relies on the metadata to correctly center the effect on the target.

Partially implements #216 