### PR TITLE
Remove usages of exotic primitives where applicable

### DIFF
--- a/EOBot/BotBase.cs
+++ b/EOBot/BotBase.cs
@@ -61,8 +61,8 @@ namespace EOBot
 
             packetProcessActions.SetInitialSequenceNumber(handshakeResult[InitializationDataKey.SequenceByte1],
                 handshakeResult[InitializationDataKey.SequenceByte2]);
-            packetProcessActions.SetEncodeMultiples((byte)handshakeResult[InitializationDataKey.ReceiveMultiple],
-                (byte)handshakeResult[InitializationDataKey.SendMultiple]);
+            packetProcessActions.SetEncodeMultiples(handshakeResult[InitializationDataKey.ReceiveMultiple],
+                handshakeResult[InitializationDataKey.SendMultiple]);
 
             connectionActions.CompleteHandshake(handshakeResult);
 

--- a/EOBot/BotHelper.cs
+++ b/EOBot/BotHelper.cs
@@ -30,7 +30,7 @@ namespace EOBot
             var accParams = new CreateAccountParameters(name, password, password, name, name, name + "@eobot.net");
             var nameResult = await accountActions.CheckAccountNameWithServer(name);
             return nameResult >= AccountReply.OK_CodeRange
-                ? await accountActions.CreateAccount(accParams, (short)nameResult)
+                ? await accountActions.CreateAccount(accParams, (int)nameResult)
                 : nameResult;
         }
 

--- a/EOBot/Interpreter/BuiltInIdentifierConfigurator.cs
+++ b/EOBot/Interpreter/BuiltInIdentifierConfigurator.cs
@@ -109,7 +109,7 @@ namespace EOBot.Interpreter
             configRepo.Host = host;
             configRepo.Port = port;
 
-            configRepo.VersionBuild = (byte)((IntVariable)_state.SymbolTable[PredefinedIdentifiers.VERSION].Identifiable).Value;
+            configRepo.VersionBuild = ((IntVariable)_state.SymbolTable[PredefinedIdentifiers.VERSION].Identifiable).Value;
 
             var connectionActions = c.Resolve<INetworkConnectionActions>();
             var connectResult = await connectionActions.ConnectToServer();
@@ -128,8 +128,8 @@ namespace EOBot.Interpreter
 
             packetProcessActions.SetInitialSequenceNumber(handshakeResult[InitializationDataKey.SequenceByte1],
                 handshakeResult[InitializationDataKey.SequenceByte2]);
-            packetProcessActions.SetEncodeMultiples((byte)handshakeResult[InitializationDataKey.ReceiveMultiple],
-                (byte)handshakeResult[InitializationDataKey.SendMultiple]);
+            packetProcessActions.SetEncodeMultiples(handshakeResult[InitializationDataKey.ReceiveMultiple],
+                handshakeResult[InitializationDataKey.SendMultiple]);
 
             connectionActions.CompleteHandshake(handshakeResult);
         }
@@ -188,7 +188,7 @@ namespace EOBot.Interpreter
         private void JoinParty(int characterId)
         {
             var c = DependencyMaster.TypeRegistry[_botIndex];
-            c.Resolve<IPartyActions>().RequestParty(PartyRequestType.Join, (short)characterId);
+            c.Resolve<IPartyActions>().RequestParty(PartyRequestType.Join, characterId);
         }
 
         private void Chat(string chatText)

--- a/EOBot/Program.cs
+++ b/EOBot/Program.cs
@@ -36,7 +36,7 @@ namespace EOBot
                 _enfFileProvider = enfFileProvider;
             }
 
-            public void NPCTakeDamage(short npcIndex, int fromPlayerId, int damageToNpc, short npcPctHealth, Option<int> spellId)
+            public void NPCTakeDamage(int npcIndex, int fromPlayerId, int damageToNpc, int npcPctHealth, Option<int> spellId)
             {
                 if (fromPlayerId != _characterProvider.MainCharacter.ID)
                     return;
@@ -53,7 +53,7 @@ namespace EOBot
                 ConsoleHelper.WriteMessage(ConsoleHelper.Type.Hit, $"{damageToNpc,7} - {npcPctHealth,3}% HP - {npcIndex,2} - {npcName ?? string.Empty}", color);
             }
 
-            public void RemoveNPCFromView(int npcIndex, int playerId, Option<short> spellId, Option<int> damage, bool showDeathAnimation)
+            public void RemoveNPCFromView(int npcIndex, int playerId, Option<int> spellId, Option<int> damage, bool showDeathAnimation)
             {
             }
 
@@ -71,7 +71,7 @@ namespace EOBot
                 var npc = _currentMapStateRepository.NPCs.SingleOrDefault(x => x.Index == npcIndex);
                 if (npc == null) return;
 
-                var newNpc = npc.WithX((byte)npc.GetDestinationX()).WithY((byte)npc.GetDestinationY()).WithFrame(NPCFrame.Standing);
+                var newNpc = npc.WithX(npc.GetDestinationX()).WithY(npc.GetDestinationY()).WithFrame(NPCFrame.Standing);
                 _currentMapStateRepository.NPCs.Remove(npc);
                 _currentMapStateRepository.NPCs.Add(newNpc);
             }
@@ -123,7 +123,7 @@ namespace EOBot
                 }
             }
 
-            public void TakeItemFromMap(short id, int amountTaken)
+            public void TakeItemFromMap(int id, int amountTaken)
             {
                 var inventoryCount = _characterInventoryProvider.ItemInventory.SingleOrDefault(x => x.ItemID == id);
                 var weight = _characterProvider.MainCharacter.Stats[CharacterStat.Weight];
@@ -131,11 +131,11 @@ namespace EOBot
                 ConsoleHelper.WriteMessage(ConsoleHelper.Type.Item, $"{weight,3}/{maxWeight,3} - weight - {inventoryCount.Amount} in inventory");
             }
 
-            public void DropItem(short id, int amountDropped)
+            public void DropItem(int id, int amountDropped)
             {
             }
 
-            public void JunkItem(short id, int amountRemoved)
+            public void JunkItem(int id, int amountRemoved)
             {
                 var inventoryCount = _characterInventoryProvider.ItemInventory.SingleOrDefault(x => x.ItemID == id);
                 var weight = _characterProvider.MainCharacter.Stats[CharacterStat.Weight];
@@ -156,18 +156,18 @@ namespace EOBot
                 _characterProvider = characterProvider;
             }
 
-            public void NotifySelfSpellCast(short playerId, short spellId, int spellHp, byte percentHealth)
+            public void NotifySelfSpellCast(int playerId, int spellId, int spellHp, int percentHealth)
             {
                 if (playerId == _characterProvider.MainCharacter.ID && spellHp > 0)
                     ConsoleHelper.WriteMessage(ConsoleHelper.Type.Heal, $"{spellHp,7} - {percentHealth}% HP", ConsoleColor.DarkGreen);
             }
 
-            public void NotifyStartSpellCast(short playerId, short spellId) { }
-            public void NotifyTargetNpcSpellCast(short playerId) { }
-            public void NotifyTargetOtherSpellCast(short sourcePlayerID, short targetPlayerID, short spellId, int recoveredHP, byte targetPercentHealth) { }
+            public void NotifyStartSpellCast(int playerId, int spellId) { }
+            public void NotifyTargetNpcSpellCast(int playerId) { }
+            public void NotifyTargetOtherSpellCast(int sourcePlayerID, int targetPlayerID, int spellId, int recoveredHP, int targetPercentHealth) { }
             public void StartOtherCharacterAttackAnimation(int characterID, int noteIndex) { }
-            public void StartOtherCharacterWalkAnimation(int characterID, byte destinationX, byte destinationY, EODirection direction) { }
-            public void NotifyGroupSpellCast(short playerId, short spellId, short spellHp, List<GroupSpellTarget> spellTargets) { }
+            public void StartOtherCharacterWalkAnimation(int characterID, MapCoordinate destination, EODirection direction) { }
+            public void NotifyGroupSpellCast(int playerId, int spellId, int spellHp, List<GroupSpellTarget> spellTargets) { }
         }
 
         static async Task<int> Main(string[] args)

--- a/EOBot/TrainerBot.cs
+++ b/EOBot/TrainerBot.cs
@@ -360,7 +360,7 @@ namespace EOBot
 
             ConsoleHelper.WriteMessage(ConsoleHelper.Type.UseItem, $"{itemToUse.Name} - {itemToUse.HP} HP - inventory: {amount - 1} - (other heal item types: {healItems.Count() - 1})");
 
-            await TrySend(() => _itemActions.UseItem((short)itemToUse.ID));
+            await TrySend(() => _itemActions.UseItem(itemToUse.ID));
 
             await Task.Delay(ATTACK_BACKOFF_MS);
         }

--- a/EOLib.Config/ConfigFileLoadActions.cs
+++ b/EOLib.Config/ConfigFileLoadActions.cs
@@ -21,15 +21,15 @@ namespace EOLib.Config
 
             int tempInt;
             _configRepository.VersionMajor = configFile.GetValue(ConfigStrings.Version, ConfigStrings.Major, out tempInt)
-                ? (byte)tempInt
+                ? tempInt
                 : ConfigDefaults.MajorVersion;
 
             _configRepository.VersionMinor = configFile.GetValue(ConfigStrings.Version, ConfigStrings.Minor, out tempInt)
-                ? (byte)tempInt
+                ? tempInt
                 : ConfigDefaults.MinorVersion;
 
             _configRepository.VersionBuild = configFile.GetValue(ConfigStrings.Version, ConfigStrings.Client, out tempInt)
-                ? (byte)tempInt
+                ? tempInt
                 : ConfigDefaults.ClientVersion;
 
             _configRepository.Language = configFile.GetValue(ConfigStrings.LANGUAGE, ConfigStrings.Language, out tempInt)

--- a/EOLib.Config/IConfigurationRepository.cs
+++ b/EOLib.Config/IConfigurationRepository.cs
@@ -8,9 +8,9 @@ namespace EOLib.Config
         string Host { get; set; }
         int Port { get; set; }
 
-        byte VersionMajor { get; set; }
-        byte VersionMinor { get; set; }
-        byte VersionBuild { get; set; }
+        int VersionMajor { get; set; }
+        int VersionMinor { get; set; }
+        int VersionBuild { get; set; }
 
         EOLanguage Language { get; set; }
 
@@ -40,9 +40,9 @@ namespace EOLib.Config
         string Host { get; }
         int Port { get; }
 
-        byte VersionMajor { get; }
-        byte VersionMinor { get; }
-        byte VersionBuild { get; }
+        int VersionMajor { get; }
+        int VersionMinor { get; }
+        int VersionBuild { get; }
 
         EOLanguage Language { get; }
 
@@ -73,9 +73,9 @@ namespace EOLib.Config
         public string Host { get; set; }
         public int Port { get; set; }
 
-        public byte VersionMajor { get; set; }
-        public byte VersionMinor { get; set; }
-        public byte VersionBuild { get; set; }
+        public int VersionMajor { get; set; }
+        public int VersionMinor { get; set; }
+        public int VersionBuild { get; set; }
 
         public EOLanguage Language { get; set; }
 

--- a/EOLib.IO.Test/Map/MapFilePropertiesTest.cs
+++ b/EOLib.IO.Test/Map/MapFilePropertiesTest.cs
@@ -125,9 +125,9 @@ namespace EOLib.IO.Test.Map
             ret.AddRange(fullName);
 
             ret.AddRange(numberEncoderService.EncodeNumber(props.PKAvailable ? 3 : 0, 1));
-            ret.AddRange(numberEncoderService.EncodeNumber((byte)props.Effect, 1));
+            ret.AddRange(numberEncoderService.EncodeNumber((int)props.Effect, 1));
             ret.AddRange(numberEncoderService.EncodeNumber(props.Music, 1));
-            ret.AddRange(numberEncoderService.EncodeNumber((byte)props.Control, 1));
+            ret.AddRange(numberEncoderService.EncodeNumber((int)props.Control, 1));
             ret.AddRange(numberEncoderService.EncodeNumber(props.AmbientNoise, 2));
             ret.AddRange(numberEncoderService.EncodeNumber(props.Width, 1));
             ret.AddRange(numberEncoderService.EncodeNumber(props.Height, 1));

--- a/EOLib.IO.Test/Map/MapFileTest.cs
+++ b/EOLib.IO.Test/Map/MapFileTest.cs
@@ -146,7 +146,7 @@ namespace EOLib.IO.Test.Map
             ret.AddRange(nes.EncodeNumber(1, 1)); //y
             ret.AddRange(nes.EncodeNumber(1, 1)); //count (cols)
             ret.AddRange(nes.EncodeNumber(1, 1)); //x
-            ret.AddRange(nes.EncodeNumber((byte)spec, 1)); //tilespec
+            ret.AddRange(nes.EncodeNumber((int)spec, 1)); //tilespec
             ret.AddRange(nes.EncodeNumber(0, 1)); //y
             ret.AddRange(nes.EncodeNumber(0, 1)); //count (cols) (empty row)
 

--- a/EOLib.IO/Extensions/EIFFileExtensions.cs
+++ b/EOLib.IO/Extensions/EIFFileExtensions.cs
@@ -5,7 +5,7 @@ namespace EOLib.IO.Extensions
 {
     public static class EIFFileExtensions
     {
-        public static bool IsShieldOnBack(this IPubFile<EIFRecord> itemFile, short graphic)
+        public static bool IsShieldOnBack(this IPubFile<EIFRecord> itemFile, int graphic)
         {
             if (itemFile == null)
                 return false;
@@ -18,7 +18,7 @@ namespace EOLib.IO.Extensions
                     shieldInfo.SubType == ItemSubType.Wings);
         }
 
-        public static bool IsRangedWeapon(this IPubFile<EIFRecord> itemFile, short graphic)
+        public static bool IsRangedWeapon(this IPubFile<EIFRecord> itemFile, int graphic)
         {
             var weaponInfo = itemFile?.FirstOrDefault(x => x.Type == ItemType.Weapon && x.DollGraphic == graphic);
             return weaponInfo?.SubType == ItemSubType.Ranged;

--- a/EOLib.IO/Map/ChestSpawnMapEntity.cs
+++ b/EOLib.IO/Map/ChestSpawnMapEntity.cs
@@ -10,24 +10,24 @@
 
         public ChestKey Key { get; private set; }
 
-        public byte Slot { get; private set; }
+        public int Slot { get; private set; }
 
-        public short ItemID { get; private set; }
+        public int ItemID { get; private set; }
 
-        public short RespawnTime { get; private set; }
+        public int RespawnTime { get; private set; }
 
         public int Amount { get; private set; }
 
         public ChestSpawnMapEntity()
-            : this(-1, -1, ChestKey.None, 0, -1, -1, -1)
+            : this(-1, -1, ChestKey.None, -1, -1, -1, -1)
         { }
 
         private ChestSpawnMapEntity(int x,
             int y,
             ChestKey key,
-            byte slot,
-            short itemID,
-            short respawnTime,
+            int slot,
+            int itemID,
+            int respawnTime,
             int amount)
         {
             X = x;
@@ -60,21 +60,21 @@
             return newEntity;
         }
 
-        public ChestSpawnMapEntity WithSlot(byte slot)
+        public ChestSpawnMapEntity WithSlot(int slot)
         {
             var newEntity = MakeCopy(this);
             newEntity.Slot = slot;
             return newEntity;
         }
 
-        public ChestSpawnMapEntity WithItemID(short itemID)
+        public ChestSpawnMapEntity WithItemID(int itemID)
         {
             var newEntity = MakeCopy(this);
             newEntity.ItemID = itemID;
             return newEntity;
         }
 
-        public ChestSpawnMapEntity WithRespawnTime(short respawnTime)
+        public ChestSpawnMapEntity WithRespawnTime(int respawnTime)
         {
             var newEntity = MakeCopy(this);
             newEntity.RespawnTime = respawnTime;

--- a/EOLib.IO/Map/IMapFileProperties.cs
+++ b/EOLib.IO/Map/IMapFileProperties.cs
@@ -9,16 +9,16 @@ namespace EOLib.IO.Map
         byte[] Checksum { get; }
         int ChecksumInt { get; }
         string Name { get; }
-        byte Width { get; }
-        byte Height { get; }
+        int Width { get; }
+        int Height { get; }
         MapEffect Effect { get; }
-        byte Music { get; }
+        int Music { get; }
         MusicControl Control { get; }
-        short AmbientNoise { get; }
-        short FillTile { get; }
-        byte RelogX { get; }
-        byte RelogY { get; }
-        byte Unknown2 { get; }
+        int AmbientNoise { get; }
+        int FillTile { get; }
+        int RelogX { get; }
+        int RelogY { get; }
+        int Unknown2 { get; }
         bool MapAvailable { get; }
         bool CanScroll { get; }
         bool PKAvailable { get; }
@@ -29,16 +29,16 @@ namespace EOLib.IO.Map
 
         IMapFileProperties WithChecksum(byte[] checksum);
         IMapFileProperties WithName(string name);
-        IMapFileProperties WithWidth(byte width);
-        IMapFileProperties WithHeight(byte height);
+        IMapFileProperties WithWidth(int width);
+        IMapFileProperties WithHeight(int height);
         IMapFileProperties WithEffect(MapEffect effect);
-        IMapFileProperties WithMusic(byte music);
+        IMapFileProperties WithMusic(int music);
         IMapFileProperties WithControl(MusicControl control);
-        IMapFileProperties WithAmbientNoise(short ambientNoise);
-        IMapFileProperties WithFillTile(short fillTile);
-        IMapFileProperties WithRelogX(byte relogX);
-        IMapFileProperties WithRelogY(byte relogY);
-        IMapFileProperties WithUnknown2(byte unknown2);
+        IMapFileProperties WithAmbientNoise(int ambientNoise);
+        IMapFileProperties WithFillTile(int fillTile);
+        IMapFileProperties WithRelogX(int relogX);
+        IMapFileProperties WithRelogY(int relogY);
+        IMapFileProperties WithUnknown2(int unknown2);
         IMapFileProperties WithMapAvailable(bool isAvailable);
         IMapFileProperties WithScrollAvailable(bool canScroll);
         IMapFileProperties WithPKAvailable(bool pkAvailable);

--- a/EOLib.IO/Map/MapFileProperties.cs
+++ b/EOLib.IO/Map/MapFileProperties.cs
@@ -14,19 +14,19 @@ namespace EOLib.IO.Map
         public int ChecksumInt { get; private set; }
         public string Name { get; private set; }
 
-        public byte Width { get; private set; }
-        public byte Height { get; private set; }
+        public int Width { get; private set; }
+        public int Height { get; private set; }
 
         public MapEffect Effect { get; private set; }
 
-        public byte Music { get; private set; }
+        public int Music { get; private set; }
         public MusicControl Control { get; private set; }
-        public short AmbientNoise { get; private set; }
+        public int AmbientNoise { get; private set; }
 
-        public short FillTile { get; private set; }
-        public byte RelogX { get; private set; }
-        public byte RelogY { get; private set; }
-        public byte Unknown2 { get; private set; }
+        public int FillTile { get; private set; }
+        public int RelogX { get; private set; }
+        public int RelogY { get; private set; }
+        public int Unknown2 { get; private set; }
 
         public bool MapAvailable { get; private set; }
         public bool CanScroll { get; private set; }
@@ -69,14 +69,14 @@ namespace EOLib.IO.Map
             return clone;
         }
 
-        public IMapFileProperties WithWidth(byte width)
+        public IMapFileProperties WithWidth(int width)
         {
             var clone = Clone();
             clone.Width = width;
             return clone;
         }
 
-        public IMapFileProperties WithHeight(byte height)
+        public IMapFileProperties WithHeight(int height)
         {
             var clone = Clone();
             clone.Height = height;
@@ -90,7 +90,7 @@ namespace EOLib.IO.Map
             return clone;
         }
 
-        public IMapFileProperties WithMusic(byte music)
+        public IMapFileProperties WithMusic(int music)
         {
             var clone = Clone();
             clone.Music = music;
@@ -104,35 +104,35 @@ namespace EOLib.IO.Map
             return clone;
         }
 
-        public IMapFileProperties WithAmbientNoise(short ambientNoise)
+        public IMapFileProperties WithAmbientNoise(int ambientNoise)
         {
             var clone = Clone();
             clone.AmbientNoise = ambientNoise;
             return clone;
         }
 
-        public IMapFileProperties WithFillTile(short fillTile)
+        public IMapFileProperties WithFillTile(int fillTile)
         {
             var clone = Clone();
             clone.FillTile = fillTile;
             return clone;
         }
 
-        public IMapFileProperties WithRelogX(byte relogX)
+        public IMapFileProperties WithRelogX(int relogX)
         {
             var clone = Clone();
             clone.RelogX = relogX;
             return clone;
         }
 
-        public IMapFileProperties WithRelogY(byte relogY)
+        public IMapFileProperties WithRelogY(int relogY)
         {
             var clone = Clone();
             clone.RelogY = relogY;
             return clone;
         }
 
-        public IMapFileProperties WithUnknown2(byte unknown2)
+        public IMapFileProperties WithUnknown2(int unknown2)
         {
             var clone = Clone();
             clone.Unknown2 = unknown2;

--- a/EOLib.IO/Map/NPCSpawnMapEntity.cs
+++ b/EOLib.IO/Map/NPCSpawnMapEntity.cs
@@ -8,24 +8,24 @@
 
         public int Y { get; private set; }
 
-        public short ID { get; private set; }
+        public int ID { get; private set; }
 
-        public byte SpawnType { get; private set; }
+        public int SpawnType { get; private set; }
 
-        public short RespawnTime { get; private set; }
+        public int RespawnTime { get; private set; }
 
-        public byte Amount { get; private set; }
+        public int Amount { get; private set; }
 
         public NPCSpawnMapEntity()
-            : this(-1, -1, -1, 0, -1, 0)
+            : this(-1, -1, -1, -1, -1, -1)
         { }
 
         private NPCSpawnMapEntity(int x,
                                   int y,
-                                  short id,
-                                  byte spawnType,
-                                  short respawnTime,
-                                  byte amount)
+                                  int id,
+                                  int spawnType,
+                                  int respawnTime,
+                                  int amount)
         {
             X = x;
             Y = y;
@@ -49,28 +49,28 @@
             return newEntity;
         }
 
-        public NPCSpawnMapEntity WithID(short id)
+        public NPCSpawnMapEntity WithID(int id)
         {
             var newEntity = MakeCopy(this);
             newEntity.ID = id;
             return newEntity;
         }
 
-        public NPCSpawnMapEntity WithSpawnType(byte spawnType)
+        public NPCSpawnMapEntity WithSpawnType(int spawnType)
         {
             var newEntity = MakeCopy(this);
             newEntity.SpawnType = spawnType;
             return newEntity;
         }
 
-        public NPCSpawnMapEntity WithRespawnTime(short respawnTime)
+        public NPCSpawnMapEntity WithRespawnTime(int respawnTime)
         {
             var newEntity = MakeCopy(this);
             newEntity.RespawnTime = respawnTime;
             return newEntity;
         }
 
-        public NPCSpawnMapEntity WithAmount(byte amount)
+        public NPCSpawnMapEntity WithAmount(int amount)
         {
             var newEntity = MakeCopy(this);
             newEntity.Amount = amount;

--- a/EOLib.IO/Map/WarpMapEntity.cs
+++ b/EOLib.IO/Map/WarpMapEntity.cs
@@ -8,26 +8,26 @@
 
         public int Y { get; private set; }
 
-        public short DestinationMapID { get; private set; }
+        public int DestinationMapID { get; private set; }
 
-        public byte DestinationMapX { get; private set; }
+        public int DestinationMapX { get; private set; }
 
-        public byte DestinationMapY { get; private set; }
+        public int DestinationMapY { get; private set; }
 
-        public byte LevelRequirement { get; private set; }
+        public int LevelRequirement { get; private set; }
 
         public DoorSpec DoorType { get; private set; }
 
         public WarpMapEntity()
-            : this(-1, -1, -1, 0, 0, 0, DoorSpec.NoDoor)
+            : this(-1, -1, -1, -1, -1, -1, DoorSpec.NoDoor)
         { }
 
         private WarpMapEntity(int x,
                               int y,
-                              short destinationMapID,
-                              byte destinationMapX,
-                              byte destinationMapY,
-                              byte levelRequirement,
+                              int destinationMapID,
+                              int destinationMapX,
+                              int destinationMapY,
+                              int levelRequirement,
                               DoorSpec doorType)
         {
             X = x;
@@ -53,28 +53,28 @@
             return newEntity;
         }
 
-        public WarpMapEntity WithDestinationMapID(short destinationMapID)
+        public WarpMapEntity WithDestinationMapID(int destinationMapID)
         {
             var newEntity = MakeCopy(this);
             newEntity.DestinationMapID = destinationMapID;
             return newEntity;
         }
 
-        public WarpMapEntity WithDestinationMapX(byte destinationMapX)
+        public WarpMapEntity WithDestinationMapX(int destinationMapX)
         {
             var newEntity = MakeCopy(this);
             newEntity.DestinationMapX = destinationMapX;
             return newEntity;
         }
 
-        public WarpMapEntity WithDestinationMapY(byte destinationMapY)
+        public WarpMapEntity WithDestinationMapY(int destinationMapY)
         {
             var newEntity = MakeCopy(this);
             newEntity.DestinationMapY = destinationMapY;
             return newEntity;
         }
 
-        public WarpMapEntity WithLevelRequirement(byte levelRequirement)
+        public WarpMapEntity WithLevelRequirement(int levelRequirement)
         {
             var newEntity = MakeCopy(this);
             newEntity.LevelRequirement = levelRequirement;

--- a/EOLib.IO/NumericConstants.cs
+++ b/EOLib.IO/NumericConstants.cs
@@ -5,10 +5,11 @@ namespace EOLib.IO
     [ExcludeFromCodeCoverage]
     public static class NumericConstants
     {
-        public const int ONE_BYTE_MAX = 253;
-        public const int TWO_BYTE_MAX = ONE_BYTE_MAX * ONE_BYTE_MAX;
-        public const int THREE_BYTE_MAX = ONE_BYTE_MAX * ONE_BYTE_MAX * ONE_BYTE_MAX;
+        public const uint ONE_BYTE_MAX = 253;
+        public const uint TWO_BYTE_MAX = ONE_BYTE_MAX * ONE_BYTE_MAX;
+        public const uint THREE_BYTE_MAX = ONE_BYTE_MAX * ONE_BYTE_MAX * ONE_BYTE_MAX;
+        public const uint FOUR_BYTE_MAX = ONE_BYTE_MAX * ONE_BYTE_MAX * ONE_BYTE_MAX * ONE_BYTE_MAX;
 
-        public static readonly int[] NUMERIC_MAXIMUM = {ONE_BYTE_MAX, TWO_BYTE_MAX, THREE_BYTE_MAX };
+        public static readonly uint[] NUMERIC_MAXIMUM = {ONE_BYTE_MAX, TWO_BYTE_MAX, THREE_BYTE_MAX, FOUR_BYTE_MAX };
     }
 }

--- a/EOLib.IO/Services/NumberEncoderService.cs
+++ b/EOLib.IO/Services/NumberEncoderService.cs
@@ -50,11 +50,11 @@ namespace EOLib.IO.Services
 
             var retNum = 0;
             if (b.Length > 3)
-                retNum += b[3]*NumericConstants.THREE_BYTE_MAX;
+                retNum += b[3]*(int)NumericConstants.THREE_BYTE_MAX;
             if (b.Length > 2)
-                retNum += b[2]*NumericConstants.TWO_BYTE_MAX;
+                retNum += b[2]*(int)NumericConstants.TWO_BYTE_MAX;
             if (b.Length > 1)
-                retNum += b[1]*NumericConstants.ONE_BYTE_MAX;
+                retNum += b[1]*(int)NumericConstants.ONE_BYTE_MAX;
 
             return retNum + b[0];
         }

--- a/EOLib.IO/Services/Serializers/ChestSpawnMapEntitySerializer.cs
+++ b/EOLib.IO/Services/Serializers/ChestSpawnMapEntitySerializer.cs
@@ -22,7 +22,7 @@ namespace EOLib.IO.Services.Serializers
 
             retBytes.AddRange(_numberEncoderService.EncodeNumber(mapEntity.X, 1));
             retBytes.AddRange(_numberEncoderService.EncodeNumber(mapEntity.Y, 1));
-            retBytes.AddRange(_numberEncoderService.EncodeNumber((short) mapEntity.Key, 2));
+            retBytes.AddRange(_numberEncoderService.EncodeNumber((int)mapEntity.Key, 2));
             retBytes.AddRange(_numberEncoderService.EncodeNumber(mapEntity.Slot, 1));
             retBytes.AddRange(_numberEncoderService.EncodeNumber(mapEntity.ItemID, 2));
             retBytes.AddRange(_numberEncoderService.EncodeNumber(mapEntity.RespawnTime, 2));
@@ -40,9 +40,9 @@ namespace EOLib.IO.Services.Serializers
                 .WithX(_numberEncoderService.DecodeNumber(data[0]))
                 .WithY(_numberEncoderService.DecodeNumber(data[1]))
                 .WithKey((ChestKey) _numberEncoderService.DecodeNumber(data[2], data[3]))
-                .WithSlot((byte) _numberEncoderService.DecodeNumber(data[4]))
-                .WithItemID((short) _numberEncoderService.DecodeNumber(data[5], data[6]))
-                .WithRespawnTime((short) _numberEncoderService.DecodeNumber(data[7], data[8]))
+                .WithSlot(_numberEncoderService.DecodeNumber(data[4]))
+                .WithItemID(_numberEncoderService.DecodeNumber(data[5], data[6]))
+                .WithRespawnTime(_numberEncoderService.DecodeNumber(data[7], data[8]))
                 .WithAmount(_numberEncoderService.DecodeNumber(data[9], data[10], data[11]));
         }
     }

