### PR TITLE
fixed new bitmap font for mac

### DIFF
--- a/EndlessClient/EndlessClient.csproj
+++ b/EndlessClient/EndlessClient.csproj
@@ -71,7 +71,7 @@
   <None Include="..\bin\$(Configuration)\client\net6.0-macos\osx-x64\sfx\*" Link="sfx\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" PublishFolderType="RootDirectory" />
   <None Include="ContentPipeline\bin\MacOSX\Content\*.xnb" Link="ContentPipeline\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" PublishFolderType="Resource" />
   <None Include="ContentPipeline\bin\MacOSX\Content\ChatBubble\*.xnb" Link="ContentPipeline\ChatBubble\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" PublishFolderType="Resource" />
-  <None Include="ContentPipeline\bin\MacOSX\Content\BitmapFonts\*.xnb" Link="ContentPipeline\BitmapFonts\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" PublishFolderType="Resource" />
+  <None Include="ContentPipeline\bin\MacOSX\Content\BitmapFonts\*" Link="ContentPipeline\BitmapFonts\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" PublishFolderType="Resource" />
   <None Include="ContentPipeline\bin\MacOSX\Content\Party\*.xnb" Link="ContentPipeline\Party\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" PublishFolderType="Resource" />
 </ItemGroup>
   <ItemGroup>

--- a/EndlessClient/EndlessClient.csproj
+++ b/EndlessClient/EndlessClient.csproj
@@ -71,7 +71,7 @@
   <None Include="..\bin\$(Configuration)\client\net6.0-macos\osx-x64\sfx\*" Link="sfx\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" PublishFolderType="RootDirectory" />
   <None Include="ContentPipeline\bin\MacOSX\Content\*.xnb" Link="ContentPipeline\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" PublishFolderType="Resource" />
   <None Include="ContentPipeline\bin\MacOSX\Content\ChatBubble\*.xnb" Link="ContentPipeline\ChatBubble\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" PublishFolderType="Resource" />
-  <None Include="ContentPipeline\bin\MacOSX\Content\Fonts\*.xnb" Link="ContentPipeline\Fonts\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" PublishFolderType="Resource" />
+  <None Include="ContentPipeline\bin\MacOSX\Content\BitmapFonts\*.xnb" Link="ContentPipeline\BitmapFonts\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" PublishFolderType="Resource" />
   <None Include="ContentPipeline\bin\MacOSX\Content\Party\*.xnb" Link="ContentPipeline\Party\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" PublishFolderType="Resource" />
 </ItemGroup>
   <ItemGroup>

--- a/EndlessClient/EndlessClient.csproj
+++ b/EndlessClient/EndlessClient.csproj
@@ -71,7 +71,7 @@
   <None Include="..\bin\$(Configuration)\client\net6.0-macos\osx-x64\sfx\*" Link="sfx\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" PublishFolderType="RootDirectory" />
   <None Include="ContentPipeline\bin\MacOSX\Content\*.xnb" Link="ContentPipeline\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" PublishFolderType="Resource" />
   <None Include="ContentPipeline\bin\MacOSX\Content\ChatBubble\*.xnb" Link="ContentPipeline\ChatBubble\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" PublishFolderType="Resource" />
-  <None Include="ContentPipeline\bin\MacOSX\Content\BitmapFonts\*" Link="ContentPipeline\BitmapFonts\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" PublishFolderType="Resource" />
+  <None Include="ContentPipeline\bin\MacOSX\Content\BitmapFonts\*.xnb" Link="ContentPipeline\BitmapFonts\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" PublishFolderType="Resource" />
   <None Include="ContentPipeline\bin\MacOSX\Content\Party\*.xnb" Link="ContentPipeline\Party\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" PublishFolderType="Resource" />
 </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
`ContentPipeline/Fonts/` no longer exists and `BitmapFonts` was missing from EndlessClient.app causing it to crash.

<img width="896" alt="image" src="https://user-images.githubusercontent.com/464887/207115496-6d55b6de-86ed-4cba-967c-0c3dba031a2f.png">
->
<img width="909" alt="image" src="https://user-images.githubusercontent.com/464887/207116004-63f1b563-8d0e-4100-9f4e-60d2b4993ad8.png">