--- a/EOLib.IO/Services/Serializers/MapPropertiesSerializer.cs
+++ b/EOLib.IO/Services/Serializers/MapPropertiesSerializer.cs
@@ -67,17 +67,17 @@ namespace EOLib.IO.Services.Serializers
                 .WithPKAvailable(_numberEncoderService.DecodeNumber(data[31]) == 3 ||
                                  (mapNameArray[0] == 0xFF && mapNameArray[1] == 0x01))
                 .WithEffect((MapEffect) _numberEncoderService.DecodeNumber(data[32]))
-                .WithMusic((byte) _numberEncoderService.DecodeNumber(data[33]))
+                .WithMusic(_numberEncoderService.DecodeNumber(data[33]))
                 .WithControl((MusicControl)_numberEncoderService.DecodeNumber(data[34]))
-                .WithAmbientNoise((short) _numberEncoderService.DecodeNumber(data[35], data[36]))
-                .WithWidth((byte) _numberEncoderService.DecodeNumber(data[37]))
-                .WithHeight((byte) _numberEncoderService.DecodeNumber(data[38]))
-                .WithFillTile((short) _numberEncoderService.DecodeNumber(data[39], data[40]))
+                .WithAmbientNoise(_numberEncoderService.DecodeNumber(data[35], data[36]))
+                .WithWidth(_numberEncoderService.DecodeNumber(data[37]))
+                .WithHeight(_numberEncoderService.DecodeNumber(data[38]))
+                .WithFillTile(_numberEncoderService.DecodeNumber(data[39], data[40]))
                 .WithMapAvailable(_numberEncoderService.DecodeNumber(data[41]) == 1)
                 .WithScrollAvailable(_numberEncoderService.DecodeNumber(data[42]) == 1)
-                .WithRelogX((byte) _numberEncoderService.DecodeNumber(data[43]))
-                .WithRelogY((byte) _numberEncoderService.DecodeNumber(data[44]))
-                .WithUnknown2((byte) _numberEncoderService.DecodeNumber(data[45]));
+                .WithRelogX(_numberEncoderService.DecodeNumber(data[43]))
+                .WithRelogY(_numberEncoderService.DecodeNumber(data[44]))
+                .WithUnknown2(_numberEncoderService.DecodeNumber(data[45]));
 
             return properties;
         }

--- a/EOLib.IO/Services/Serializers/NPCSpawnMapEntitySerializer.cs
+++ b/EOLib.IO/Services/Serializers/NPCSpawnMapEntitySerializer.cs
@@ -38,10 +38,10 @@ namespace EOLib.IO.Services.Serializers
             return new NPCSpawnMapEntity()
                 .WithX(_numberEncoderService.DecodeNumber(data[0]))
                 .WithY(_numberEncoderService.DecodeNumber(data[1]))
-                .WithID((short) _numberEncoderService.DecodeNumber(data[2], data[3]))
-                .WithSpawnType((byte) _numberEncoderService.DecodeNumber(data[4]))
-                .WithRespawnTime((short) _numberEncoderService.DecodeNumber(data[5], data[6]))
-                .WithAmount((byte) _numberEncoderService.DecodeNumber(data[7]));
+                .WithID(_numberEncoderService.DecodeNumber(data[2], data[3]))
+                .WithSpawnType(_numberEncoderService.DecodeNumber(data[4]))
+                .WithRespawnTime(_numberEncoderService.DecodeNumber(data[5], data[6]))
+                .WithAmount(_numberEncoderService.DecodeNumber(data[7]));
         }
     }
 }

--- a/EOLib.IO/Services/Serializers/PubFileSerializer.cs
+++ b/EOLib.IO/Services/Serializers/PubFileSerializer.cs
@@ -34,7 +34,7 @@ namespace EOLib.IO.Services.Serializers
 
                 var lenBytes = new byte[2];
                 mem.Read(lenBytes, 0, 2);
-                var recordsInFile = (short)_numberEncoderService.DecodeNumber(lenBytes);
+                var recordsInFile = _numberEncoderService.DecodeNumber(lenBytes);
 
                 mem.Seek(1, SeekOrigin.Current);
 

--- a/EOLib.IO/Services/Serializers/PubRecordSerializer.cs
+++ b/EOLib.IO/Services/Serializers/PubRecordSerializer.cs
@@ -21,9 +21,9 @@ namespace EOLib.IO.Services.Serializers
         {
             var record = recordFactory();
 
-            var nameLengths = new List<byte>();
+            var nameLengths = new List<int>();
             for (int i = 0; i < record.NumberOfNames; i++)
-                nameLengths.Add((byte)_numberEncoderService.DecodeNumber(data[i]));
+                nameLengths.Add(_numberEncoderService.DecodeNumber(data[i]));
 
             int offset = nameLengths.Count;
             var names = new List<string>(nameLengths.Count);

--- a/EOLib.IO/Services/Serializers/WarpMapEntitySerializer.cs
+++ b/EOLib.IO/Services/Serializers/WarpMapEntitySerializer.cs
@@ -25,7 +25,7 @@ namespace EOLib.IO.Services.Serializers
             retBytes.AddRange(_numberEncoderService.EncodeNumber(mapEntity.DestinationMapX, 1));
             retBytes.AddRange(_numberEncoderService.EncodeNumber(mapEntity.DestinationMapY, 1));
             retBytes.AddRange(_numberEncoderService.EncodeNumber(mapEntity.LevelRequirement, 1));
-            retBytes.AddRange(_numberEncoderService.EncodeNumber((short)mapEntity.DoorType, 2));
+            retBytes.AddRange(_numberEncoderService.EncodeNumber((int)mapEntity.DoorType, 2));
 
             return retBytes.ToArray();
         }
@@ -37,10 +37,10 @@ namespace EOLib.IO.Services.Serializers
 
             return new WarpMapEntity()
                 .WithX(_numberEncoderService.DecodeNumber(data[0]))
-                .WithDestinationMapID((short) _numberEncoderService.DecodeNumber(data[1], data[2]))
-                .WithDestinationMapX((byte) _numberEncoderService.DecodeNumber(data[3]))
-                .WithDestinationMapY((byte) _numberEncoderService.DecodeNumber(data[4]))
-                .WithLevelRequirement((byte) _numberEncoderService.DecodeNumber(data[5]))
+                .WithDestinationMapID(_numberEncoderService.DecodeNumber(data[1], data[2]))
+                .WithDestinationMapX(_numberEncoderService.DecodeNumber(data[3]))
+                .WithDestinationMapY(_numberEncoderService.DecodeNumber(data[4]))
+                .WithLevelRequirement(_numberEncoderService.DecodeNumber(data[5]))
                 .WithDoorType((DoorSpec) _numberEncoderService.DecodeNumber(data[6], data[7]));
         }
     }

--- a/EOLib.Test/Net/FileTransfer/FileRequestServiceTest.cs
+++ b/EOLib.Test/Net/FileTransfer/FileRequestServiceTest.cs
@@ -52,7 +52,6 @@ namespace EOLib.Test.Net.FileTransfer
         public void RequestFile_ResponsePacketInvalidExtraByte_ThrowsMalformedPacketException()
         {
             Mock.Get(_packetSendService).SetupReceivedPacketHasHeader(PacketFamily.Init, PacketAction.Init, (byte)InitReply.ItemFile, 33);
-
             Assert.ThrowsAsync<MalformedPacketException>(async () => await _fileRequestService.RequestFile<EIFRecord>(InitFileType.Item, 1));
         }
 

--- a/EOLib.Test/Net/PacketEncoderServiceTest.cs
+++ b/EOLib.Test/Net/PacketEncoderServiceTest.cs
@@ -19,7 +19,7 @@ namespace EOLib.IO.Test.Services
                 .AddShort(0)
                 .AddShort(111)
                 .AddShort(127)
-                .AddChar((byte)DialogReply.Link)
+                .AddChar((int)DialogReply.Link)
                 .AddChar(1)
                 .Build();
 

--- a/EOLib/Domain/Account/AccountActions.cs
+++ b/EOLib/Domain/Account/AccountActions.cs
@@ -88,7 +88,7 @@ namespace EOLib.Domain.Account
             return reply;
         }
 
-        public async Task<AccountReply> CreateAccount(ICreateAccountParameters parameters, short sessionID)
+        public async Task<AccountReply> CreateAccount(ICreateAccountParameters parameters, int sessionID)
         {
             var createAccountPacket = new PacketBuilder(PacketFamily.Account, PacketAction.Create)
                 .AddShort(sessionID)
@@ -149,7 +149,7 @@ namespace EOLib.Domain.Account
 
         Task<AccountReply> CheckAccountNameWithServer(string accountName);
 
-        Task<AccountReply> CreateAccount(ICreateAccountParameters parameters, short sessionID);
+        Task<AccountReply> CreateAccount(ICreateAccountParameters parameters, int sessionID);
 
         Task<AccountReply> ChangePassword(IChangePasswordParameters parameters);
     }

--- a/EOLib/Domain/Character/Character.cs
+++ b/EOLib/Domain/Character/Character.cs
@@ -28,7 +28,7 @@ namespace EOLib.Domain.Character
 
         public string GuildTag { get; }
 
-        public byte ClassID { get; }
+        public int ClassID { get; }
 
         public AdminLevel AdminLevel { get; }
 

--- a/EOLib/Domain/Character/CharacterActions.cs
+++ b/EOLib/Domain/Character/CharacterActions.cs
@@ -29,7 +29,7 @@ namespace EOLib.Domain.Character
         public void Face(EODirection direction)
         {
             var packet = new PacketBuilder(PacketFamily.Face, PacketAction.Player)
-                .AddChar((byte) direction)
+                .AddChar((int)direction)
                 .Build();
 
             _packetSendService.SendPacket(packet);
@@ -42,10 +42,10 @@ namespace EOLib.Domain.Character
             var renderProperties = _characterRepository.MainCharacter.RenderProperties;
 
             var packet = new PacketBuilder(PacketFamily.Walk, admin ? PacketAction.Admin : PacketAction.Player)
-                .AddChar((byte) renderProperties.Direction)
+                .AddChar((int)renderProperties.Direction)
                 .AddThree(DateTime.Now.ToEOTimeStamp())
-                .AddChar((byte)renderProperties.GetDestinationX())
-                .AddChar((byte)renderProperties.GetDestinationY())
+                .AddChar(renderProperties.GetDestinationX())
+                .AddChar(renderProperties.GetDestinationY())
                 .Build();
 
             _packetSendService.SendPacket(packet);
@@ -58,7 +58,7 @@ namespace EOLib.Domain.Character
             _characterRepository.MainCharacter = c.WithStats(c.Stats.WithNewStat(CharacterStat.SP, sp));
 
             var packet = new PacketBuilder(PacketFamily.Attack, PacketAction.Use)
-                .AddChar((byte) _characterRepository.MainCharacter.RenderProperties.Direction)
+                .AddChar((int) _characterRepository.MainCharacter.RenderProperties.Direction)
                 .AddThree(DateTime.Now.ToEOTimeStamp())
                 .Build();
 
@@ -77,7 +77,7 @@ namespace EOLib.Domain.Character
                 : PacketFamily.Sit;
 
             var packet = new PacketBuilder(packetFamily, PacketAction.Request)
-                .AddChar((byte)sitAction)
+                .AddChar((int)sitAction)
                 .Build();
 
             _packetSendService.SendPacket(packet);
@@ -88,9 +88,9 @@ namespace EOLib.Domain.Character
             var rp = _characterRepository.MainCharacter.RenderProperties;
             var action = rp.SitState == SitState.Chair ? SitAction.Stand : SitAction.Sit;
             var packet = new PacketBuilder(PacketFamily.Chair, PacketAction.Request)
-                .AddChar((byte)action)
-                .AddChar((byte)rp.GetDestinationX())
-                .AddChar((byte)rp.GetDestinationY())
+                .AddChar((int)action)
+                .AddChar(rp.GetDestinationX())
+                .AddChar(rp.GetDestinationY())
                 .Build();
 
             _packetSendService.SendPacket(packet);
@@ -99,7 +99,7 @@ namespace EOLib.Domain.Character
         public void PrepareCastSpell(int spellId)
         {
             var packet = new PacketBuilder(PacketFamily.Spell, PacketAction.Request)
-                .AddShort((short)spellId)
+                .AddShort(spellId)
                 .AddThree(DateTime.Now.ToEOTimeStamp())
                 .Build();
 
@@ -127,7 +127,7 @@ namespace EOLib.Domain.Character
             if (data.Target == IO.SpellTarget.Group)
             {
                 builder = builder
-                    .AddShort((short)spellId)
+                    .AddShort(spellId)
                     .AddThree(DateTime.Now.ToEOTimeStamp());
             }
             else
@@ -137,21 +137,21 @@ namespace EOLib.Domain.Character
                     : target is Character
                         ? SpellTargetType.Player
                         : throw new InvalidOperationException("Invalid spell target specified, must be player or character");
-                builder = builder.AddChar((byte)spellTargetType);
+                builder = builder.AddChar((int)spellTargetType);
 
                 if (data.Target == IO.SpellTarget.Normal)
                 {
                     builder = builder
                         .AddChar(1) // unknown
                         .AddShort(1) // unknown
-                        .AddShort((short)spellId)
-                        .AddShort((short)target.Index)
+                        .AddShort(spellId)
+                        .AddShort(target.Index)
                         .AddThree(DateTime.Now.ToEOTimeStamp());
                 }
                 else
                 {
                     builder = builder
-                        .AddShort((short)spellId)
+                        .AddShort(spellId)
                         .AddInt(DateTime.Now.ToEOTimeStamp());
                 }
             }
@@ -162,7 +162,7 @@ namespace EOLib.Domain.Character
         public void Emote(Emote whichEmote)
         {
             var packet = new PacketBuilder(PacketFamily.Emote, PacketAction.Report)
-                .AddChar((byte)whichEmote)
+                .AddChar((int)whichEmote)
                 .Build();
 
             _packetSendService.SendPacket(packet);

--- a/EOLib/Domain/Character/CharacterManagementActions.cs
+++ b/EOLib/Domain/Character/CharacterManagementActions.cs
@@ -25,7 +25,7 @@ namespace EOLib.Domain.Character
             _characterSelectorRepository = characterSelectorRepository;
         }
 
-        public async Task<short> RequestCharacterCreation()
+        public async Task<int> RequestCharacterCreation()
         {
             var packet = new PacketBuilder(PacketFamily.Character, PacketAction.Request)
                 .AddBreakString("NEW")
@@ -34,14 +34,14 @@ namespace EOLib.Domain.Character
             return responsePacket.ReadShort();
         }
 
-        public async Task<CharacterReply> CreateCharacter(ICharacterCreateParameters parameters, short createID)
+        public async Task<CharacterReply> CreateCharacter(ICharacterCreateParameters parameters, int createID)
         {
             var packet = new PacketBuilder(PacketFamily.Character, PacketAction.Create)
                 .AddShort(createID)
-                .AddShort((short)parameters.Gender)
-                .AddShort((short)parameters.HairStyle)
-                .AddShort((short)parameters.HairColor)
-                .AddShort((short)parameters.Race)
+                .AddShort(parameters.Gender)
+                .AddShort(parameters.HairStyle)
+                .AddShort(parameters.HairColor)
+                .AddShort(parameters.Race)
                 .AddByte(255)
                 .AddBreakString(parameters.Name)
                 .Build();
@@ -53,7 +53,7 @@ namespace EOLib.Domain.Character
             return translatedData.Response;
         }
 
-        public async Task<short> RequestCharacterDelete()
+        public async Task<int> RequestCharacterDelete()
         {
             var packet = _characterSelectorRepository.CharacterForDelete.Match(
                 some: c => new PacketBuilder(PacketFamily.Character, PacketAction.Take).AddInt(c.ID).Build(),
@@ -65,7 +65,7 @@ namespace EOLib.Domain.Character
             return deleteRequestId;
         }
 
-        public async Task<CharacterReply> DeleteCharacter(short deleteRequestID)
+        public async Task<CharacterReply> DeleteCharacter(int deleteRequestID)
         {
             var packet = _characterSelectorRepository.CharacterForDelete.Match(
                 some: c => new PacketBuilder(PacketFamily.Character, PacketAction.Remove).AddShort(deleteRequestID).AddInt(c.ID).Build(),
@@ -81,12 +81,12 @@ namespace EOLib.Domain.Character
 
     public interface ICharacterManagementActions
     {
-        Task<short> RequestCharacterCreation();
+        Task<int> RequestCharacterCreation();
 
-        Task<CharacterReply> CreateCharacter(ICharacterCreateParameters parameters, short createID);
+        Task<CharacterReply> CreateCharacter(ICharacterCreateParameters parameters, int createID);
 
-        Task<short> RequestCharacterDelete();
+        Task<int> RequestCharacterDelete();
 
-        Task<CharacterReply> DeleteCharacter(short deleteRequestID);
+        Task<CharacterReply> DeleteCharacter(int deleteRequestID);
     }
 }

--- a/EOLib/Domain/Character/CharacterRenderProperties.cs
+++ b/EOLib/Domain/Character/CharacterRenderProperties.cs
@@ -12,16 +12,16 @@ namespace EOLib.Domain.Character
 
         public CharacterActionState CurrentAction { get; }
 
-        public byte HairStyle { get; }
-        public byte HairColor { get; }
-        public byte Race { get; }
-        public byte Gender { get; }
+        public int HairStyle { get; }
+        public int HairColor { get; }
+        public int Race { get; }
+        public int Gender { get; }
 
-        public short BootsGraphic { get; }
-        public short ArmorGraphic { get; }
-        public short HatGraphic { get; }
-        public short ShieldGraphic { get; }
-        public short WeaponGraphic { get; }
+        public int BootsGraphic { get; }
+        public int ArmorGraphic { get; }
+        public int HatGraphic { get; }
+        public int ShieldGraphic { get; }
+        public int WeaponGraphic { get; }
 
         public EODirection Direction { get; }
         public int MapX { get; }

--- a/EOLib/Domain/Character/InventoryItem.cs
+++ b/EOLib/Domain/Character/InventoryItem.cs
@@ -5,7 +5,7 @@ namespace EOLib.Domain.Character
     [Record(Features.Default | Features.EquatableEquals | Features.ObjectEquals)]
     public sealed partial class InventoryItem
     {
-        public short ItemID { get; }
+        public int ItemID { get; }
         
         public int Amount { get; }
     }

--- a/EOLib/Domain/Character/InventorySpell.cs
+++ b/EOLib/Domain/Character/InventorySpell.cs
@@ -5,8 +5,8 @@ namespace EOLib.Domain.Character
     [Record]
     public sealed partial class InventorySpell
     {
-        public short ID { get; }
+        public int ID { get; }
 
-        public short Level { get; }
+        public int Level { get; }
     }
 }

--- a/EOLib/Domain/Character/PaperdollData.cs
+++ b/EOLib/Domain/Character/PaperdollData.cs
@@ -20,19 +20,19 @@ namespace EOLib.Domain.Character
 
         public string Rank { get; }
 
-        public short PlayerID { get; }
+        public int PlayerID { get; }
 
-        public byte Class { get; }
+        public int Class { get; }
 
-        public byte Gender { get; }
+        public int Gender { get; }
 
-        public IReadOnlyDictionary<EquipLocation, short> Paperdoll { get; }
+        public IReadOnlyDictionary<EquipLocation, int> Paperdoll { get; }
 
         public OnlineIcon Icon { get; }
 
         public PaperdollData()
         {
-            Paperdoll = new Dictionary<EquipLocation, short>();
+            Paperdoll = new Dictionary<EquipLocation, int>();
         }
     }
 }

--- a/EOLib/Domain/Character/TrainingActions.cs
+++ b/EOLib/Domain/Character/TrainingActions.cs
@@ -21,8 +21,8 @@ namespace EOLib.Domain.Character
                 return;
 
             var packet = new PacketBuilder(PacketFamily.StatSkill, PacketAction.Add)
-                .AddChar((byte) TrainType.Stat)
-                .AddShort((byte) GetStatIndex(whichStat))
+                .AddChar((int) TrainType.Stat)
+                .AddShort(GetStatIndex(whichStat))
                 .Build();
 
             _packetSendService.SendPacket(packet);
@@ -31,8 +31,8 @@ namespace EOLib.Domain.Character
         public void LevelUpSkill(int spellId)
         {
             var packet = new PacketBuilder(PacketFamily.StatSkill, PacketAction.Add)
-                .AddChar((byte)TrainType.Skill)
-                .AddShort((short)spellId)
+                .AddChar((int)TrainType.Skill)
+                .AddShort(spellId)
                 .Build();
 
             _packetSendService.SendPacket(packet);
@@ -52,7 +52,7 @@ namespace EOLib.Domain.Character
             }
         }
 
-        private static short GetStatIndex(CharacterStat whichStat)
+        private static int GetStatIndex(CharacterStat whichStat)
         {
             switch (whichStat)
             {

--- a/EOLib/Domain/Chat/ChatActions.cs
+++ b/EOLib/Domain/Chat/ChatActions.cs
@@ -109,7 +109,7 @@ namespace EOLib.Domain.Chat
         {
             // GLOBAL_REMOVE with 'n' enables whispers...? 
             var packet = new PacketBuilder(PacketFamily.Global, whispersEnabled ? PacketAction.Remove : PacketAction.Player)
-                .AddChar((byte)(whispersEnabled ? 'n' : 'y'))
+                .AddChar(whispersEnabled ? 'n' : 'y')
                 .Build();
             _packetSendService.SendPacket(packet);
         }
@@ -117,7 +117,7 @@ namespace EOLib.Domain.Chat
         public void SetGlobalActive(bool active)
         {
             var packet = new PacketBuilder(PacketFamily.Global, active ? PacketAction.Open : PacketAction.Close)
-                .AddChar((byte)(active ? 'y' : 'n'))
+                .AddChar(active ? 'y' : 'n')
                 .Build();
             _packetSendService.SendPacket(packet);
         }

--- a/EOLib/Domain/Chat/Commands/PingCommand.cs
+++ b/EOLib/Domain/Chat/Commands/PingCommand.cs
@@ -27,16 +27,16 @@ namespace EOLib.Domain.Chat.Commands
 
         public bool Execute(string parameter)
         {
-            short requestID;
+            int requestID;
             do
             {
-                requestID = (short) _random.Next(0, short.MaxValue - 1);
+                requestID = _random.Next(0, short.MaxValue - 1);
             } while (_pingTimeRepository.PingRequests.ContainsKey(requestID));
 
             _pingTimeRepository.PingRequests.Add(requestID, DateTime.Now);
 
             var packet = new PacketBuilder(PacketFamily.Message, PacketAction.Ping)
-                .AddShort((short)requestID)
+                .AddShort(requestID)
                 .Build();
 
             _packetSendService.SendPacketAsync(packet);

--- a/EOLib/Domain/Extensions/CharacterExtensions.cs
+++ b/EOLib/Domain/Extensions/CharacterExtensions.cs
@@ -37,7 +37,7 @@ namespace EOLib.Domain.Extensions
         public static Character.Character WithDamage(this Character.Character original, int damageTaken, bool isDead)
         {
             var stats = original.Stats;
-            stats = stats.WithNewStat(CharacterStat.HP, (short)Math.Max(stats[CharacterStat.HP] - damageTaken, 0));
+            stats = stats.WithNewStat(CharacterStat.HP, Math.Max(stats[CharacterStat.HP] - damageTaken, 0));
 
             var props = original.RenderProperties
                 .WithIsDead(isDead);

--- a/EOLib/Domain/Interact/INPCInteractionNotifier.cs
+++ b/EOLib/Domain/Interact/INPCInteractionNotifier.cs
@@ -8,9 +8,9 @@ namespace EOLib.Domain.Interact
     {
         void NotifyInteractionFromNPC(NPCType npcType);
 
-        void NotifySkillLearnSuccess(short spellId, int characterGold);
+        void NotifySkillLearnSuccess(int spellId, int characterGold);
 
-        void NotifySkillLearnFail(SkillmasterReply skillmasterReply, short classId);
+        void NotifySkillLearnFail(SkillmasterReply skillmasterReply, int classId);
 
         void NotifySkillForget();
 
@@ -22,9 +22,9 @@ namespace EOLib.Domain.Interact
     {
         public void NotifyInteractionFromNPC(NPCType npcType) { }
 
-        public void NotifySkillLearnSuccess(short spellId, int characterGold) { }
+        public void NotifySkillLearnSuccess(int spellId, int characterGold) { }
 
-        public void NotifySkillLearnFail(SkillmasterReply skillmasterReply, short classId) { }
+        public void NotifySkillLearnFail(SkillmasterReply skillmasterReply, int classId) { }
 
         public void NotifySkillForget() { }
 

--- a/EOLib/Domain/Interact/MapNPCActions.cs
+++ b/EOLib/Domain/Interact/MapNPCActions.cs
@@ -26,7 +26,7 @@ namespace EOLib.Domain.Interact
         public void RequestShop(NPC.NPC npc)
         {
             var packet = new PacketBuilder(PacketFamily.Shop, PacketAction.Open)
-                .AddShort((short)npc.Index)
+                .AddShort(npc.Index)
                 .Build();
 
             _packetSendService.SendPacket(packet);
@@ -39,7 +39,7 @@ namespace EOLib.Domain.Interact
             var data = _enfFileProvider.ENFFile[npc.ID];
 
             var packet = new PacketBuilder(PacketFamily.Quest, PacketAction.Use)
-                .AddShort((short)npc.Index)
+                .AddShort(npc.Index)
                 .AddShort(data.VendorID)
                 .Build();
 
@@ -49,7 +49,7 @@ namespace EOLib.Domain.Interact
         public void RequestBank(NPC.NPC npc)
         {
             var packet = new PacketBuilder(PacketFamily.Bank, PacketAction.Open)
-                .AddShort((short)npc.Index)
+                .AddShort(npc.Index)
                 .Build();
 
             _packetSendService.SendPacket(packet);
@@ -58,7 +58,7 @@ namespace EOLib.Domain.Interact
         public void RequestSkillmaster(NPC.NPC npc)
         {
             var packet = new PacketBuilder(PacketFamily.StatSkill, PacketAction.Open)
-                .AddShort((short)npc.Index)
+                .AddShort(npc.Index)
                 .Build();
 
             _packetSendService.SendPacket(packet);

--- a/EOLib/Domain/Interact/PaperdollActions.cs
+++ b/EOLib/Domain/Interact/PaperdollActions.cs
@@ -17,7 +17,7 @@ namespace EOLib.Domain.Interact
         public void RequestPaperdoll(int characterId)
         {
             var packet = new PacketBuilder(PacketFamily.PaperDoll, PacketAction.Request)
-                .AddShort((short)characterId)
+                .AddShort(characterId)
                 .Build();
             _packetSendService.SendPacket(packet);
         }

--- a/EOLib/Domain/Interact/Quest/QuestActions.cs
+++ b/EOLib/Domain/Interact/Quest/QuestActions.cs
@@ -17,7 +17,7 @@ namespace EOLib.Domain.Interact.Quest
             _questDataProvider = questDataProvider;
         }
 
-        public void RespondToQuestDialog(DialogReply reply, byte linkId = 0)
+        public void RespondToQuestDialog(DialogReply reply, int linkId = 0)
         {
             _questDataProvider.QuestDialogData.MatchSome(data =>
             {
@@ -26,7 +26,7 @@ namespace EOLib.Domain.Interact.Quest
                     .AddShort(data.DialogID) // ignored by eoserv
                     .AddShort(data.QuestID)
                     .AddShort(data.VendorID) // ignored by eoserv
-                    .AddChar((byte)reply);
+                    .AddChar((int)reply);
 
                 if (reply == DialogReply.Link)
                     builder = builder.AddChar(linkId);
@@ -39,7 +39,7 @@ namespace EOLib.Domain.Interact.Quest
         public void RequestQuestHistory(QuestPage page)
         {
             var packet = new PacketBuilder(PacketFamily.Quest, PacketAction.List)
-                .AddChar((byte)page)
+                .AddChar((int)page)
                 .Build();
 
             _packetSendService.SendPacket(packet);
@@ -48,7 +48,7 @@ namespace EOLib.Domain.Interact.Quest
 
     public interface IQuestActions
     {
-        void RespondToQuestDialog(DialogReply reply, byte linkId = 0);
+        void RespondToQuestDialog(DialogReply reply, int linkId = 0);
 
         void RequestQuestHistory(QuestPage page);
     }

--- a/EOLib/Domain/Interact/Quest/QuestDialogData.cs
+++ b/EOLib/Domain/Interact/Quest/QuestDialogData.cs
@@ -6,25 +6,25 @@ namespace EOLib.Domain.Interact.Quest
     [Record]
     public sealed partial class QuestDialogData
     {
-        public short VendorID { get; }
+        public int VendorID { get; }
 
-        public short QuestID { get; }
+        public int QuestID { get; }
 
-        public short SessionID { get; }
+        public int SessionID { get; }
 
-        public short DialogID { get; }
+        public int DialogID { get; }
 
-        public IReadOnlyDictionary<short, string> DialogTitles { get; }
+        public IReadOnlyDictionary<int, string> DialogTitles { get; }
 
         public IReadOnlyList<string> PageText { get; }
 
-        public IReadOnlyList<(short ActionID, string DisplayText)> Actions { get; }
+        public IReadOnlyList<(int ActionID, string DisplayText)> Actions { get; }
 
         public QuestDialogData()
         {
-            DialogTitles = new Dictionary<short, string>();
+            DialogTitles = new Dictionary<int, string>();
             PageText = new List<string>();
-            Actions = new List<(short, string)>();
+            Actions = new List<(int, string)>();
         }
     }
 }

--- a/EOLib/Domain/Interact/Quest/QuestProgressData.cs
+++ b/EOLib/Domain/Interact/Quest/QuestProgressData.cs
@@ -33,9 +33,9 @@ namespace EOLib.Domain.Interact.Quest
             }
         }
 
-        public short Progress { get; }
+        public int Progress { get; }
 
-        public short Target { get; }
+        public int Target { get; }
 
     }
 }

--- a/EOLib/Domain/Interact/Shop/ShopActions.cs
+++ b/EOLib/Domain/Interact/Shop/ShopActions.cs
@@ -14,7 +14,7 @@ namespace EOLib.Domain.Interact.Shop
             _packetSendService = packetSendService;
         }
 
-        public void BuyItem(short itemId, int amount)
+        public void BuyItem(int itemId, int amount)
         {
             var packet = new PacketBuilder(PacketFamily.Shop, PacketAction.Buy)
                 .AddShort(itemId)
@@ -24,7 +24,7 @@ namespace EOLib.Domain.Interact.Shop
             _packetSendService.SendPacket(packet);
         }
 
-        public void SellItem(short itemId, int amount)
+        public void SellItem(int itemId, int amount)
         {
             var packet = new PacketBuilder(PacketFamily.Shop, PacketAction.Sell)
                 .AddShort(itemId)
@@ -34,7 +34,7 @@ namespace EOLib.Domain.Interact.Shop
             _packetSendService.SendPacket(packet);
         }
 
-        public void CraftItem(short itemId)
+        public void CraftItem(int itemId)
         {
             var packet = new PacketBuilder(PacketFamily.Shop, PacketAction.Create)
                 .AddShort(itemId)
@@ -46,10 +46,10 @@ namespace EOLib.Domain.Interact.Shop
 
     public interface IShopActions
     {
-        void BuyItem(short itemId, int amount);
+        void BuyItem(int itemId, int amount);
 
-        void SellItem(short itemId, int amount);
+        void SellItem(int itemId, int amount);
 
-        void CraftItem(short itemId);
+        void CraftItem(int itemId);
     }
 }

--- a/EOLib/Domain/Interact/Skill/Skill.cs
+++ b/EOLib/Domain/Interact/Skill/Skill.cs
@@ -6,27 +6,27 @@ namespace EOLib.Domain.Interact.Skill
     [Record]
     public sealed partial class Skill
     {
-        public short Id { get; }
+        public int Id { get; }
 
-        public byte LevelRequirement { get; }
+        public int LevelRequirement { get; }
 
-        public byte ClassRequirement { get; }
+        public int ClassRequirement { get; }
 
         public int GoldRequirement { get; }
 
-        public IReadOnlyList<short> SkillRequirements { get; }
+        public IReadOnlyList<int> SkillRequirements { get; }
 
-        public short StrRequirement { get; }
+        public int StrRequirement { get; }
 
-        public short IntRequirement { get; }
+        public int IntRequirement { get; }
 
-        public short WisRequirement { get; }
+        public int WisRequirement { get; }
 
-        public short AgiRequirement { get; }
+        public int AgiRequirement { get; }
 
-        public short ConRequirement { get; }
+        public int ConRequirement { get; }
 
-        public short ChaRequirement { get; }
+        public int ChaRequirement { get; }
     }
 
 }

--- a/EOLib/Domain/Interact/Skill/SkillDataRepository.cs
+++ b/EOLib/Domain/Interact/Skill/SkillDataRepository.cs
@@ -5,7 +5,7 @@ namespace EOLib.Domain.Interact.Skill
 {
     public interface ISkillDataRepository : IResettable
     {
-        short ID { get; set; }
+        int ID { get; set; }
 
         string Title { get; set; }
 
@@ -14,7 +14,7 @@ namespace EOLib.Domain.Interact.Skill
 
     public interface ISkillDataProvider : IResettable
     {
-        short ID { get; }
+        int ID { get; }
 
         string Title { get; }
 
@@ -24,7 +24,7 @@ namespace EOLib.Domain.Interact.Skill
     [AutoMappedType(IsSingleton = true)]
     public class SkillDataRepository : ISkillDataRepository, ISkillDataProvider
     {
-        public short ID { get; set; }
+        public int ID { get; set; }
 
         public string Title { get; set; }
 

--- a/EOLib/Domain/Interact/Skill/SkillmasterActions.cs
+++ b/EOLib/Domain/Interact/Skill/SkillmasterActions.cs
@@ -17,7 +17,7 @@ namespace EOLib.Domain.Interact.Skill
             _skillDataProvider = skillDataProvider;
         }
 
-        public void LearnSkill(short spellId)
+        public void LearnSkill(int spellId)
         {
             var packet = new PacketBuilder(PacketFamily.StatSkill, PacketAction.Take)
                 .AddInt(_skillDataProvider.ID)
@@ -27,7 +27,7 @@ namespace EOLib.Domain.Interact.Skill
             _packetSendService.SendPacket(packet);
         }
 
-        public void ForgetSkill(short spellId)
+        public void ForgetSkill(int spellId)
         {
             var packet = new PacketBuilder(PacketFamily.StatSkill, PacketAction.Remove)
                 .AddInt(_skillDataProvider.ID)
@@ -49,9 +49,9 @@ namespace EOLib.Domain.Interact.Skill
 
     public interface ISkillmasterActions
     {
-        void LearnSkill(short spellId);
+        void LearnSkill(int spellId);
 
-        void ForgetSkill(short spellId);
+        void ForgetSkill(int spellId);
 
         void ResetCharacter();
     }

--- a/EOLib/Domain/Item/ItemActions.cs
+++ b/EOLib/Domain/Item/ItemActions.cs
@@ -15,7 +15,7 @@ namespace EOLib.Domain.Item
             _packetSendService = packetSendService;
         }
 
-        public void UseItem(short itemId)
+        public void UseItem(int itemId)
         {
             var packet = new PacketBuilder(PacketFamily.Item, PacketAction.Use)
                 .AddShort(itemId)
@@ -24,38 +24,38 @@ namespace EOLib.Domain.Item
             _packetSendService.SendPacket(packet);
         }
 
-        public void EquipItem(short itemId, bool alternateLocation)
+        public void EquipItem(int itemId, bool alternateLocation)
         {
             var packet = new PacketBuilder(PacketFamily.PaperDoll, PacketAction.Add)
                 .AddShort(itemId)
-                .AddChar((byte)(alternateLocation ? 1 : 0))
+                .AddChar(alternateLocation ? 1 : 0)
                 .Build();
 
             _packetSendService.SendPacket(packet);
         }
 
-        public void UnequipItem(short itemId, bool alternateLocation)
+        public void UnequipItem(int itemId, bool alternateLocation)
         {
             var packet = new PacketBuilder(PacketFamily.PaperDoll, PacketAction.Remove)
                 .AddShort(itemId)
-                .AddChar((byte)(alternateLocation ? 1 : 0))
+                .AddChar(alternateLocation ? 1 : 0)
                 .Build();
 
             _packetSendService.SendPacket(packet);
         }
 
-        public void DropItem(short itemId, int amount, MapCoordinate dropPoint)
+        public void DropItem(int itemId, int amount, MapCoordinate dropPoint)
         {
             var packet = new PacketBuilder(PacketFamily.Item, PacketAction.Drop)
                 .AddShort(itemId)
                 .AddInt(amount)
-                .AddChar((byte)dropPoint.X)
-                .AddChar((byte)dropPoint.Y)
+                .AddChar(dropPoint.X)
+                .AddChar(dropPoint.Y)
                 .Build();
             _packetSendService.SendPacket(packet);
         }
 
-        public void JunkItem(short itemId, int amount)
+        public void JunkItem(int itemId, int amount)
         {
             var packet = new PacketBuilder(PacketFamily.Item, PacketAction.Junk)
                 .AddShort(itemId)
@@ -68,14 +68,14 @@ namespace EOLib.Domain.Item
 
     public interface IItemActions
     {
-        void UseItem(short itemId);
+        void UseItem(int itemId);
 
-        void EquipItem(short itemId, bool alternateLocation);
+        void EquipItem(int itemId, bool alternateLocation);
 
-        void UnequipItem(short itemId, bool alternateLocation);
+        void UnequipItem(int itemId, bool alternateLocation);
 
-        void DropItem(short itemId, int amount, MapCoordinate dropPoint);
+        void DropItem(int itemId, int amount, MapCoordinate dropPoint);
 
-        void JunkItem(short itemId, int amount);
+        void JunkItem(int itemId, int amount);
     }
 }

--- a/EOLib/Domain/Jukebox/JukeboxActions.cs
+++ b/EOLib/Domain/Jukebox/JukeboxActions.cs
@@ -35,8 +35,8 @@ namespace EOLib.Domain.Jukebox
                 .MatchSome(rec =>
                 {
                     var packet = new PacketBuilder(PacketFamily.JukeBox, PacketAction.Use)
-                        .AddChar((byte)rec.DollGraphic) // todo: determine what GameServer expects; eoserv sends DollGraphic as a response in Character::PlayBard
-                        .AddChar((byte)(noteIndex + 1))
+                        .AddChar(rec.DollGraphic) // todo: determine what GameServer expects; eoserv sends DollGraphic as a response in Character::PlayBard
+                        .AddChar(noteIndex + 1)
                         .Build();
 
                     _packetSendService.SendPacket(packet);

--- a/EOLib/Domain/Login/LoginActions.cs
+++ b/EOLib/Domain/Login/LoginActions.cs
@@ -88,7 +88,7 @@ namespace EOLib.Domain.Login
             return data.Response;
         }
 
-        public async Task<short> RequestCharacterLogin(Character.Character character)
+        public async Task<int> RequestCharacterLogin(Character.Character character)
         {
             var packet = new PacketBuilder(PacketFamily.Welcome, PacketAction.Request)
                 .AddInt(character.ID)
@@ -139,10 +139,10 @@ namespace EOLib.Domain.Login
             return data.SessionID;
         }
 
-        public async Task<CharacterLoginReply> CompleteCharacterLogin(short sessionID)
+        public async Task<CharacterLoginReply> CompleteCharacterLogin(int sessionID)
         {
             var packet = new PacketBuilder(PacketFamily.Welcome, PacketAction.Message)
-                .AddThree((ushort)sessionID)
+                .AddThree(sessionID)
                 .AddInt(_characterRepository.MainCharacter.ID)
                 .Build();
 
@@ -211,8 +211,8 @@ namespace EOLib.Domain.Login
 
         Task<LoginReply> LoginToServer(ILoginParameters parameters);
 
-        Task<short> RequestCharacterLogin(Character.Character character);
+        Task<int> RequestCharacterLogin(Character.Character character);
 
-        Task<CharacterLoginReply> CompleteCharacterLogin(short sessionID);
+        Task<CharacterLoginReply> CompleteCharacterLogin(int sessionID);
     }
 }

--- a/EOLib/Domain/Login/LoginRequestCompletedData.cs
+++ b/EOLib/Domain/Login/LoginRequestCompletedData.cs
@@ -11,9 +11,9 @@ namespace EOLib.Domain.Login
     {
         public IReadOnlyList<string> News { get; }
 
-        public byte CharacterWeight { get; }
+        public int CharacterWeight { get; }
 
-        public byte CharacterMaxWeight { get; }
+        public int CharacterMaxWeight { get; }
 
         public IReadOnlyList<InventoryItem> CharacterItemInventory { get; }
 

--- a/EOLib/Domain/Login/LoginRequestGrantedData.cs
+++ b/EOLib/Domain/Login/LoginRequestGrantedData.cs
@@ -9,36 +9,36 @@ namespace EOLib.Domain.Login
     [Record]
     public sealed partial class LoginRequestGrantedData : ITranslatedData
     {
-        public short SessionID { get; }
+        public int SessionID { get; }
         public int CharacterID { get; }
 
-        public short MapID { get; }
+        public int MapID { get; }
         public IReadOnlyList<byte> MapRID { get; }
         public int MapLen { get; }
 
         public int EifRid { get; }
-        public short EifLen { get; }
+        public int EifLen { get; }
         public int EnfRid { get; }
-        public short EnfLen { get; }
+        public int EnfLen { get; }
         public int EsfRid { get; }
-        public short EsfLen { get; }
+        public int EsfLen { get; }
         public int EcfRid { get; }
-        public short EcfLen { get; }
+        public int EcfLen { get; }
 
         public string Name { get; }
         public string Title { get; }
         public string GuildName { get; }
         public string GuildRank { get; }
-        public byte ClassID { get; }
+        public int ClassID { get; }
         public string GuildTag { get; }
         public AdminLevel AdminLevel { get; }
 
         public CharacterStats CharacterStats { get; }
 
-        public IReadOnlyDictionary<EquipLocation, short> Paperdoll { get; }
+        public IReadOnlyDictionary<EquipLocation, int> Paperdoll { get; }
 
-        public byte GuildRankNum { get; }
-        public short JailMap { get; }
+        public int GuildRankNum { get; }
+        public int JailMap { get; }
         public bool FirstTimePlayer { get; }
     }
 }

--- a/EOLib/Domain/Login/PlayerInfoRepository.cs
+++ b/EOLib/Domain/Login/PlayerInfoRepository.cs
@@ -8,7 +8,7 @@ namespace EOLib.Domain.Login
 
         string PlayerPassword { get; set; }
 
-        short PlayerID { get; set; }
+        int PlayerID { get; set; }
 
         bool IsFirstTimePlayer { get; set; }
 
@@ -21,7 +21,7 @@ namespace EOLib.Domain.Login
 
         string PlayerPassword { get; }
 
-        short PlayerID { get; }
+        int PlayerID { get; }
 
         bool IsFirstTimePlayer { get; }
 
@@ -35,7 +35,7 @@ namespace EOLib.Domain.Login
 
         public string PlayerPassword { get; set; }
 
-        public short PlayerID { get; set; }
+        public int PlayerID { get; set; }
 
         public bool IsFirstTimePlayer { get; set; }
 

--- a/EOLib/Domain/Map/ChestActions.cs
+++ b/EOLib/Domain/Map/ChestActions.cs
@@ -21,8 +21,8 @@ namespace EOLib.Domain.Map
         public void AddItemToChest(InventoryItem item)
         {
             var packet = new PacketBuilder(PacketFamily.Chest, PacketAction.Add)
-                .AddChar((byte)_chestDataProvider.Location.X)
-                .AddChar((byte)_chestDataProvider.Location.Y)
+                .AddChar(_chestDataProvider.Location.X)
+                .AddChar(_chestDataProvider.Location.Y)
                 .AddShort(item.ItemID)
                 .AddThree(item.Amount)
                 .Build();
@@ -30,11 +30,11 @@ namespace EOLib.Domain.Map
             _packetSendService.SendPacket(packet);
         }
 
-        public void TakeItemFromChest(short itemId)
+        public void TakeItemFromChest(int itemId)
         {
             var packet = new PacketBuilder(PacketFamily.Chest, PacketAction.Take)
-                .AddChar((byte)_chestDataProvider.Location.X)
-                .AddChar((byte)_chestDataProvider.Location.Y)
+                .AddChar(_chestDataProvider.Location.X)
+                .AddChar(_chestDataProvider.Location.Y)
                 .AddShort(itemId)
                 .Build();
 
@@ -47,6 +47,6 @@ namespace EOLib.Domain.Map
 
         void AddItemToChest(InventoryItem item);
 
-        void TakeItemFromChest(short itemId);
+        void TakeItemFromChest(int itemId);
     }
 }

--- a/EOLib/Domain/Map/ChestItem.cs
+++ b/EOLib/Domain/Map/ChestItem.cs
@@ -5,7 +5,7 @@ namespace EOLib.Domain.Map
     [Record]
     public sealed partial class ChestItem
     {
-        public short ItemID { get; }
+        public int ItemID { get; }
 
         public int Amount { get; }
 

--- a/EOLib/Domain/Map/CurrentMapStateRepository.cs
+++ b/EOLib/Domain/Map/CurrentMapStateRepository.cs
@@ -7,11 +7,11 @@ namespace EOLib.Domain.Map
 {
     public interface ICurrentMapStateRepository
     {
-        short CurrentMapID { get; set; }
+        int CurrentMapID { get; set; }
 
         bool ShowMiniMap { get; set; }
 
-        short JailMapID { get; set; }
+        int JailMapID { get; set; }
 
         bool IsJail { get; }
 
@@ -29,24 +29,24 @@ namespace EOLib.Domain.Map
 
         WarpState MapWarpState { get; set; }
 
-        Option<short> MapWarpSession { get; set; }
+        Option<int> MapWarpSession { get; set; }
 
-        Option<short> MapWarpID { get; set; }
+        Option<int> MapWarpID { get; set; }
 
         Option<DateTime> MapWarpTime { get; set; }
 
-        HashSet<short> UnknownPlayerIDs { get; set; }
+        HashSet<int> UnknownPlayerIDs { get; set; }
 
-        HashSet<byte> UnknownNPCIndexes { get; set; }
+        HashSet<int> UnknownNPCIndexes { get; set; }
     }
 
     public interface ICurrentMapStateProvider
     {
-        short CurrentMapID { get; }
+        int CurrentMapID { get; }
 
         bool ShowMiniMap { get; }
 
-        short JailMapID { get; }
+        int JailMapID { get; }
 
         bool IsJail { get; }
 
@@ -64,25 +64,25 @@ namespace EOLib.Domain.Map
 
         WarpState MapWarpState { get; }
 
-        Option<short> MapWarpSession { get; }
+        Option<int> MapWarpSession { get; }
 
-        Option<short> MapWarpID { get; }
+        Option<int> MapWarpID { get; }
 
         Option<DateTime> MapWarpTime { get; }
 
-        HashSet<short> UnknownPlayerIDs { get; }
+        HashSet<int> UnknownPlayerIDs { get; }
 
-        HashSet<byte> UnknownNPCIndexes { get; }
+        HashSet<int> UnknownNPCIndexes { get; }
     }
 
     [AutoMappedType(IsSingleton = true)]
     public class CurrentMapStateRepository : ICurrentMapStateRepository, ICurrentMapStateProvider, IResettable
     {
-        public short CurrentMapID { get; set; }
+        public int CurrentMapID { get; set; }
 
         public bool ShowMiniMap { get; set; }
 
-        public short JailMapID { get; set; }
+        public int JailMapID { get; set; }
 
         public bool IsJail => JailMapID == CurrentMapID;
 
@@ -100,15 +100,15 @@ namespace EOLib.Domain.Map
 
         public WarpState MapWarpState { get; set; }
 
-        public Option<short> MapWarpSession { get; set; }
+        public Option<int> MapWarpSession { get; set; }
 
-        public Option<short> MapWarpID { get; set; }
+        public Option<int> MapWarpID { get; set; }
 
         public Option<DateTime> MapWarpTime { get; set; }
 
-        public HashSet<short> UnknownPlayerIDs { get; set; }
+        public HashSet<int> UnknownPlayerIDs { get; set; }
 
-        public HashSet<byte> UnknownNPCIndexes { get; set; }
+        public HashSet<int> UnknownNPCIndexes { get; set; }
 
         IReadOnlyDictionary<int, Character.Character> ICurrentMapStateProvider.Characters => Characters;
 
@@ -139,12 +139,12 @@ namespace EOLib.Domain.Map
             OpenDoors = new HashSet<Warp>();
             PendingDoors = new HashSet<Warp>();
             VisibleSpikeTraps = new HashSet<MapCoordinate>();
-            UnknownPlayerIDs = new HashSet<short>();
-            UnknownNPCIndexes = new HashSet<byte>();
+            UnknownPlayerIDs = new HashSet<int>();
+            UnknownNPCIndexes = new HashSet<int>();
 
             MapWarpState = WarpState.None;
-            MapWarpSession = Option.None<short>();
-            MapWarpID = Option.None<short>();
+            MapWarpSession = Option.None<int>();
+            MapWarpID = Option.None<int>();
         }
     }
 }

--- a/EOLib/Domain/Map/LockerActions.cs
+++ b/EOLib/Domain/Map/LockerActions.cs
@@ -22,8 +22,8 @@ namespace EOLib.Domain.Map
         public void AddItemToLocker(InventoryItem item)
         {
             var packet = new PacketBuilder(PacketFamily.Locker, PacketAction.Add)
-                .AddChar((byte)_lockerDataProvider.Location.X)
-                .AddChar((byte)_lockerDataProvider.Location.Y)
+                .AddChar(_lockerDataProvider.Location.X)
+                .AddChar(_lockerDataProvider.Location.Y)
                 .AddShort(item.ItemID)
                 .AddThree(item.Amount)
                 .Build();
@@ -31,18 +31,18 @@ namespace EOLib.Domain.Map
             _packetSendService.SendPacket(packet);
         }
 
-        public void TakeItemFromLocker(short itemId)
+        public void TakeItemFromLocker(int itemId)
         {
             var packet = new PacketBuilder(PacketFamily.Locker, PacketAction.Take)
-                .AddChar((byte)_lockerDataProvider.Location.X)
-                .AddChar((byte)_lockerDataProvider.Location.Y)
+                .AddChar(_lockerDataProvider.Location.X)
+                .AddChar(_lockerDataProvider.Location.Y)
                 .AddShort(itemId)
                 .Build();
 
             _packetSendService.SendPacket(packet);
         }
 
-        public int GetNewItemAmount(short itemId, int amount)
+        public int GetNewItemAmount(int itemId, int amount)
         {
             return _lockerDataProvider.Items
                 .SingleOrNone(x => x.ItemID == itemId)
@@ -54,8 +54,8 @@ namespace EOLib.Domain.Map
     {
         void AddItemToLocker(InventoryItem item);
 
-        void TakeItemFromLocker(short itemId);
+        void TakeItemFromLocker(int itemId);
 
-        int GetNewItemAmount(short itemId, int amount);
+        int GetNewItemAmount(int itemId, int amount);
     }
 }

--- a/EOLib/Domain/Map/MapActions.cs
+++ b/EOLib/Domain/Map/MapActions.cs
@@ -55,29 +55,29 @@ namespace EOLib.Domain.Map
                 return;
 
             var packet = new PacketBuilder(PacketFamily.Door, PacketAction.Open)
-                .AddChar((byte)warp.X)
-                .AddChar((byte)warp.Y)
+                .AddChar(warp.X)
+                .AddChar(warp.Y)
                 .Build();
 
             _packetSendService.SendPacket(packet);
             _currentMapStateRepository.PendingDoors.Add(warp);
         }
 
-        public void OpenChest(byte x, byte y)
+        public void OpenChest(MapCoordinate location)
         {
             var packet = new PacketBuilder(PacketFamily.Chest, PacketAction.Open)
-                .AddChar(x)
-                .AddChar(y)
+                .AddChar(location.X)
+                .AddChar(location.Y)
                 .Build();
 
             _packetSendService.SendPacket(packet);
         }
 
-        public void OpenLocker(byte x, byte y)
+        public void OpenLocker(MapCoordinate location)
         {
             var packet = new PacketBuilder(PacketFamily.Locker, PacketAction.Open)
-                .AddChar(x)
-                .AddChar(y)
+                .AddChar(location.X)
+                .AddChar(location.Y)
                 .Build();
 
             _packetSendService.SendPacket(packet);
@@ -92,8 +92,8 @@ namespace EOLib.Domain.Map
 
         void OpenDoor(Warp warp);
 
-        void OpenChest(byte x, byte y);
+        void OpenChest(MapCoordinate location);
 
-        void OpenLocker(byte x, byte y);
+        void OpenLocker(MapCoordinate location);
     }
 }

--- a/EOLib/Domain/Map/MapItem.cs
+++ b/EOLib/Domain/Map/MapItem.cs
@@ -7,13 +7,13 @@ namespace EOLib.Domain.Map
     [Record]
     public sealed partial class MapItem
     {
-        public short UniqueID { get; }
+        public int UniqueID { get; }
 
-        public short ItemID { get; }
+        public int ItemID { get; }
 
-        public byte X { get; }
+        public int X { get; }
 
-        public byte Y { get; }
+        public int Y { get; }
 
         public int Amount { get; }
 
@@ -25,7 +25,7 @@ namespace EOLib.Domain.Map
 
         public static MapItem None => new MapItem();
 
-        public MapItem(short uid, short id, byte x, byte y, int amount)
+        public MapItem(int uid, int id, int x, int y, int amount)
         {
             UniqueID = uid;
             ItemID = id;

--- a/EOLib/Domain/Map/WarpAgreePacketData.cs
+++ b/EOLib/Domain/Map/WarpAgreePacketData.cs
@@ -7,7 +7,7 @@ namespace EOLib.Domain.Map
     [Record]
     public sealed partial class WarpAgreePacketData : ITranslatedData
     {
-        public short MapID { get; }
+        public int MapID { get; }
 
         public WarpAnimation WarpAnimation { get; }
 

--- a/EOLib/Domain/NPC/NPC.cs
+++ b/EOLib/Domain/NPC/NPC.cs
@@ -11,9 +11,9 @@ namespace EOLib.Domain.NPC
 
         public int Index { get; }
 
-        public byte X { get; }
+        public int X { get; }
 
-        public byte Y { get; }
+        public int Y { get; }
 
         public EODirection Direction { get; }
 
@@ -21,6 +21,6 @@ namespace EOLib.Domain.NPC
 
         public int ActualAttackFrame { get; }
 
-        public Option<short> OpponentID { get; }
+        public Option<int> OpponentID { get; }
     }
 }

--- a/EOLib/Domain/Notifiers/IEffectNotifier.cs
+++ b/EOLib/Domain/Notifiers/IEffectNotifier.cs
@@ -6,28 +6,28 @@ namespace EOLib.Domain.Notifiers
 {
     public interface IEffectNotifier
     {
-        void NotifyWarpLeaveEffect(short characterId, WarpAnimation anim);
+        void NotifyWarpLeaveEffect(int characterId, WarpAnimation anim);
 
-        void NotifyWarpEnterEffect(short characterId, WarpAnimation anim);
+        void NotifyWarpEnterEffect(int characterId, WarpAnimation anim);
 
-        void NotifyPotionEffect(short playerId, int effectId);
+        void NotifyPotionEffect(int playerId, int effectId);
 
-        void NotifyMapEffect(MapEffect effect, byte strength = 0);
+        void NotifyMapEffect(MapEffect effect, int strength = 0);
 
-        void NotifyEffectAtLocation(byte x, byte y, short effectId);
+        void NotifyEffectAtLocation(MapCoordinate location, int effectId);
     }
 
     [AutoMappedType]
     public class NoOpEffectNotifier : IEffectNotifier
     {
-        public void NotifyWarpLeaveEffect(short characterId, WarpAnimation anim) { }
+        public void NotifyWarpLeaveEffect(int characterId, WarpAnimation anim) { }
 
-        public void NotifyWarpEnterEffect(short characterId, WarpAnimation anim) { }
+        public void NotifyWarpEnterEffect(int characterId, WarpAnimation anim) { }
 
-        public void NotifyPotionEffect(short playerId, int effectId) { }
+        public void NotifyPotionEffect(int playerId, int effectId) { }
 
-        public void NotifyMapEffect(MapEffect effect, byte strength = 0) { }
+        public void NotifyMapEffect(MapEffect effect, int strength = 0) { }
 
-        public void NotifyEffectAtLocation(byte x, byte y, short effectId) { }
+        public void NotifyEffectAtLocation(MapCoordinate location, int effectId) { }
     }
 }

--- a/EOLib/Domain/Notifiers/IEmoteNotifier.cs
+++ b/EOLib/Domain/Notifiers/IEmoteNotifier.cs
@@ -5,7 +5,7 @@ namespace EOLib.Domain.Notifiers
 {
     public interface IEmoteNotifier
     {
-        void NotifyEmote(short playerId, Emote emote);
+        void NotifyEmote(int playerId, Emote emote);
 
         void MakeMainPlayerDrunk();
     }
@@ -13,7 +13,7 @@ namespace EOLib.Domain.Notifiers
     [AutoMappedType]
     public class NoOpEmoteNotifier : IEmoteNotifier
     {
-        public void NotifyEmote(short playerId, Emote emote) { }
+        public void NotifyEmote(int playerId, Emote emote) { }
 
         public void MakeMainPlayerDrunk() { }
     }

--- a/EOLib/Domain/Notifiers/IMainCharacterEventNotifier.cs
+++ b/EOLib/Domain/Notifiers/IMainCharacterEventNotifier.cs
@@ -9,11 +9,11 @@ namespace EOLib.Domain.Notifiers
 
         void NotifyTakeDamage(int damageTaken, int playerPercentHealth, bool isHeal);
 
-        void TakeItemFromMap(short id, int amountTaken);
+        void TakeItemFromMap(int id, int amountTaken);
 
-        void DropItem(short id, int amountDropped);
+        void DropItem(int id, int amountDropped);
 
-        void JunkItem(short id, int amountRemoved);
+        void JunkItem(int id, int amountRemoved);
     }
 
     [AutoMappedType]
@@ -23,10 +23,10 @@ namespace EOLib.Domain.Notifiers
 
         public void NotifyTakeDamage(int damageTaken, int playerPercentHealth, bool isHeal) { }
 
-        public void TakeItemFromMap(short id, int amountTaken) { }
+        public void TakeItemFromMap(int id, int amountTaken) { }
 
-        public void DropItem(short id, int amountDropped) { }
+        public void DropItem(int id, int amountDropped) { }
 
-        public void JunkItem(short id, int amountTaken) { }
+        public void JunkItem(int id, int amountTaken) { }
     }
 }

--- a/EOLib/Domain/Notifiers/INPCActionNotifier.cs
+++ b/EOLib/Domain/Notifiers/INPCActionNotifier.cs
@@ -10,11 +10,11 @@ namespace EOLib.Domain.Notifiers
 
         void StartNPCAttackAnimation(int npcIndex);
 
-        void RemoveNPCFromView(int npcIndex, int playerId, Option<short> spellId, Option<int> damage, bool showDeathAnimation);
+        void RemoveNPCFromView(int npcIndex, int playerId, Option<int> spellId, Option<int> damage, bool showDeathAnimation);
 
         void ShowNPCSpeechBubble(int npcIndex, string message);
 
-        void NPCTakeDamage(short npcIndex, int fromPlayerId, int damageToNpc, short npcPctHealth, Option<int> spellId);
+        void NPCTakeDamage(int npcIndex, int fromPlayerId, int damageToNpc, int npcPctHealth, Option<int> spellId);
 
         void NPCDropItem(MapItem item);
     }
@@ -26,11 +26,11 @@ namespace EOLib.Domain.Notifiers
 
         public void StartNPCAttackAnimation(int npcIndex) { }
 
-        public void RemoveNPCFromView(int npcIndex, int playerId, Option<short> spellId, Option<int> damage, bool showDeathAnimation) { }
+        public void RemoveNPCFromView(int npcIndex, int playerId, Option<int> spellId, Option<int> damage, bool showDeathAnimation) { }
 
         public void ShowNPCSpeechBubble(int npcIndex, string message) { }
 
-        public void NPCTakeDamage(short npcIndex, int fromPlayerId, int damageToNpc, short npcPctHealth, Option<int> spellId) { }
+        public void NPCTakeDamage(int npcIndex, int fromPlayerId, int damageToNpc, int npcPctHealth, Option<int> spellId) { }
 
         public void NPCDropItem(MapItem item) { }
     }

--- a/EOLib/Domain/Notifiers/IOtherCharacterAnimationNotifier.cs
+++ b/EOLib/Domain/Notifiers/IOtherCharacterAnimationNotifier.cs
@@ -1,4 +1,5 @@
 ﻿using AutomaticTypeMapper;
+using EOLib.Domain.Map;
 using EOLib.Domain.Spells;
 using System.Collections.Generic;
 
@@ -6,36 +7,36 @@ namespace EOLib.Domain.Notifiers
 {
     public interface IOtherCharacterAnimationNotifier
     {
-        void StartOtherCharacterWalkAnimation(int characterID, byte destinationX, byte destinationY, EODirection direction);
+        void StartOtherCharacterWalkAnimation(int characterID, MapCoordinate destination, EODirection direction);
 
         void StartOtherCharacterAttackAnimation(int characterID, int noteIndex = -1);
 
-        void NotifyStartSpellCast(short playerId, short spellId);
+        void NotifyStartSpellCast(int playerId, int spellId);
 
-        void NotifyTargetNpcSpellCast(short playerId);
+        void NotifyTargetNpcSpellCast(int playerId);
 
-        void NotifySelfSpellCast(short playerId, short spellId, int spellHp, byte percentHealth);
+        void NotifySelfSpellCast(int playerId, int spellId, int spellHp, int percentHealth);
 
-        void NotifyTargetOtherSpellCast(short sourcePlayerID, short targetPlayerID, short spellId, int recoveredHP, byte targetPercentHealth);
+        void NotifyTargetOtherSpellCast(int sourcePlayerID, int targetPlayerID, int spellId, int recoveredHP, int targetPercentHealth);
 
-        void NotifyGroupSpellCast(short playerId, short spellId, short spellHp, List<GroupSpellTarget> spellTargets);
+        void NotifyGroupSpellCast(int playerId, int spellId, int spellHp, List<GroupSpellTarget> spellTargets);
     }
 
     [AutoMappedType]
     public class NoOpOtherCharacterAnimationNotifier : IOtherCharacterAnimationNotifier
     {
-        public void StartOtherCharacterWalkAnimation(int characterID, byte destinationX, byte destinationY, EODirection direction) { }
+        public void StartOtherCharacterWalkAnimation(int characterID, MapCoordinate destination, EODirection direction) { }
 
         public void StartOtherCharacterAttackAnimation(int characterID, int noteIndex = -1) { }
 
-        public void NotifyStartSpellCast(short playerId, short spellId) { }
+        public void NotifyStartSpellCast(int playerId, int spellId) { }
 
-        public void NotifyTargetNpcSpellCast(short playerId) { }
+        public void NotifyTargetNpcSpellCast(int playerId) { }
 
-        public void NotifySelfSpellCast(short playerId, short spellId, int spellHp, byte percentHealth) { }
+        public void NotifySelfSpellCast(int playerId, int spellId, int spellHp, int percentHealth) { }
 
-        public void NotifyTargetOtherSpellCast(short sourcePlayerID, short targetPlayerID, short spellId, int recoveredHP, byte targetPercentHealth) { }
+        public void NotifyTargetOtherSpellCast(int sourcePlayerID, int targetPlayerID, int spellId, int recoveredHP, int targetPercentHealth) { }
 
-        public void NotifyGroupSpellCast(short playerId, short spellId, short spellHp, List<GroupSpellTarget> spellTargets) { }
+        public void NotifyGroupSpellCast(int playerId, int spellId, int spellHp, List<GroupSpellTarget> spellTargets) { }
     }
 }

--- a/EOLib/Domain/Notifiers/IPartyEventNotifier.cs
+++ b/EOLib/Domain/Notifiers/IPartyEventNotifier.cs
@@ -5,7 +5,7 @@ namespace EOLib.Domain.Notifiers
 {
     public interface IPartyEventNotifier
     {
-        void NotifyPartyRequest(PartyRequestType type, short playerId, string name);
+        void NotifyPartyRequest(PartyRequestType type, int playerId, string name);
 
         void NotifyPartyJoined();
 
@@ -17,7 +17,7 @@ namespace EOLib.Domain.Notifiers
     [AutoMappedType]
     public class NoOpPartyEventNotifier : IPartyEventNotifier
     {
-        public void NotifyPartyRequest(PartyRequestType type, short playerId, string name) { }
+        public void NotifyPartyRequest(PartyRequestType type, int playerId, string name) { }
 
         public void NotifyPartyJoined() { }
 

--- a/EOLib/Domain/Notifiers/ISoundNotifier.cs
+++ b/EOLib/Domain/Notifiers/ISoundNotifier.cs
@@ -1,16 +1,15 @@
 ﻿using AutomaticTypeMapper;
-using EOLib.Domain.Map;
 
 namespace EOLib.Domain.Notifiers
 {
     public interface ISoundNotifier
     {
-        void NotifySoundEffect(byte soundEffectId);
+        void NotifySoundEffect(int soundEffectId);
     }
 
     [AutoMappedType]
     public class NoOpSoundNotifier : ISoundNotifier
     {
-        public void NotifySoundEffect(byte soundEffectId) { }
+        public void NotifySoundEffect(int soundEffectId) { }
     }
 }

--- a/EOLib/Domain/Notifiers/ITradeEventNotifier.cs
+++ b/EOLib/Domain/Notifiers/ITradeEventNotifier.cs
@@ -4,7 +4,7 @@ namespace EOLib.Domain.Notifiers
 {
     public interface ITradeEventNotifier
     {
-        void NotifyTradeRequest(short playerId, string name);
+        void NotifyTradeRequest(int playerId, string name);
 
         void NotifyTradeAccepted();
 
@@ -14,7 +14,7 @@ namespace EOLib.Domain.Notifiers
     [AutoMappedType]
     public class NoopTradeEventNotifier : ITradeEventNotifier
     {
-        public void NotifyTradeRequest(short playerId, string name) { }
+        public void NotifyTradeRequest(int playerId, string name) { }
 
         public void NotifyTradeAccepted() { }
 

--- a/EOLib/Domain/Party/PartyActions.cs
+++ b/EOLib/Domain/Party/PartyActions.cs
@@ -14,20 +14,20 @@ namespace EOLib.Domain.Party
             _packetSendService = packetSendService;
         }
 
-        public void RequestParty(PartyRequestType type, short targetCharacterId)
+        public void RequestParty(PartyRequestType type, int targetCharacterId)
         {
             var packet = new PacketBuilder(PacketFamily.Party, PacketAction.Request)
-                .AddChar((byte)type)
+                .AddChar((int)type)
                 .AddShort(targetCharacterId)
                 .Build();
 
             _packetSendService.SendPacket(packet);
         }
 
-        public void AcceptParty(PartyRequestType type, short targetCharacterId)
+        public void AcceptParty(PartyRequestType type, int targetCharacterId)
         {
             var packet = new PacketBuilder(PacketFamily.Party, PacketAction.Accept)
-                .AddChar((byte)type)
+                .AddChar((int)type)
                 .AddShort(targetCharacterId)
                 .Build();
 
@@ -42,7 +42,7 @@ namespace EOLib.Domain.Party
             _packetSendService.SendPacket(packet);
         }
 
-        public void RemovePartyMember(short targetCharacterId)
+        public void RemovePartyMember(int targetCharacterId)
         {
             var packet = new PacketBuilder(PacketFamily.Party, PacketAction.Remove)
                 .AddShort(targetCharacterId)
@@ -54,12 +54,12 @@ namespace EOLib.Domain.Party
 
     public interface IPartyActions
     {
-        void RequestParty(PartyRequestType type, short targetCharacterId);
+        void RequestParty(PartyRequestType type, int targetCharacterId);
 
-        void AcceptParty(PartyRequestType type, short targetCharacterId);
+        void AcceptParty(PartyRequestType type, int targetCharacterId);
 
         void ListParty();
 
-        void RemovePartyMember(short targetCharacterId);
+        void RemovePartyMember(int targetCharacterId);
     }
 }

--- a/EOLib/Domain/Party/PartyMember.cs
+++ b/EOLib/Domain/Party/PartyMember.cs
@@ -5,13 +5,13 @@ namespace EOLib.Domain.Party
     [Record(Features.ObjectEquals | Features.Withers | Features.Builder | Features.Constructor | Features.ToString)]
     public sealed partial class PartyMember
     {
-        public short CharacterID { get; }
+        public int CharacterID { get; }
 
         public bool IsLeader { get; }
 
-        public byte Level { get; }
+        public int Level { get; }
 
-        public byte PercentHealth { get; }
+        public int PercentHealth { get; }
 
         public string Name { get; }
     }

--- a/EOLib/Domain/Protocol/InitializationOutOfDateData.cs
+++ b/EOLib/Domain/Protocol/InitializationOutOfDateData.cs
@@ -4,7 +4,7 @@ namespace EOLib.Domain.Protocol
 {
     public class InitializationOutOfDateData : IInitializationData
     {
-        private readonly byte _requiredVersionNumber;
+        private readonly int _requiredVersionNumber;
         public InitReply Response => InitReply.ClientOutOfDate;
 
         public int this[InitializationDataKey key]
@@ -17,7 +17,7 @@ namespace EOLib.Domain.Protocol
             }
         }
 
-        public InitializationOutOfDateData(byte requiredVersionNumber)
+        public InitializationOutOfDateData(int requiredVersionNumber)
         {
             _requiredVersionNumber = requiredVersionNumber;
         }

--- a/EOLib/Domain/Protocol/InitializationSuccessData.cs
+++ b/EOLib/Domain/Protocol/InitializationSuccessData.cs
@@ -8,15 +8,15 @@ namespace EOLib.Domain.Protocol
 
         public int this[InitializationDataKey key] => GetValueHelper(key);
 
-        private readonly byte _seq1, _seq2, _sendMulti, _recvMulti;
-        private readonly short _playerID;
+        private readonly int _seq1, _seq2, _sendMulti, _recvMulti;
+        private readonly int _playerID;
         private readonly int _hashResponse;
 
-        public InitializationSuccessData(byte sequence1,
-                                         byte sequence2,
-                                         byte receiveMultiple,
-                                         byte sendMultiple,
-                                         short playerID,
+        public InitializationSuccessData(int sequence1,
+                                         int sequence2,
+                                         int receiveMultiple,
+                                         int sendMultiple,
+                                         int playerID,
                                          int hashResponse)
         {
             _seq1 = sequence1;

--- a/EOLib/Domain/Protocol/PingTimeRepository.cs
+++ b/EOLib/Domain/Protocol/PingTimeRepository.cs
@@ -6,17 +6,17 @@ namespace EOLib.Domain.Protocol
 {
     public interface IPingTimeRepository
     {
-        Dictionary<short, DateTime> PingRequests { get; set; }
+        Dictionary<int, DateTime> PingRequests { get; set; }
     }
 
     [AutoMappedType(IsSingleton = true)]
     public class PingTimeRepository : IPingTimeRepository
     {
-        public Dictionary<short, DateTime> PingRequests { get; set; }
+        public Dictionary<int, DateTime> PingRequests { get; set; }
 
         public PingTimeRepository()
         {
-            PingRequests = new Dictionary<short, DateTime>();
+            PingRequests = new Dictionary<int, DateTime>();
         }
     }
 }

--- a/EOLib/Domain/Spells/GroupSpellTarget.cs
+++ b/EOLib/Domain/Spells/GroupSpellTarget.cs
@@ -5,10 +5,10 @@ namespace EOLib.Domain.Spells
     [Record]
     public sealed partial class GroupSpellTarget
     {
-        public short TargetId { get; }
+        public int TargetId { get; }
 
-        public byte PercentHealth { get; }
+        public int PercentHealth { get; }
 
-        public short TargetHp { get; }
+        public int TargetHp { get; }
     }
 }

--- a/EOLib/Domain/Trade/TradeActions.cs
+++ b/EOLib/Domain/Trade/TradeActions.cs
@@ -1,7 +1,6 @@
 ﻿using AutomaticTypeMapper;
 using EOLib.Net;
 using EOLib.Net.Communication;
-using System;
 
 namespace EOLib.Domain.Trade
 {
@@ -15,7 +14,7 @@ namespace EOLib.Domain.Trade
             _packetSendService = packetSendService;
         }
 
-        public void RequestTrade(short characterID)
+        public void RequestTrade(int characterID)
         {
             var packet = new PacketBuilder(PacketFamily.Trade, PacketAction.Request)
                 .AddChar(6)
@@ -24,7 +23,7 @@ namespace EOLib.Domain.Trade
             _packetSendService.SendPacket(packet);
         }
 
-        public void AcceptTradeRequest(short characterID)
+        public void AcceptTradeRequest(int characterID)
         {
             var packet = new PacketBuilder(PacketFamily.Trade, PacketAction.Accept)
                 .AddChar(6)
@@ -33,7 +32,7 @@ namespace EOLib.Domain.Trade
             _packetSendService.SendPacket(packet);
         }
 
-        public void RemoveItemFromOffer(short itemID)
+        public void RemoveItemFromOffer(int itemID)
         {
             var packet = new PacketBuilder(PacketFamily.Trade, PacketAction.Remove)
                 .AddShort(itemID)
@@ -41,7 +40,7 @@ namespace EOLib.Domain.Trade
             _packetSendService.SendPacket(packet);
         }
 
-        public void AddItemToOffer(short itemID, int amount)
+        public void AddItemToOffer(int itemID, int amount)
         {
             var packet = new PacketBuilder(PacketFamily.Trade, PacketAction.Add)
                 .AddShort(itemID)
@@ -53,7 +52,7 @@ namespace EOLib.Domain.Trade
         public void AgreeToTrade(bool agree)
         {
             var packet = new PacketBuilder(PacketFamily.Trade, PacketAction.Agree)
-                .AddChar((byte)(agree ? 1 : 0))
+                .AddChar(agree ? 1 : 0)
                 .Build();
             _packetSendService.SendPacket(packet);
         }
@@ -69,13 +68,13 @@ namespace EOLib.Domain.Trade
 
     public interface ITradeActions
     {
-        void RequestTrade(short characterID);
+        void RequestTrade(int characterID);
 
-        void AcceptTradeRequest(short characterID);
+        void AcceptTradeRequest(int characterID);
 
-        void RemoveItemFromOffer(short itemID);
+        void RemoveItemFromOffer(int itemID);
 
-        void AddItemToOffer(short itemID, int amount);
+        void AddItemToOffer(int itemID, int amount);
 
         void AgreeToTrade(bool agree);
 

--- a/EOLib/Domain/Trade/TradeOffer.cs
+++ b/EOLib/Domain/Trade/TradeOffer.cs
@@ -9,7 +9,7 @@ namespace EOLib.Domain.Trade
     {
         public bool Agrees { get; }
 
-        public short PlayerID { get; }
+        public int PlayerID { get; }
 
         public string PlayerName { get; }
 

--- a/EOLib/Net/Connection/NetworkConnectionActions.cs
+++ b/EOLib/Net/Connection/NetworkConnectionActions.cs
@@ -83,7 +83,7 @@ namespace EOLib.Net.Connection
                 .AddChar(_configurationProvider.VersionMinor)
                 .AddChar(_configurationProvider.VersionBuild)
                 .AddChar(112)
-                .AddChar((byte)hdSerialNumber.Length)
+                .AddChar(hdSerialNumber.Length)
                 .AddString(hdSerialNumber)
                 .Build();
 
@@ -96,11 +96,11 @@ namespace EOLib.Net.Connection
 
         public void CompleteHandshake(IInitializationData initializationData)
         {
-            _playerInfoRepository.PlayerID = (short)initializationData[InitializationDataKey.PlayerID];
+            _playerInfoRepository.PlayerID = initializationData[InitializationDataKey.PlayerID];
 
             var packet = new PacketBuilder(PacketFamily.Connection, PacketAction.Accept)
-                .AddShort((short)initializationData[InitializationDataKey.SendMultiple])
-                .AddShort((short)initializationData[InitializationDataKey.ReceiveMultiple])
+                .AddShort(initializationData[InitializationDataKey.SendMultiple])
+                .AddShort(initializationData[InitializationDataKey.ReceiveMultiple])
                 .AddShort(_playerInfoRepository.PlayerID)
                 .Build();
 

--- a/EOLib/Net/FileTransfer/FileRequestActions.cs
+++ b/EOLib/Net/FileTransfer/FileRequestActions.cs
@@ -46,7 +46,7 @@ namespace EOLib.Net.FileTransfer
             _playerInfoProvider = playerInfoProvider;
         }
 
-        public bool NeedsFileForLogin(InitFileType fileType, short optionalID = 0)
+        public bool NeedsFileForLogin(InitFileType fileType, int optionalID = 0)
         {
             var expectedChecksum = _numberEncoderService.DecodeNumber(_loginFileChecksumProvider.MapChecksum);
             var expectedLength = _loginFileChecksumProvider.MapLength;
@@ -56,20 +56,20 @@ namespace EOLib.Net.FileTransfer
                 : NeedPub(fileType);
         }
 
-        public bool NeedsMapForWarp(short mapID, byte[] mapRid, int fileSize)
+        public bool NeedsMapForWarp(int mapID, byte[] mapRid, int fileSize)
         {
             var expectedChecksum = _numberEncoderService.DecodeNumber(mapRid);
             return NeedMap(mapID, expectedChecksum, fileSize);
         }
 
-        public void RequestMapForWarp(short mapID, short sessionID)
+        public void RequestMapForWarp(int mapID, int sessionID)
         {
             _fileRequestService.RequestMapFileForWarp(mapID, sessionID);
             _currentMapStateRepository.MapWarpSession = Option.Some(sessionID);
             _currentMapStateRepository.MapWarpID = Option.Some(mapID);
         }
 
-        public async Task GetMapFromServer(short mapID, short sessionID)
+        public async Task GetMapFromServer(int mapID, int sessionID)
         {
             var mapFile = await _fileRequestService.RequestMapFile(mapID, sessionID);
             _mapFileSaveService.SaveFileToDefaultDirectory(mapFile, rewriteChecksum: false);
@@ -80,35 +80,35 @@ namespace EOLib.Net.FileTransfer
                 _mapFileRepository.MapFiles.Add(mapID, mapFile);
         }
 
-        public async Task GetItemFileFromServer(short sessionID)
+        public async Task GetItemFileFromServer(int sessionID)
         {
             var itemFile = await _fileRequestService.RequestFile<EIFRecord>(InitFileType.Item, sessionID);
             _pubFileSaveService.SaveFile(PubFileNameConstants.PathToEIFFile, itemFile, rewriteChecksum: false);
             _pubFileRepository.EIFFile = (EIFFile)itemFile;
         }
 
-        public async Task GetNPCFileFromServer(short sessionID)
+        public async Task GetNPCFileFromServer(int sessionID)
         {
             var npcFile = await _fileRequestService.RequestFile<ENFRecord>(InitFileType.Npc, sessionID);
             _pubFileSaveService.SaveFile(PubFileNameConstants.PathToENFFile, npcFile, rewriteChecksum: false);
             _pubFileRepository.ENFFile = (ENFFile)npcFile;
         }
 
-        public async Task GetSpellFileFromServer(short sessionID)
+        public async Task GetSpellFileFromServer(int sessionID)
         {
             var spellFile = await _fileRequestService.RequestFile<ESFRecord>(InitFileType.Spell, sessionID);
             _pubFileSaveService.SaveFile(PubFileNameConstants.PathToESFFile, spellFile, rewriteChecksum: false);
             _pubFileRepository.ESFFile = (ESFFile)spellFile;
         }
 
-        public async Task GetClassFileFromServer(short sessionID)
+        public async Task GetClassFileFromServer(int sessionID)
         {
             var classFile = await _fileRequestService.RequestFile<ECFRecord>(InitFileType.Class, sessionID);
             _pubFileSaveService.SaveFile(PubFileNameConstants.PathToECFFile, classFile, rewriteChecksum: false);
             _pubFileRepository.ECFFile = (ECFFile)classFile;
         }
 
-        private bool NeedMap(short mapID, int expectedChecksum, int expectedLength)
+        private bool NeedMap(int mapID, int expectedChecksum, int expectedLength)
         {
             if (!_mapFileRepository.MapFiles.ContainsKey(mapID))
                 return true; //map with that ID is not in the cache, need to get it from the server
@@ -147,20 +147,20 @@ namespace EOLib.Net.FileTransfer
 
     public interface IFileRequestActions
     {
-        bool NeedsFileForLogin(InitFileType fileType, short optionalID = 0);
+        bool NeedsFileForLogin(InitFileType fileType, int optionalID = 0);
 
-        bool NeedsMapForWarp(short mapID, byte[] mapRid, int fileSize);
+        bool NeedsMapForWarp(int mapID, byte[] mapRid, int fileSize);
 
-        void RequestMapForWarp(short mapID, short sessionID);
+        void RequestMapForWarp(int mapID, int sessionID);
 
-        Task GetMapFromServer(short mapID, short sessionID);
+        Task GetMapFromServer(int mapID, int sessionID);
 
-        Task GetItemFileFromServer(short sessionID);
+        Task GetItemFileFromServer(int sessionID);
 
-        Task GetNPCFileFromServer(short sessionID);
+        Task GetNPCFileFromServer(int sessionID);
 
-        Task GetSpellFileFromServer(short sessionID);
+        Task GetSpellFileFromServer(int sessionID);
 
-        Task GetClassFileFromServer(short sessionID);
+        Task GetClassFileFromServer(int sessionID);
     }
 }

--- a/EOLib/Net/FileTransfer/FileRequestService.cs
+++ b/EOLib/Net/FileTransfer/FileRequestService.cs
@@ -26,10 +26,10 @@ namespace EOLib.Net.FileTransfer
             _pubFileDeserializer = pubFileDeserializer;
         }
 
-        public async Task<IMapFile> RequestMapFile(short mapID, short sessionID)
+        public async Task<IMapFile> RequestMapFile(int mapID, int sessionID)
         {
             var request = new PacketBuilder(PacketFamily.Welcome, PacketAction.Agree)
-                .AddChar((byte)InitFileType.Map)
+                .AddChar((int)InitFileType.Map)
                 .AddShort(sessionID)
                 .AddShort(mapID)
                 .Build();
@@ -37,7 +37,7 @@ namespace EOLib.Net.FileTransfer
             return await GetMapFile(request, mapID);
         }
 
-        public void RequestMapFileForWarp(short mapID, short sessionID)
+        public void RequestMapFileForWarp(int mapID, int sessionID)
         {
             var request = new PacketBuilder(PacketFamily.Warp, PacketAction.Take)
                 .AddShort(mapID)
@@ -47,11 +47,11 @@ namespace EOLib.Net.FileTransfer
             _packetSendService.SendPacket(request);
         }
 
-        public async Task<IPubFile<TRecord>> RequestFile<TRecord>(InitFileType fileType, short sessionID)
+        public async Task<IPubFile<TRecord>> RequestFile<TRecord>(InitFileType fileType, int sessionID)
             where TRecord : class, IPubRecord, new()
         {
             var request = new PacketBuilder(PacketFamily.Welcome, PacketAction.Agree)
-                .AddChar((byte)fileType)
+                .AddChar((int)fileType)
                 .AddShort(sessionID)
                 .AddChar(1) // file id (for chunking oversize pub files)
                 .Build();
@@ -110,11 +110,11 @@ namespace EOLib.Net.FileTransfer
 
     public interface IFileRequestService
     {
-        Task<IMapFile> RequestMapFile(short mapID, short sessionID);
+        Task<IMapFile> RequestMapFile(int mapID, int sessionID);
 
-        void RequestMapFileForWarp(short mapID, short sessionID);
+        void RequestMapFileForWarp(int mapID, int sessionID);
 
-        Task<IPubFile<TRecord>> RequestFile<TRecord>(InitFileType fileType, short sessionID)
+        Task<IPubFile<TRecord>> RequestFile<TRecord>(InitFileType fileType, int sessionID)
             where TRecord : class, IPubRecord, new();
     }
 }

--- a/EOLib/Net/FileTransfer/LoginFileChecksumRepository.cs
+++ b/EOLib/Net/FileTransfer/LoginFileChecksumRepository.cs
@@ -15,13 +15,13 @@ namespace EOLib.Net.FileTransfer
 
         int ECFChecksum { get; set; }
 
-        short EIFLength { get; set; }
+        int EIFLength { get; set; }
 
-        short ENFLength { get; set; }
+        int ENFLength { get; set; }
 
-        short ESFLength { get; set; }
+        int ESFLength { get; set; }
 
-        short ECFLength { get; set; }
+        int ECFLength { get; set; }
 
         byte[] MapChecksum { get; set; }
 
@@ -41,13 +41,13 @@ namespace EOLib.Net.FileTransfer
 
         int ECFChecksum { get; }
 
-        short EIFLength { get; }
+        int EIFLength { get; }
 
-        short ENFLength { get; }
+        int ENFLength { get; }
 
-        short ESFLength { get; }
+        int ESFLength { get; }
 
-        short ECFLength { get; }
+        int ECFLength { get; }
 
         byte[] MapChecksum { get; }
 
@@ -68,13 +68,13 @@ namespace EOLib.Net.FileTransfer
 
         public int ECFChecksum { get; set; }
 
-        public short EIFLength { get; set; }
+        public int EIFLength { get; set; }
 
-        public short ENFLength { get; set; }
+        public int ENFLength { get; set; }
 
-        public short ESFLength { get; set; }
+        public int ESFLength { get; set; }
 
-        public short ECFLength { get; set; }
+        public int ECFLength { get; set; }
 
         public byte[] MapChecksum { get; set; }
 

--- a/EOLib/Net/IPacket.cs
+++ b/EOLib/Net/IPacket.cs
@@ -19,9 +19,9 @@ namespace EOLib.Net
 
         byte PeekByte();
 
-        byte PeekChar();
+        int PeekChar();
 
-        short PeekShort();
+        int PeekShort();
 
         int PeekThree();
 
@@ -37,9 +37,9 @@ namespace EOLib.Net
 
         byte ReadByte();
 
-        byte ReadChar();
+        int ReadChar();
 
-        short ReadShort();
+        int ReadShort();
 
         int ReadThree();
 

--- a/EOLib/Net/IPacketBuilder.cs
+++ b/EOLib/Net/IPacketBuilder.cs
@@ -18,9 +18,9 @@ namespace EOLib.Net
 
         IPacketBuilder AddByte(byte b);
 
-        IPacketBuilder AddChar(byte b);
+        IPacketBuilder AddChar(int b);
 
-        IPacketBuilder AddShort(short s);
+        IPacketBuilder AddShort(int s);
 
         IPacketBuilder AddThree(int t);
 

--- a/EOLib/Net/Packet.cs
+++ b/EOLib/Net/Packet.cs
@@ -58,18 +58,18 @@ namespace EOLib.Net
             return RawData[ReadPosition];
         }
 
-        public byte PeekChar()
+        public int PeekChar()
         {
             ThrowIfOutOfBounds(0);
-            return (byte) _encoderService.DecodeNumber(RawData[ReadPosition]);
+            return _encoderService.DecodeNumber(RawData[ReadPosition]);
         }
 
-        public short PeekShort()
+        public int PeekShort()
         {
             ThrowIfOutOfBounds(1);
 
             var bytes = new[] {RawData[ReadPosition], RawData[ReadPosition + 1]};
-            return (short) _encoderService.DecodeNumber(bytes);
+            return _encoderService.DecodeNumber(bytes);
         }
 
         public int PeekThree()
@@ -140,14 +140,14 @@ namespace EOLib.Net
             return ret;
         }
 
-        public byte ReadChar()
+        public int ReadChar()
         {
             var ret = PeekChar();
             ReadPosition += 1;
             return ret;
         }
 
-        public short ReadShort()
+        public int ReadShort()
         {
             var ret = PeekShort();
             ReadPosition += 2;

--- a/EOLib/Net/PacketBuilder.cs
+++ b/EOLib/Net/PacketBuilder.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using EOLib.IO;
 using EOLib.IO.Services;
 
 namespace EOLib.Net
@@ -60,23 +62,27 @@ namespace EOLib.Net
             return AddBytes(new[] { b });
         }
 
-        public IPacketBuilder AddChar(byte b)
+        public IPacketBuilder AddChar(int b)
         {
+            ThrowIfOutOfBounds(b, NumericConstants.ONE_BYTE_MAX);
             return AddBytes(_encoderService.EncodeNumber(b, 1));
         }
 
-        public IPacketBuilder AddShort(short s)
+        public IPacketBuilder AddShort(int s)
         {
-            return AddBytes(_encoderService.EncodeNumber((ushort)s, 2));
+            ThrowIfOutOfBounds(s, NumericConstants.TWO_BYTE_MAX);
+            return AddBytes(_encoderService.EncodeNumber(s, 2));
         }
 
         public IPacketBuilder AddThree(int t)
         {
+            ThrowIfOutOfBounds(t, NumericConstants.THREE_BYTE_MAX);
             return AddBytes(_encoderService.EncodeNumber(t, 3));
         }
 
         public IPacketBuilder AddInt(int i)
         {
+            ThrowIfOutOfBounds(i, NumericConstants.FOUR_BYTE_MAX);
             return AddBytes(_encoderService.EncodeNumber(i, 4));
         }
 
@@ -103,6 +109,14 @@ namespace EOLib.Net
         public IPacket Build()
         {
             return new Packet(_data.ToList());
+        }
+
+        private static void ThrowIfOutOfBounds(int input, uint maximum)
+        {
+            if ((uint)input > maximum)
+            {
+                throw new ArgumentException($"Input value is out of bounds (value={input}, bounds={maximum})", nameof(input));
+            }
         }
     }
 }

--- a/EOLib/Net/PacketProcessing/PacketEncoderRepository.cs
+++ b/EOLib/Net/PacketProcessing/PacketEncoderRepository.cs
@@ -5,13 +5,13 @@ namespace EOLib.Net.PacketProcessing
     [AutoMappedType(IsSingleton = true)]
     public class PacketEncoderRepository : IPacketEncoderRepository
     {
-        public byte ReceiveMultiplier { get; set; }
-        public byte SendMultiplier { get; set; }
+        public int ReceiveMultiplier { get; set; }
+        public int SendMultiplier { get; set; }
     }
 
     public interface IPacketEncoderRepository
     {
-        byte ReceiveMultiplier { get; set; }
-        byte SendMultiplier { get; set; }
+        int ReceiveMultiplier { get; set; }
+        int SendMultiplier { get; set; }
     }
 }

--- a/EOLib/Net/PacketProcessing/PacketEncoderService.cs
+++ b/EOLib/Net/PacketProcessing/PacketEncoderService.cs
@@ -37,7 +37,7 @@ namespace EOLib.Net.PacketProcessing
             return new Packet(byteList.ToList());
         }
 
-        public byte[] Encode(IPacket original, byte encodeMultiplier)
+        public byte[] Encode(IPacket original, int encodeMultiplier)
         {
             if (encodeMultiplier == 0 || !PacketValidForEncode(original))
                 return original.RawData.ToArray();
@@ -50,7 +50,7 @@ namespace EOLib.Net.PacketProcessing
             return byteList.ToArray();
         }
 
-        public IPacket Decode(IEnumerable<byte> original, byte decodeMultiplier)
+        public IPacket Decode(IEnumerable<byte> original, int decodeMultiplier)
         {
             var originalBytes = original.ToArray();
             if (decodeMultiplier == 0 || !PacketValidForDecode(originalBytes))
@@ -126,8 +126,8 @@ namespace EOLib.Net.PacketProcessing
 
         IPacket AddSequenceNumber(IPacket pkt, int sequenceNumber);
 
-        byte[] Encode(IPacket original, byte encodeMultiplier);
+        byte[] Encode(IPacket original, int encodeMultiplier);
 
-        IPacket Decode(IEnumerable<byte> original, byte decodeMultiplier);
+        IPacket Decode(IEnumerable<byte> original, int decodeMultiplier);
     }
 }

--- a/EOLib/Net/PacketProcessing/PacketProcessActions.cs
+++ b/EOLib/Net/PacketProcessing/PacketProcessActions.cs
@@ -40,7 +40,7 @@ namespace EOLib.Net.PacketProcessing
             _sequenceRepository.SequenceStart = updatedSequence;
         }
 
-        public void SetEncodeMultiples(byte emulti_d, byte emulti_e)
+        public void SetEncodeMultiples(int emulti_d, int emulti_e)
         {
             _encoderRepository.ReceiveMultiplier = emulti_d;
             _encoderRepository.SendMultiplier = emulti_e;
@@ -86,7 +86,7 @@ namespace EOLib.Net.PacketProcessing
 
         void SetUpdatedBaseSequenceNumber(int seq1, int seq2);
 
-        void SetEncodeMultiples(byte emulti_d, byte emulti_e);
+        void SetEncodeMultiples(int emulti_d, int emulti_e);
 
         byte[] EncodePacket(IPacket pkt);
 

--- a/EOLib/Net/Translators/LoginRequestGrantedPacketTranslator.cs
+++ b/EOLib/Net/Translators/LoginRequestGrantedPacketTranslator.cs
@@ -94,7 +94,7 @@ namespace EOLib.Net.Translators
                 .WithNewStat(CharacterStat.Constituion, dispCon)
                 .WithNewStat(CharacterStat.Charisma, dispCha);
 
-            var paperDoll = new Dictionary<EquipLocation, short>();
+            var paperDoll = new Dictionary<EquipLocation, int>();
             for (var equipLocation = (EquipLocation)0; equipLocation < EquipLocation.PAPERDOLL_MAX; ++equipLocation)
             {
                 paperDoll[equipLocation] = packet.ReadShort();

--- a/EOLib/PacketHandlers/Commands/PingResponseHandler.cs
+++ b/EOLib/PacketHandlers/Commands/PingResponseHandler.cs
@@ -38,7 +38,7 @@ namespace EOLib.PacketHandlers.Commands
         public override bool HandlePacket(IPacket packet)
         {
             var now = DateTime.Now;
-            short requestID = packet.ReadShort();
+            var requestID = packet.ReadShort();
             if (!_pingTimeRepository.PingRequests.ContainsKey(requestID))
                 return true;
 

--- a/EOLib/PacketHandlers/Effects/EffectAgreeHandler.cs
+++ b/EOLib/PacketHandlers/Effects/EffectAgreeHandler.cs
@@ -1,5 +1,6 @@
 ﻿using AutomaticTypeMapper;
 using EOLib.Domain.Login;
+using EOLib.Domain.Map;
 using EOLib.Domain.Notifiers;
 using EOLib.Net;
 using EOLib.Net.Handlers;
@@ -29,7 +30,7 @@ namespace EOLib.PacketHandlers.Effects
             var effectId = packet.ReadShort();
 
             foreach (var notifier in _effectNotifiers)
-                notifier.NotifyEffectAtLocation(x, y, effectId);
+                notifier.NotifyEffectAtLocation(new MapCoordinate(x, y), effectId);
 
             return true;
         }

--- a/EOLib/PacketHandlers/Init/MapWarpFileDownloadHandler.cs
+++ b/EOLib/PacketHandlers/Init/MapWarpFileDownloadHandler.cs
@@ -1,7 +1,5 @@
 ﻿using AutomaticTypeMapper;
-using EOLib.Domain.Character;
 using EOLib.Domain.Map;
-using EOLib.Domain.Notifiers;
 using EOLib.Domain.Protocol;
 using EOLib.IO.Map;
 using EOLib.IO.Repositories;
@@ -9,7 +7,6 @@ using EOLib.IO.Services;
 using EOLib.IO.Services.Serializers;
 using EOLib.Net;
 using EOLib.Net.Communication;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace EOLib.PacketHandlers.Init
@@ -64,7 +61,7 @@ namespace EOLib.PacketHandlers.Init
             return true;
         }
 
-        private void SendWarpAcceptToServer(short mapID, short sessionID)
+        private void SendWarpAcceptToServer(int mapID, int sessionID)
         {
             var response = new PacketBuilder(PacketFamily.Warp, PacketAction.Accept)
                 .AddShort(mapID)

--- a/EOLib/PacketHandlers/Items/ItemReplyHandler.cs
+++ b/EOLib/PacketHandlers/Items/ItemReplyHandler.cs
@@ -77,7 +77,7 @@ namespace EOLib.PacketHandlers.Items
                     var tp = packet.ReadShort();
 
                     stats = stats.WithNewStat(CharacterStat.HP, hp).WithNewStat(CharacterStat.TP, tp);
-                    var percentHealth = (int)Math.Round(100.0 * (double)stats[CharacterStat.HP] / stats[CharacterStat.MaxHP]);
+                    var percentHealth = (int)Math.Round(100.0 * stats[CharacterStat.HP] / stats[CharacterStat.MaxHP]);
 
                     foreach (var notifier in _mainCharacterEventNotifiers)
                         notifier.NotifyTakeDamage(hpGain, percentHealth, isHeal: true);
@@ -96,7 +96,7 @@ namespace EOLib.PacketHandlers.Items
                     var potionId = packet.ReadShort();
 
                     foreach (var notifier in _effectNotifiers)
-                        notifier.NotifyPotionEffect((short)character.ID, potionId);
+                        notifier.NotifyPotionEffect(character.ID, potionId);
 
                     break;
                 case ItemType.CureCurse:
@@ -173,7 +173,7 @@ namespace EOLib.PacketHandlers.Items
                     {
                         foreach (var notifier in _emoteNotifiers)
                         {
-                            notifier.NotifyEmote((short)_characterRepository.MainCharacter.ID, Domain.Character.Emote.LevelUp);
+                            notifier.NotifyEmote(_characterRepository.MainCharacter.ID, Domain.Character.Emote.LevelUp);
                         }
 
                         stats = stats.WithNewStat(CharacterStat.Level, levelUpLevel);

--- a/EOLib/PacketHandlers/NPC/NPCAcceptHandler.cs
+++ b/EOLib/PacketHandlers/NPC/NPCAcceptHandler.cs
@@ -56,7 +56,7 @@ namespace EOLib.PacketHandlers.NPC
             _characterRepository.MainCharacter = _characterRepository.MainCharacter.WithStats(stats);
 
             foreach (var notifier in _emoteNotifiers)
-                notifier.NotifyEmote((short)_characterRepository.MainCharacter.ID, Domain.Character.Emote.LevelUp);
+                notifier.NotifyEmote(_characterRepository.MainCharacter.ID, Domain.Character.Emote.LevelUp);
 
             return true;
         }

--- a/EOLib/PacketHandlers/NPC/NPCJunkHandler.cs
+++ b/EOLib/PacketHandlers/NPC/NPCJunkHandler.cs
@@ -47,7 +47,7 @@ namespace EOLib.PacketHandlers.NPC
                 {
                     notifier.RemoveNPCFromView(index,
                         _characterProvider.MainCharacter.ID,
-                        spellId: Option.None<short>(),
+                        spellId: Option.None<int>(),
                         damage: Option.None<int>(),
                         showDeathAnimation: true);
                 }

--- a/EOLib/PacketHandlers/NPC/NPCPlayerHandler.cs
+++ b/EOLib/PacketHandlers/NPC/NPCPlayerHandler.cs
@@ -131,7 +131,7 @@ namespace EOLib.PacketHandlers.NPC
                 var characterToUpdate = _characterRepository.MainCharacter;
 
                 var stats = characterToUpdate.Stats;
-                stats = stats.WithNewStat(CharacterStat.HP, (short)Math.Max(stats[CharacterStat.HP] - damageTaken, 0));
+                stats = stats.WithNewStat(CharacterStat.HP, Math.Max(stats[CharacterStat.HP] - damageTaken, 0));
 
                 var props = characterToUpdate.RenderProperties.WithIsDead(isDead);
                 _characterRepository.MainCharacter = characterToUpdate.WithStats(stats).WithRenderProperties(props);
@@ -172,7 +172,7 @@ namespace EOLib.PacketHandlers.NPC
                 notifier.ShowNPCSpeechBubble(npc.Index, message);
         }
 
-        private static DomainNPC EnsureCorrectXAndY(DomainNPC npc, byte destinationX, byte destinationY)
+        private static DomainNPC EnsureCorrectXAndY(DomainNPC npc, int destinationX, int destinationY)
         {
             var opposite = npc.Direction.Opposite();
             var tempNPC = npc
@@ -180,8 +180,8 @@ namespace EOLib.PacketHandlers.NPC
                 .WithX(destinationX)
                 .WithY(destinationY);
             return npc
-                .WithX((byte)tempNPC.GetDestinationX())
-                .WithY((byte)tempNPC.GetDestinationY());
+                .WithX(tempNPC.GetDestinationX())
+                .WithY(tempNPC.GetDestinationY());
         }
     }
 }

--- a/EOLib/PacketHandlers/NPC/NPCSpecHandler.cs
+++ b/EOLib/PacketHandlers/NPC/NPCSpecHandler.cs
@@ -107,7 +107,7 @@ namespace EOLib.PacketHandlers.NPC
             return true;
         }
 
-        private void RemoveNPCFromView(short deadNPCIndex, int playerId, Option<short> spellId, Option<int> damage, bool showDeathAnimation)
+        private void RemoveNPCFromView(int deadNPCIndex, int playerId, Option<int> spellId, Option<int> damage, bool showDeathAnimation)
         {
             foreach (var notifier in _npcActionNotifiers)
                 notifier.RemoveNPCFromView(deadNPCIndex, playerId, spellId, damage, showDeathAnimation);
@@ -115,7 +115,7 @@ namespace EOLib.PacketHandlers.NPC
             _currentMapStateRepository.NPCs.RemoveWhere(npc => npc.Index == deadNPCIndex);
         }
 
-        private void UpdatePlayerDirection(short playerID, EODirection playerDirection)
+        private void UpdatePlayerDirection(int playerID, EODirection playerDirection)
         {
             if (playerID == _characterRepository.MainCharacter.ID)
             {
@@ -145,12 +145,12 @@ namespace EOLib.PacketHandlers.NPC
             _characterRepository.MainCharacter = _characterRepository.MainCharacter.WithStats(stats);
         }
 
-        private void ShowDroppedItem(short playerID, short droppedItemUID, short droppedItemID, byte x, byte y, int droppedAmount)
+        private void ShowDroppedItem(int playerID, int droppedItemUID, int droppedItemID, int x, int y, int droppedAmount)
         {
             var mapItem = new MapItem(droppedItemUID, droppedItemID, x, y, droppedAmount)
                 .WithIsNPCDrop(true)
                 .WithDropTime(Option.Some(DateTime.Now))
-                .WithOwningPlayerID(Option.Some<int>(playerID));
+                .WithOwningPlayerID(Option.Some(playerID));
 
             _currentMapStateRepository.MapItems.RemoveWhere(item => item.UniqueID == droppedItemUID);
             _currentMapStateRepository.MapItems.Add(mapItem);

--- a/EOLib/PacketHandlers/NPC/NPCTakeDamageHandler.cs
+++ b/EOLib/PacketHandlers/NPC/NPCTakeDamageHandler.cs
@@ -90,7 +90,7 @@ namespace EOLib.PacketHandlers.NPC
             }
             catch (InvalidOperationException)
             {
-                _currentMapStateRepository.UnknownNPCIndexes.Add((byte)npcIndex);
+                _currentMapStateRepository.UnknownNPCIndexes.Add(npcIndex);
                 return true;
             }
 

--- a/EOLib/PacketHandlers/Paperdoll/ItemEquipHandler.cs
+++ b/EOLib/PacketHandlers/Paperdoll/ItemEquipHandler.cs
@@ -64,7 +64,7 @@ namespace EOLib.PacketHandlers.Paperdoll
                 var paperdollSlot = itemRec.GetEquipLocation() + subLoc;
 
                 var paperdollEquipData = paperdollData.Paperdoll.ToDictionary(k => k.Key, v => v.Value);
-                paperdollEquipData[paperdollSlot] = itemUnequipped ? (short)0 : itemId;
+                paperdollEquipData[paperdollSlot] = itemUnequipped ? 0 : itemId;
 
                 _paperdollRepository.VisibleCharacterPaperdolls[playerId] = paperdollData.WithPaperdoll(paperdollEquipData);
             }

--- a/EOLib/PacketHandlers/Paperdoll/PaperdollReplyHandler.cs
+++ b/EOLib/PacketHandlers/Paperdoll/PaperdollReplyHandler.cs
@@ -44,7 +44,7 @@ namespace EOLib.PacketHandlers.Paperdoll
             if (packet.ReadChar() != 0)
                 return false;
 
-            var paperdoll = new Dictionary<EquipLocation, short>((int)EquipLocation.PAPERDOLL_MAX);
+            var paperdoll = new Dictionary<EquipLocation, int>((int)EquipLocation.PAPERDOLL_MAX);
             for (var loc = (EquipLocation)0; loc < EquipLocation.PAPERDOLL_MAX; ++loc)
                 paperdoll[loc] = packet.ReadShort();
 

--- a/EOLib/PacketHandlers/Players/PlayersAgreeHandler.cs
+++ b/EOLib/PacketHandlers/Players/PlayersAgreeHandler.cs
@@ -56,7 +56,7 @@ namespace EOLib.PacketHandlers.Players
                 var anim = (WarpAnimation)packet.ReadChar();
 
                 foreach (var notifier in _effectNotifiers)
-                    notifier.NotifyWarpEnterEffect((short)character.ID, anim);
+                    notifier.NotifyWarpEnterEffect(character.ID, anim);
             }
 
             if (packet.ReadByte() != 255)

--- a/EOLib/PacketHandlers/Quest/QuestDialogHandler.cs
+++ b/EOLib/PacketHandlers/Quest/QuestDialogHandler.cs
@@ -53,12 +53,12 @@ namespace EOLib.PacketHandlers.Quest
                 DialogID = dialogID, // not used by eoserv
             };
 
-            var dialogTitles = new Dictionary<short, string>(numDialogs);
+            var dialogTitles = new Dictionary<int, string>(numDialogs);
             for (int i = 0; i < numDialogs; i++)
                 dialogTitles.Add(packet.ReadShort(), packet.ReadBreakString());
 
             var pages = new List<string>();
-            var links = new List<(short, string)>();
+            var links = new List<(int, string)>();
             while (packet.ReadPosition < packet.Length)
             {
                 var entryType = (DialogEntryType)packet.ReadShort();

--- a/EOLib/PacketHandlers/Recover/RecoverListHandler.cs
+++ b/EOLib/PacketHandlers/Recover/RecoverListHandler.cs
@@ -63,7 +63,7 @@ namespace EOLib.PacketHandlers.Recover
                 .WithNewStat(CharacterStat.Armor, armor);
 
             _characterRepository.MainCharacter = _characterRepository.MainCharacter
-                .WithClassID((byte)@class)
+                .WithClassID(@class)
                 .WithStats(stats);
 
             return true;

--- a/EOLib/PacketHandlers/Recover/RecoverReplyHandler.cs
+++ b/EOLib/PacketHandlers/Recover/RecoverReplyHandler.cs
@@ -44,7 +44,7 @@ namespace EOLib.PacketHandlers.Recover
             {
                 stats = stats.WithNewStat(CharacterStat.Level, level);
                 foreach (var notifier in _emoteNotifiers)
-                    notifier.NotifyEmote((short)_characterRepository.MainCharacter.ID, Domain.Character.Emote.LevelUp);
+                    notifier.NotifyEmote(_characterRepository.MainCharacter.ID, Domain.Character.Emote.LevelUp);
             }
 
             if (packet.ReadPosition < packet.Length)

--- a/EOLib/PacketHandlers/Spell/SpellTargetSelfHandler.cs
+++ b/EOLib/PacketHandlers/Spell/SpellTargetSelfHandler.cs
@@ -31,16 +31,16 @@ namespace EOLib.PacketHandlers.Spell
 
         public override bool HandlePacket(IPacket packet)
         {
-            short fromPlayerID = packet.ReadShort();
-            short spellID = packet.ReadShort();
-            int spellHP = packet.ReadInt();
-            byte percentHealth = packet.ReadChar();
+            var fromPlayerID = packet.ReadShort();
+            var spellID = packet.ReadShort();
+            var spellHP = packet.ReadInt();
+            var percentHealth = packet.ReadChar();
 
             if (packet.ReadPosition != packet.Length)
             {
                 //main player was source of this packet (otherwise, other player was source)
-                short characterHP = packet.ReadShort();
-                short characterTP = packet.ReadShort();
+                var characterHP = packet.ReadShort();
+                var characterTP = packet.ReadShort();
                 if (packet.ReadShort() != 1) //malformed packet! eoserv sends '1' here
                     return false;
 

--- a/EOLib/PacketHandlers/StatSkill/StatskillOpenHandler.cs
+++ b/EOLib/PacketHandlers/StatSkill/StatskillOpenHandler.cs
@@ -44,7 +44,7 @@ namespace EOLib.PacketHandlers.StatSkill
                     LevelRequirement = packet.ReadChar(),
                     ClassRequirement = packet.ReadChar(),
                     GoldRequirement = packet.ReadInt(),
-                    SkillRequirements = new List<short>
+                    SkillRequirements = new List<int>
                     {
                         packet.ReadShort(),
                         packet.ReadShort(),

--- a/EOLib/PacketHandlers/Walk/WalkPlayerHandler.cs
+++ b/EOLib/PacketHandlers/Walk/WalkPlayerHandler.cs
@@ -53,7 +53,7 @@ namespace EOLib.PacketHandlers.Walk
                 }
 
                 foreach (var notifier in _otherCharacterAnimationNotifiers)
-                    notifier.StartOtherCharacterWalkAnimation(characterID, x, y, dir);
+                    notifier.StartOtherCharacterWalkAnimation(characterID, new MapCoordinate(x, y), dir);
             }
             else
             {
@@ -63,7 +63,7 @@ namespace EOLib.PacketHandlers.Walk
             return true;
         }
 
-        private static CharacterRenderProperties EnsureCorrectXAndY(CharacterRenderProperties renderProperties, byte x, byte y)
+        private static CharacterRenderProperties EnsureCorrectXAndY(CharacterRenderProperties renderProperties, int x, int y)
         {
             var opposite = renderProperties.Direction.Opposite();
             var tempRenderProperties = renderProperties

--- a/EOLib/PacketHandlers/Warp/WarpRequestHandler.cs
+++ b/EOLib/PacketHandlers/Warp/WarpRequestHandler.cs
@@ -96,7 +96,7 @@ namespace EOLib.PacketHandlers.Warp
             return true;
         }
 
-        private void SendWarpAcceptToServer(short mapID, short sessionID)
+        private void SendWarpAcceptToServer(int mapID, int sessionID)
         {
             var response = new PacketBuilder(PacketFamily.Warp, PacketAction.Accept)
                 .AddShort(mapID)

--- a/EndlessClient/Audio/AudioActions.cs
+++ b/EndlessClient/Audio/AudioActions.cs
@@ -55,7 +55,7 @@ namespace EndlessClient.Audio
                 _sfxPlayer.StopLoopingSfx();
         }
 
-        public void NotifySoundEffect(byte soundEffectId)
+        public void NotifySoundEffect(int soundEffectId)
         {
             _sfxPlayer.PlaySfx((SoundEffectID)soundEffectId);
         }

--- a/EndlessClient/Controllers/AccountController.cs
+++ b/EndlessClient/Controllers/AccountController.cs
@@ -59,11 +59,7 @@ namespace EndlessClient.Controllers
                 return;
 
             var createAccountOperation = _networkOperationFactory.CreateSafeBlockingOperation(
-                () =>
-                {
-                    short sessionID = (short)nameResult;
-                    return _accountActions.CreateAccount(createAccountParameters, sessionID);
-                },
+                () => _accountActions.CreateAccount(createAccountParameters, (int)nameResult),
                 SetInitialStateAndShowError,
                 SetInitialStateAndShowError);
             if (!await createAccountOperation.Invoke().ConfigureAwait(false))

--- a/EndlessClient/Controllers/InventoryController.cs
+++ b/EndlessClient/Controllers/InventoryController.cs
@@ -126,7 +126,7 @@ namespace EndlessClient.Controllers
                         {
                             if (e.Result == XNADialogResult.OK)
                             {
-                                _itemActions.UseItem((short)record.ID);
+                                _itemActions.UseItem(record.ID);
                             }
                         };
                         msgBox.ShowDialog();
@@ -149,7 +149,7 @@ namespace EndlessClient.Controllers
 
             if (useItem)
             {
-                _itemActions.UseItem((short)record.ID);
+                _itemActions.UseItem(record.ID);
 
                 if (record.Type == ItemType.Beer)
                 {
@@ -184,7 +184,7 @@ namespace EndlessClient.Controllers
                         EOResourceID.STATUS_LABEL_ITEM_EQUIP_CAN_ONLY_BE_USED_BY, detail);
                     break;
                 case ItemEquipResult.Ok:
-                    _itemActions.EquipItem((short)itemData.ID, isAlternateEquipLocation);
+                    _itemActions.EquipItem(itemData.ID, isAlternateEquipLocation);
                     break;
             }
         }

--- a/EndlessClient/Controllers/MainButtonController.cs
+++ b/EndlessClient/Controllers/MainButtonController.cs
@@ -128,8 +128,7 @@ namespace EndlessClient.Controllers
 
                 _packetProcessActions.SetInitialSequenceNumber(initData[InitializationDataKey.SequenceByte1],
                     initData[InitializationDataKey.SequenceByte2]);
-                _packetProcessActions.SetEncodeMultiples((byte) initData[InitializationDataKey.ReceiveMultiple],
-                    (byte) initData[InitializationDataKey.SendMultiple]);
+                _packetProcessActions.SetEncodeMultiples(initData[InitializationDataKey.ReceiveMultiple], initData[InitializationDataKey.SendMultiple]);
 
                 _networkConnectionActions.CompleteHandshake(initData);
                 return true;

--- a/EndlessClient/Controllers/MapInteractionController.cs
+++ b/EndlessClient/Controllers/MapInteractionController.cs
@@ -146,7 +146,7 @@ namespace EndlessClient.Controllers
                         case TileSpec.Chest:
                             if (unwalkableAction == UnwalkableTileAction.Chest)
                             {
-                                _mapActions.OpenChest((byte)cellState.Coordinate.X, (byte)cellState.Coordinate.Y);
+                                _mapActions.OpenChest(cellState.Coordinate);
                                 _inGameDialogActions.ShowChestDialog();
 
                                 _userInputRepository.ClickHandled = true;
@@ -155,7 +155,7 @@ namespace EndlessClient.Controllers
                         case TileSpec.BankVault:
                             if (unwalkableAction == UnwalkableTileAction.Locker)
                             {
-                                _mapActions.OpenLocker((byte)cellState.Coordinate.X, (byte)cellState.Coordinate.Y);
+                                _mapActions.OpenLocker(cellState.Coordinate);
                                 _inGameDialogActions.ShowLockerDialog();
 
                                 _userInputRepository.ClickHandled = true;

--- a/EndlessClient/Dialogs/Actions/NpcInteractionActions.cs
+++ b/EndlessClient/Dialogs/Actions/NpcInteractionActions.cs
@@ -42,12 +42,12 @@ namespace EndlessClient.Dialogs.Actions
             }
         }
 
-        public void NotifySkillLearnSuccess(short spellId, int characterGold)
+        public void NotifySkillLearnSuccess(int spellId, int characterGold)
         {
             _sfxPlayer.PlaySfx(SoundEffectID.LearnNewSpell);
         }
 
-        public void NotifySkillLearnFail(SkillmasterReply skillmasterReply, short classId)
+        public void NotifySkillLearnFail(SkillmasterReply skillmasterReply, int classId)
         {
             switch (skillmasterReply)
             {

--- a/EndlessClient/Dialogs/Actions/PartyDialogActions.cs
+++ b/EndlessClient/Dialogs/Actions/PartyDialogActions.cs
@@ -39,7 +39,7 @@ namespace EndlessClient.Dialogs.Actions
             _configurationProvider = configurationProvider;
         }
 
-        public void NotifyPartyRequest(PartyRequestType type, short playerId, string name)
+        public void NotifyPartyRequest(PartyRequestType type, int playerId, string name)
         {
             if (!_configurationProvider.Interaction)
                 return;

--- a/EndlessClient/Dialogs/Actions/TradeDialogActions.cs
+++ b/EndlessClient/Dialogs/Actions/TradeDialogActions.cs
@@ -41,7 +41,7 @@ namespace EndlessClient.Dialogs.Actions
             _configurationProvider = configurationProvider;
         }
 
-        public void NotifyTradeRequest(short playerId, string name)
+        public void NotifyTradeRequest(int playerId, string name)
         {
             if (!_configurationProvider.Interaction)
                 return;

--- a/EndlessClient/Dialogs/CreateCharacterDialog.cs
+++ b/EndlessClient/Dialogs/CreateCharacterDialog.cs
@@ -33,10 +33,10 @@ namespace EndlessClient.Dialogs
         public string Name => _inputBox.Text.Trim();
 
         private CharacterRenderProperties RenderProperties => _characterControl.RenderProperties;
-        public byte Gender => RenderProperties.Gender;
-        public byte HairStyle => RenderProperties.HairStyle;
-        public byte HairColor => RenderProperties.HairColor;
-        public byte Race => RenderProperties.Race;
+        public int Gender => RenderProperties.Gender;
+        public int HairStyle => RenderProperties.HairStyle;
+        public int HairColor => RenderProperties.HairColor;
+        public int Race => RenderProperties.Race;
 
         public CreateCharacterDialog(
             INativeGraphicsManager nativeGraphicsManager,

--- a/EndlessClient/Dialogs/PaperdollDialogItem.cs
+++ b/EndlessClient/Dialogs/PaperdollDialogItem.cs
@@ -24,7 +24,7 @@ namespace EndlessClient.Dialogs
 
         public EquipLocation EquipLocation { get; }
 
-        public short ItemID => (short)_itemInfo.Match(r => r.ID, () => 0);
+        public int ItemID => _itemInfo.Match(r => r.ID, () => 0);
 
         public event EventHandler<EIFRecord> RightClick;
 

--- a/EndlessClient/Dialogs/QuestDialog.cs
+++ b/EndlessClient/Dialogs/QuestDialog.cs
@@ -141,7 +141,7 @@ namespace EndlessClient.Dialogs
                     PrimaryText = action.DisplayText
                 };
 
-                var linkIndex = (byte)action.ActionID;
+                var linkIndex = action.ActionID;
                 actionItem.SetPrimaryClickAction((_, _) =>
                 {
                     _questActions.RespondToQuestDialog(DialogReply.Link, linkIndex);

--- a/EndlessClient/Dialogs/ShopDialog.cs
+++ b/EndlessClient/Dialogs/ShopDialog.cs
@@ -335,9 +335,9 @@ namespace EndlessClient.Dialogs
                         return;
 
                     if (buying)
-                        _shopActions.BuyItem((short)shopItem.ID, amount);
+                        _shopActions.BuyItem(shopItem.ID, amount);
                     else
-                        _shopActions.SellItem((short)shopItem.ID, amount);
+                        _shopActions.SellItem(shopItem.ID, amount);
                 };
                 dlg.ShowDialog();
             }
@@ -388,7 +388,7 @@ namespace EndlessClient.Dialogs
                 if (e.Result == XNADialogResult.Cancel)
                     return;
 
-                _shopActions.CraftItem((short)craftItem.ID);
+                _shopActions.CraftItem(craftItem.ID);
             };
             dlg2.ShowDialog();
 

--- a/EndlessClient/Dialogs/TradeDialog.cs
+++ b/EndlessClient/Dialogs/TradeDialog.cs
@@ -260,7 +260,7 @@ namespace EndlessClient.Dialogs
                     };
 
                     if (actualOffer.PlayerID == _characterProvider.MainCharacter.ID)
-                        newListItem.RightClick += (_, _) => _tradeActions.RemoveItemFromOffer((short)itemRec.ID);
+                        newListItem.RightClick += (_, _) => _tradeActions.RemoveItemFromOffer(itemRec.ID);
 
                     newListItem.SetParentControl(this);
                     listItems.Add(newListItem);

--- a/EndlessClient/Input/UnwalkableTileActionsHandler.cs
+++ b/EndlessClient/Input/UnwalkableTileActionsHandler.cs
@@ -29,11 +29,11 @@ namespace EndlessClient.Input
                 switch (action)
                 {
                     case UnwalkableTileAction.Chest:
-                        _mapActions.OpenChest((byte)cellState.Coordinate.X, (byte)cellState.Coordinate.Y);
+                        _mapActions.OpenChest(cellState.Coordinate);
                         _inGameDialogActions.ShowChestDialog();
                         break;
                     case UnwalkableTileAction.Locker:
-                        _mapActions.OpenLocker((byte)cellState.Coordinate.X, (byte)cellState.Coordinate.Y);
+                        _mapActions.OpenLocker(cellState.Coordinate);
                         _inGameDialogActions.ShowLockerDialog();
                         break;
                     case UnwalkableTileAction.Chair: _characterActions.SitInChair(); break;

--- a/EndlessClient/Network/UnknownEntitiesRequester.cs
+++ b/EndlessClient/Network/UnknownEntitiesRequester.cs
@@ -82,7 +82,7 @@ namespace EndlessClient.Network
         private IPacket CreateRequestForNPCs()
         {
             IPacketBuilder builder = new PacketBuilder(PacketFamily.NPCMapInfo, PacketAction.Request)
-                .AddChar((byte)_currentMapStateRepository.UnknownNPCIndexes.Count)
+                .AddChar(_currentMapStateRepository.UnknownNPCIndexes.Count)
                 .AddByte(0xFF);
 
             foreach (var index in _currentMapStateRepository.UnknownNPCIndexes)

--- a/EndlessClient/Rendering/Character/CharacterAnimationActions.cs
+++ b/EndlessClient/Rendering/Character/CharacterAnimationActions.cs
@@ -120,12 +120,12 @@ namespace EndlessClient.Rendering.Character
             Animator.Emote(_characterRepository.MainCharacter.ID, whichEmote);
         }
 
-        public void StartOtherCharacterWalkAnimation(int characterID, byte destinationX, byte destinationY, EODirection direction)
+        public void StartOtherCharacterWalkAnimation(int characterID, MapCoordinate destination, EODirection direction)
         {
             if (!_hudControlProvider.IsInGame || !_currentMapStateProvider.Characters.ContainsKey(characterID))
                 return;
 
-            Animator.StartOtherCharacterWalkAnimation(characterID, destinationX, destinationY, direction);
+            Animator.StartOtherCharacterWalkAnimation(characterID, destination, direction);
             
             ShowWaterSplashiesIfNeeded(CharacterActionState.Walking, characterID);
             _spikeTrapActions.HideSpikeTrap(characterID);
@@ -147,13 +147,13 @@ namespace EndlessClient.Rendering.Character
             ShowWaterSplashiesIfNeeded(CharacterActionState.Attacking, characterID);
         }
 
-        public void NotifyWarpLeaveEffect(short characterId, WarpAnimation anim)
+        public void NotifyWarpLeaveEffect(int characterId, WarpAnimation anim)
         {
             if (anim == WarpAnimation.Admin)
                 _characterRendererProvider.CharacterRenderers[characterId].PlayEffect((int)HardCodedEffect.WarpLeave);
         }
 
-        public void NotifyWarpEnterEffect(short characterId, WarpAnimation anim)
+        public void NotifyWarpEnterEffect(int characterId, WarpAnimation anim)
         {
             if (anim == WarpAnimation.Admin)
             {
@@ -164,7 +164,7 @@ namespace EndlessClient.Rendering.Character
             }
         }
 
-        public void NotifyPotionEffect(short playerId, int effectId)
+        public void NotifyPotionEffect(int playerId, int effectId)
         {
             if (playerId == _characterRepository.MainCharacter.ID)
                 _characterRendererProvider.MainCharacterRenderer.MatchSome(cr => cr.PlayEffect(effectId + 1));
@@ -172,13 +172,13 @@ namespace EndlessClient.Rendering.Character
                 _characterRendererProvider.CharacterRenderers[playerId].PlayEffect(effectId + 1);
         }
 
-        public void NotifyStartSpellCast(short playerId, short spellId)
+        public void NotifyStartSpellCast(int playerId, int spellId)
         {
             var shoutName = _pubFileProvider.ESFFile[spellId].Shout;
             _characterRendererProvider.CharacterRenderers[playerId].ShoutSpellPrep(shoutName.ToLower());
         }
 
-        public void NotifyTargetNpcSpellCast(short playerId)
+        public void NotifyTargetNpcSpellCast(int playerId)
         {
             // Main player starts its spell cast animation immediately when targeting NPC
             // Other players need to wait for packet to be received and do it here
@@ -189,7 +189,7 @@ namespace EndlessClient.Rendering.Character
             }
         }
 
-        public void NotifySelfSpellCast(short playerId, short spellId, int spellHp, byte percentHealth)
+        public void NotifySelfSpellCast(int playerId, int spellId, int spellHp, int percentHealth)
         {
             var spellGraphic = _pubFileProvider.ESFFile[spellId].Graphic;
 
@@ -211,7 +211,7 @@ namespace EndlessClient.Rendering.Character
             }
         }
 
-        public void NotifyTargetOtherSpellCast(short sourcePlayerID, short targetPlayerID, short spellId, int recoveredHP, byte targetPercentHealth)
+        public void NotifyTargetOtherSpellCast(int sourcePlayerID, int targetPlayerID, int spellId, int recoveredHP, int targetPercentHealth)
         {
             if (sourcePlayerID == _characterRepository.MainCharacter.ID)
             {
@@ -240,7 +240,7 @@ namespace EndlessClient.Rendering.Character
             }
         }
 
-        public void NotifyGroupSpellCast(short playerId, short spellId, short spellHp, List<GroupSpellTarget> spellTargets)
+        public void NotifyGroupSpellCast(int playerId, int spellId, int spellHp, List<GroupSpellTarget> spellTargets)
         {
             if (playerId == _characterRepository.MainCharacter.ID)
             {
@@ -276,7 +276,7 @@ namespace EndlessClient.Rendering.Character
             }
         }
 
-        public void NotifyMapEffect(MapEffect effect, byte strength = 0)
+        public void NotifyMapEffect(MapEffect effect, int strength = 0)
         {
             switch (effect)
             {
@@ -300,7 +300,7 @@ namespace EndlessClient.Rendering.Character
             }
         }
 
-        public void NotifyEmote(short playerId, Emote emote)
+        public void NotifyEmote(int playerId, Emote emote)
         {
             switch (emote)
             {
@@ -327,12 +327,12 @@ namespace EndlessClient.Rendering.Character
             _statusLabelSetter.SetStatusLabel(EOResourceID.STATUS_LABEL_TYPE_WARNING, EOResourceID.STATUS_LABEL_ITEM_USE_DRUNK);
         }
 
-        public void NotifyEffectAtLocation(byte x, byte y, short effectId)
+        public void NotifyEffectAtLocation(MapCoordinate location, int effectId)
         {
             if (_hudControlProvider.IsInGame)
             {
                 _hudControlProvider.GetComponent<IMapRenderer>(HudControlIdentifier.MapRenderer)
-                    .RenderEffect(x, y, effectId);
+                    .RenderEffect(location, effectId);
             }
         }
 

--- a/EndlessClient/Rendering/Character/CharacterAnimator.cs
+++ b/EndlessClient/Rendering/Character/CharacterAnimator.cs
@@ -198,13 +198,13 @@ namespace EndlessClient.Rendering.Character
             _spellSlotDataRepository.SpellIsPrepared = false;
         }
 
-        public void StartOtherCharacterWalkAnimation(int characterID, byte destinationX, byte destinationY, EODirection direction)
+        public void StartOtherCharacterWalkAnimation(int characterID, MapCoordinate destination, EODirection direction)
         {
             if (_otherPlayerStartWalkingTimes.ContainsKey(characterID))
             {
                 _otherPlayerStartWalkingTimes[characterID].Replay = true;
                 _queuedDirections[characterID] = direction;
-                _queuedPositions[characterID] = new MapCoordinate(destinationX, destinationY);
+                _queuedPositions[characterID] = destination;
                 return;
             }
 
@@ -261,7 +261,7 @@ namespace EndlessClient.Rendering.Character
             }
             else
             {
-                _currentMapStateRepository.UnknownPlayerIDs.Add((short)characterID);
+                _currentMapStateRepository.UnknownPlayerIDs.Add(characterID);
             }
 
             _startEmoteTimes[characterID] = startEmoteTime;
@@ -606,7 +606,7 @@ namespace EndlessClient.Rendering.Character
 
         void MainCharacterCancelSpellPrep();
 
-        void StartOtherCharacterWalkAnimation(int characterID, byte targetX, byte targetY, EODirection direction);
+        void StartOtherCharacterWalkAnimation(int characterID, MapCoordinate destination, EODirection direction);
 
         void StartOtherCharacterAttackAnimation(int characterID, Action sfxCallback);
 

--- a/EndlessClient/Rendering/ContextMenuRenderer.cs
+++ b/EndlessClient/Rendering/ContextMenuRenderer.cs
@@ -269,7 +269,7 @@ namespace EndlessClient.Rendering
             }
 
             _lastPartyRequestTime = DateTime.Now;
-            _partyActions.RequestParty(PartyRequestType.Join, (short)_characterRenderer.Character.ID);
+            _partyActions.RequestParty(PartyRequestType.Join, _characterRenderer.Character.ID);
             _statusLabelSetter.SetStatusLabel(EOResourceID.STATUS_LABEL_TYPE_ACTION, EOResourceID.STATUS_LABEL_PARTY_REQUESTED_TO_JOIN);
         }
 
@@ -288,7 +288,7 @@ namespace EndlessClient.Rendering
             }
 
             _lastPartyRequestTime = DateTime.Now;
-            _partyActions.RequestParty(PartyRequestType.Invite, (short)_characterRenderer.Character.ID);
+            _partyActions.RequestParty(PartyRequestType.Invite, _characterRenderer.Character.ID);
             _statusLabelSetter.SetStatusLabel(EOResourceID.STATUS_LABEL_TYPE_ACTION, _characterRenderer.Character.Name, EOResourceID.STATUS_LABEL_PARTY_IS_INVITED);
         }
 
@@ -309,7 +309,7 @@ namespace EndlessClient.Rendering
 
             _lastTradeRequestedTime = DateTime.Now;
 
-            _tradeActions.RequestTrade((short)_characterRenderer.Character.ID);
+            _tradeActions.RequestTrade(_characterRenderer.Character.ID);
 
             _statusLabelSetter.SetStatusLabel(EOResourceID.STATUS_LABEL_TYPE_ACTION, EOResourceID.STATUS_LABEL_TRADE_REQUESTED_TO_TRADE);
         }

--- a/EndlessClient/Rendering/Map/IMapRenderer.cs
+++ b/EndlessClient/Rendering/Map/IMapRenderer.cs
@@ -11,11 +11,11 @@ namespace EndlessClient.Rendering.Map
 
         void StartMapTransition();
 
-        void StartEarthquake(byte strength);
+        void StartEarthquake(int strength);
 
         void RedrawGroundLayer();
 
-        void RenderEffect(byte x, byte y, short effectId);
+        void RenderEffect(MapCoordinate location, int effectId);
 
         void ClearTransientRenderables();
     }

--- a/EndlessClient/Rendering/Map/MapRenderer.cs
+++ b/EndlessClient/Rendering/Map/MapRenderer.cs
@@ -160,7 +160,7 @@ namespace EndlessClient.Rendering.Map
             _mapTransitionState = new MapTransitionState(Option.Some(DateTime.Now), 1);
         }
 
-        public void StartEarthquake(byte strength)
+        public void StartEarthquake(int strength)
         {
             _quakeState = Option.Some(new MapQuakeState(strength));
         }
@@ -171,10 +171,8 @@ namespace EndlessClient.Rendering.Map
             _mapTransitionState = new MapTransitionState(Option.Some(DateTime.Now - new TimeSpan(0, 5, 0)), 255);
         }
 
-        public void RenderEffect(byte x, byte y, short effectId)
+        public void RenderEffect(MapCoordinate coordinate, int effectId)
         {
-            var coordinate = new MapCoordinate(x, y);
-
             if (!_mapGridEffectRenderers.ContainsKey(coordinate))
             {
                 var renderer = _effectRendererFactory.Create();

--- a/EndlessClient/Rendering/NPC/NPCActions.cs
+++ b/EndlessClient/Rendering/NPC/NPCActions.cs
@@ -68,7 +68,7 @@ namespace EndlessClient.Rendering.NPC
             _sfxPlayer.PlaySfx(SoundEffectID.PunchAttack);
         }
 
-        public void RemoveNPCFromView(int npcIndex, int playerId, Option<short> spellId, Option<int> damage, bool showDeathAnimation)
+        public void RemoveNPCFromView(int npcIndex, int playerId, Option<int> spellId, Option<int> damage, bool showDeathAnimation)
         {
             //possible that the server might send a packet for the npc to be removed by the map switch is completed
             if (!_hudControlProvider.IsInGame || !_npcRendererRepository.NPCRenderers.ContainsKey(npcIndex))
@@ -101,7 +101,7 @@ namespace EndlessClient.Rendering.NPC
             _chatBubbleActions.ShowChatBubbleForNPC(npcIndex, message);
         }
 
-        public void NPCTakeDamage(short npcIndex, int fromPlayerId, int damageToNpc, short npcPctHealth, Option<int> spellId)
+        public void NPCTakeDamage(int npcIndex, int fromPlayerId, int damageToNpc, int npcPctHealth, Option<int> spellId)
         {
             if (_npcRendererRepository.NPCRenderers.ContainsKey(npcIndex))
                 _npcRendererRepository.NPCRenderers[npcIndex].ShowDamageCounter(damageToNpc, npcPctHealth, isHeal: false);

--- a/EndlessClient/Rendering/NPC/NPCAnimator.cs
+++ b/EndlessClient/Rendering/NPC/NPCAnimator.cs
@@ -123,8 +123,8 @@ namespace EndlessClient.Rendering.NPC
             if (nextFrameNPC.IsActing(NPCActionState.Standing))
             {
                 nextFrameNPC = nextFrameNPC
-                    .WithX((byte)nextFrameNPC.GetDestinationX())
-                    .WithY((byte)nextFrameNPC.GetDestinationY());
+                    .WithX(nextFrameNPC.GetDestinationX())
+                    .WithY(nextFrameNPC.GetDestinationY());
             }
 
             return nextFrameNPC;

--- a/EndlessClient/Subscribers/MainCharacterEventSubscriber.cs
+++ b/EndlessClient/Subscribers/MainCharacterEventSubscriber.cs
@@ -48,7 +48,7 @@ namespace EndlessClient.Subscribers
             _characterRendererProvider.MainCharacterRenderer.MatchSome(r => r.ShowDamageCounter(damageTaken, playerPercentHealth, isHeal));
         }
 
-        public void TakeItemFromMap(short id, int amountTaken)
+        public void TakeItemFromMap(int id, int amountTaken)
         {
             var rec = _pubFileProvider.EIFFile[id];
 
@@ -59,7 +59,7 @@ namespace EndlessClient.Subscribers
                 $" {amountTaken} {rec.Name}");
         }
 
-        public void DropItem(short id, int amountDropped)
+        public void DropItem(int id, int amountDropped)
         {
             var rec = _pubFileProvider.EIFFile[id];
 
@@ -70,7 +70,7 @@ namespace EndlessClient.Subscribers
                 $" {amountDropped} {rec.Name}");
         }
 
-        public void JunkItem(short id, int amountRemoved)
+        public void JunkItem(int id, int amountRemoved)
         {
             var rec = _pubFileProvider.EIFFile[id];
             

--- a/EndlessClient/Test/CharacterStateTest.cs
+++ b/EndlessClient/Test/CharacterStateTest.cs
@@ -51,7 +51,7 @@ namespace EndlessClient.Test
         private KeyboardState _previousState, _currentState;
 
         private bool _isBowEquipped;
-        private short _lastGraphic;
+        private int _lastGraphic;
 
         private DateTime _lastWalk, _lastAttack, _lastSpell;
 
@@ -116,7 +116,7 @@ namespace EndlessClient.Test
             var update = false;
             if (KeyPressed(Keys.D1))
             {
-                _baseProperties = _baseProperties.WithGender((byte)((_baseProperties.Gender + increment) % 2));
+                _baseProperties = _baseProperties.WithGender((_baseProperties.Gender + increment) % 2);
                 update = true;
             }
             else if (KeyPressed(Keys.D2))
@@ -125,13 +125,13 @@ namespace EndlessClient.Test
                 {
                     const int NUM_HAIR_COLORS = 10;
                     if (_baseProperties.HairColor + increment < 0) _baseProperties = _baseProperties.WithHairColor(NUM_HAIR_COLORS);
-                    _baseProperties = _baseProperties.WithHairColor((byte)((_baseProperties.HairColor + increment) % NUM_HAIR_COLORS));
+                    _baseProperties = _baseProperties.WithHairColor((_baseProperties.HairColor + increment) % NUM_HAIR_COLORS);
                 }
                 else
                 {
                     const int NUM_HAIR_STYLES = 21;
                     if (_baseProperties.HairStyle + increment < 0) _baseProperties = _baseProperties.WithHairColor(NUM_HAIR_STYLES);
-                    _baseProperties = _baseProperties.WithHairStyle((byte)((_baseProperties.HairStyle + increment) % NUM_HAIR_STYLES));
+                    _baseProperties = _baseProperties.WithHairStyle((_baseProperties.HairStyle + increment) % NUM_HAIR_STYLES);
                 }
                 update = true;
             }
@@ -173,7 +173,7 @@ namespace EndlessClient.Test
                 {
                     _lastGraphic = _baseProperties.WeaponGraphic;
                     var firstBowWeapon = EIFFile.First(x => x.Type == ItemType.Weapon && x.SubType == ItemSubType.Ranged);
-                    _baseProperties = _baseProperties.WithWeaponGraphic((short)firstBowWeapon.DollGraphic).WithIsRangedWeapon(true);
+                    _baseProperties = _baseProperties.WithWeaponGraphic(firstBowWeapon.DollGraphic).WithIsRangedWeapon(true);
                 }
                 else
                 {
@@ -271,7 +271,7 @@ namespace EndlessClient.Test
 
         private bool CtrlPressed => _previousState.IsKeyDown(Keys.LeftControl) || _previousState.IsKeyDown(Keys.RightControl);
 
-        private short GetNextItemGraphicMatching(ItemType type, short currentGraphic)
+        private int GetNextItemGraphicMatching(ItemType type, int currentGraphic)
         {
             var increment = ShiftPressed ? -1 : 1;
             var matchingItems = EIFFile.Where(x => x.Type == type).OrderBy(x => x.ID).ToList();
@@ -283,7 +283,7 @@ namespace EndlessClient.Test
                 return 0;
             }
 
-            return (short)matchingItems[_itemIndices[type]].DollGraphic;
+            return matchingItems[_itemIndices[type]].DollGraphic;
         }
 
         private IPubFile<EIFRecord> EIFFile => _eifFileProvider.EIFFile;

--- a/EndlessClient/UIControls/CreateCharacterControl.cs
+++ b/EndlessClient/UIControls/CreateCharacterControl.cs
@@ -50,22 +50,22 @@ namespace EndlessClient.UIControls
 
         public void NextGender()
         {
-            RenderProperties = RenderProperties.WithGender((byte)((RenderProperties.Gender + 1) % 2));
+            RenderProperties = RenderProperties.WithGender((RenderProperties.Gender + 1) % 2);
         }
 
         public void NextRace()
         {
-            RenderProperties = RenderProperties.WithRace((byte)((RenderProperties.Race + 1) % 6));
+            RenderProperties = RenderProperties.WithRace((RenderProperties.Race + 1) % 6);
         }
 
         public void NextHairStyle()
         {
-            RenderProperties = RenderProperties.WithHairStyle((byte)((RenderProperties.HairStyle + 1) % 21));
+            RenderProperties = RenderProperties.WithHairStyle((RenderProperties.HairStyle + 1) % 21);
         }
 
         public void NextHairColor()
         {
-            RenderProperties = RenderProperties.WithHairColor((byte)((RenderProperties.HairColor + 1) % 10));
+            RenderProperties = RenderProperties.WithHairColor((RenderProperties.HairColor + 1) % 10);
         }
 
         private static CharacterRenderProperties GetDefaultProperties()

--- a/PacketDecoder/MainForm.cs
+++ b/PacketDecoder/MainForm.cs
@@ -109,7 +109,7 @@ namespace PacketDecoder
 
             if (txt == txtDMulti)
             {
-                _packetProcessActions.SetEncodeMultiples((byte)param, _packetEncoderRepository.SendMultiplier);
+                _packetProcessActions.SetEncodeMultiples(param, _packetEncoderRepository.SendMultiplier);
                 if (param < 6 || param > 12)
                 {
                     txtDMulti.BackColor = Color.FromArgb(255, 255, 128, 128);
@@ -121,7 +121,7 @@ namespace PacketDecoder
             }
             else if (txt == txtEMulti)
             {
-                _packetProcessActions.SetEncodeMultiples(_packetEncoderRepository.ReceiveMultiplier, (byte)param);
+                _packetProcessActions.SetEncodeMultiples(_packetEncoderRepository.ReceiveMultiplier, param);
                 if (param < 6 || param > 12)
                 {
                     txtEMulti.BackColor = Color.FromArgb(255, 255, 128, 128);


### PR DESCRIPTION
Use `int` primitive in place of `short` and `byte` wherever possible. Fixes out-of-range issues for values greater than `short.MaxValue`.

Closes #149 