### PR TITLE
Map entity rendering performance enhancements and minor client bug fixes

### DIFF
--- a/EOBot/Interpreter/BuiltInIdentifierConfigurator.cs
+++ b/EOBot/Interpreter/BuiltInIdentifierConfigurator.cs
@@ -275,7 +275,7 @@ namespace EOBot.Interpreter
             var ms = DependencyMaster.TypeRegistry[_botIndex].Resolve<ICurrentMapStateProvider>();
 
             var mapStateObj = new RuntimeEvaluatedMemberObjectVariable();
-            mapStateObj.SymbolTable["characters"] = (true, () => new ArrayVariable(ms.Characters.Values.Select(GetMapStateCharacter).ToList()));
+            mapStateObj.SymbolTable["characters"] = (true, () => new ArrayVariable(ms.Characters.Select(GetMapStateCharacter).ToList()));
             mapStateObj.SymbolTable["npcs"] = (true, () => new ArrayVariable(ms.NPCs.Select(GetMapStateNPC).ToList()));
             mapStateObj.SymbolTable["items"] = (true, () => new ArrayVariable(ms.MapItems.Select(GetMapStateItem).ToList()));
 

--- a/EOBot/TrainerBot.cs
+++ b/EOBot/TrainerBot.cs
@@ -116,6 +116,7 @@ namespace EOBot
                         ConsoleHelper.WriteMessage(ConsoleHelper.Type.Chat, $"{message.Who}: {message.Message}", ConsoleColor.Cyan);
 
                     _cachedChat = _chatProvider.AllChat[ChatTab.Local].ToHashSet();
+                    Console.Beep(261, 1500);
                 }
 
                 var character = _characterRepository.MainCharacter;
@@ -129,6 +130,9 @@ namespace EOBot
                     if (cachedPlayerCount > 0)
                     {
                         ConsoleHelper.WriteMessage(ConsoleHelper.Type.Warning, $"{cachedPlayerCount,7} - Players on map - You may not be able to train here", ConsoleColor.DarkYellow);
+                        Console.Beep(220, 500);
+                        Console.Beep(247, 500);
+                        Console.Beep(220, 500);
                     }
                 }
 

--- a/EOBot/TrainerBot.cs
+++ b/EOBot/TrainerBot.cs
@@ -116,7 +116,10 @@ namespace EOBot
                         ConsoleHelper.WriteMessage(ConsoleHelper.Type.Chat, $"{message.Who}: {message.Message}", ConsoleColor.Cyan);
 
                     _cachedChat = _chatProvider.AllChat[ChatTab.Local].ToHashSet();
-                    Console.Beep(261, 1500);
+                    if (OperatingSystem.IsWindows())
+                    {
+                        Console.Beep(261, 1500);
+                    }
                 }
 
                 var character = _characterRepository.MainCharacter;
@@ -124,12 +127,13 @@ namespace EOBot
 
                 var currentPositionCellState = mapCellStateProvider.GetCellStateAt(charRenderProps.MapX, charRenderProps.MapY);
 
-                if (cachedPlayerCount != mapStateProvider.Characters.Count)
+                if (cachedPlayerCount != mapStateProvider.Characters.Count())
                 {
-                    cachedPlayerCount = mapStateProvider.Characters.Count;
-                    if (cachedPlayerCount > 0)
+                    cachedPlayerCount = mapStateProvider.Characters.Count();
+                    ConsoleHelper.WriteMessage(ConsoleHelper.Type.Warning, $"{cachedPlayerCount,7} - Players on map - You may not be able to train here", ConsoleColor.DarkYellow);
+
+                    if (OperatingSystem.IsWindows())
                     {
-                        ConsoleHelper.WriteMessage(ConsoleHelper.Type.Warning, $"{cachedPlayerCount,7} - Players on map - You may not be able to train here", ConsoleColor.DarkYellow);
                         Console.Beep(220, 500);
                         Console.Beep(247, 500);
                         Console.Beep(220, 500);

--- a/EOLib/Domain/Login/LoginActions.cs
+++ b/EOLib/Domain/Login/LoginActions.cs
@@ -185,7 +185,7 @@ namespace EOLib.Domain.Login
 
             _currentMapStateRepository.Characters = data.MapCharacters.Except(new[] { mainCharacter }).ToDictionary(k => k.ID, v => v);
             _currentMapStateRepository.NPCs = new HashSet<NPC.NPC>(data.MapNPCs);
-            _currentMapStateRepository.MapItems = new HashSet<MapItem>(data.MapItems);
+            _currentMapStateRepository.MapItems = new MapEntityCollectionHashSet<MapItem>(item => item.UniqueID, item => new MapCoordinate(item.X, item.Y), data.MapItems);
 
             _playerInfoRepository.PlayerIsInGame = true;
             _characterSessionRepository.ResetState();

--- a/EOLib/Domain/Login/LoginActions.cs
+++ b/EOLib/Domain/Login/LoginActions.cs
@@ -183,8 +183,8 @@ namespace EOLib.Domain.Login
             _characterInventoryRepository.ItemInventory = new HashSet<InventoryItem>(data.CharacterItemInventory);
             _characterInventoryRepository.SpellInventory = new HashSet<InventorySpell>(data.CharacterSpellInventory);
 
-            _currentMapStateRepository.Characters = data.MapCharacters.Except(new[] { mainCharacter }).ToDictionary(k => k.ID, v => v);
-            _currentMapStateRepository.NPCs = new HashSet<NPC.NPC>(data.MapNPCs);
+            _currentMapStateRepository.Characters = new MapEntityCollectionHashSet<Character.Character>(c => c.ID, c => new MapCoordinate(c.X, c.Y), data.MapCharacters.Except(new[] { mainCharacter }));
+            _currentMapStateRepository.NPCs = new MapEntityCollectionHashSet<NPC.NPC>(n => n.Index, n => new MapCoordinate(n.X, n.Y), data.MapNPCs);
             _currentMapStateRepository.MapItems = new MapEntityCollectionHashSet<MapItem>(item => item.UniqueID, item => new MapCoordinate(item.X, item.Y), data.MapItems);
 
             _playerInfoRepository.PlayerIsInGame = true;

--- a/EOLib/Domain/Map/CurrentMapStateRepository.cs
+++ b/EOLib/Domain/Map/CurrentMapStateRepository.cs
@@ -19,7 +19,7 @@ namespace EOLib.Domain.Map
 
         HashSet<NPC.NPC> NPCs { get; set; }
 
-        HashSet<MapItem> MapItems { get; set; }
+        MapEntityCollectionHashSet<MapItem> MapItems { get; set; }
 
         HashSet<Warp> OpenDoors { get; set;  }
 
@@ -54,7 +54,7 @@ namespace EOLib.Domain.Map
 
         IReadOnlyCollection<NPC.NPC> NPCs { get; }
 
-        IReadOnlyCollection<MapItem> MapItems { get; }
+        IReadOnlyMapEntityCollection<MapItem> MapItems { get; }
 
         IReadOnlyCollection<Warp> OpenDoors { get; }
 
@@ -90,7 +90,7 @@ namespace EOLib.Domain.Map
 
         public HashSet<NPC.NPC> NPCs { get; set; }
 
-        public HashSet<MapItem> MapItems { get; set; }
+        public MapEntityCollectionHashSet<MapItem> MapItems { get; set; }
 
         public HashSet<Warp> OpenDoors { get; set; }
 
@@ -114,7 +114,7 @@ namespace EOLib.Domain.Map
 
         IReadOnlyCollection<NPC.NPC> ICurrentMapStateProvider.NPCs => NPCs;
 
-        IReadOnlyCollection<MapItem> ICurrentMapStateProvider.MapItems => MapItems;
+        IReadOnlyMapEntityCollection<MapItem> ICurrentMapStateProvider.MapItems => MapItems;
 
         IReadOnlyCollection<Warp> ICurrentMapStateProvider.OpenDoors => OpenDoors;
 
@@ -135,7 +135,7 @@ namespace EOLib.Domain.Map
 
             Characters = new Dictionary<int, Character.Character>();
             NPCs = new HashSet<NPC.NPC>();
-            MapItems = new HashSet<MapItem>();
+            MapItems = new MapEntityCollectionHashSet<MapItem>(x => x.UniqueID, x => new MapCoordinate(x.X, x.Y));
             OpenDoors = new HashSet<Warp>();
             PendingDoors = new HashSet<Warp>();
             VisibleSpikeTraps = new HashSet<MapCoordinate>();

--- a/EOLib/Domain/Map/CurrentMapStateRepository.cs
+++ b/EOLib/Domain/Map/CurrentMapStateRepository.cs
@@ -15,9 +15,9 @@ namespace EOLib.Domain.Map
 
         bool IsJail { get; }
 
-        Dictionary<int, Character.Character> Characters { get; set; }
+        MapEntityCollectionHashSet<Character.Character> Characters { get; set; }
 
-        HashSet<NPC.NPC> NPCs { get; set; }
+        MapEntityCollectionHashSet<NPC.NPC> NPCs { get; set; }
 
         MapEntityCollectionHashSet<MapItem> MapItems { get; set; }
 
@@ -50,9 +50,9 @@ namespace EOLib.Domain.Map
 
         bool IsJail { get; }
 
-        IReadOnlyDictionary<int, Character.Character> Characters { get; }
+        IReadOnlyMapEntityCollection<Character.Character> Characters { get; }
 
-        IReadOnlyCollection<NPC.NPC> NPCs { get; }
+        IReadOnlyMapEntityCollection<NPC.NPC> NPCs { get; }
 
         IReadOnlyMapEntityCollection<MapItem> MapItems { get; }
 
@@ -86,9 +86,9 @@ namespace EOLib.Domain.Map
 
         public bool IsJail => JailMapID == CurrentMapID;
 
-        public Dictionary<int, Character.Character> Characters { get; set; }
+        public MapEntityCollectionHashSet<Character.Character> Characters { get; set; }
 
-        public HashSet<NPC.NPC> NPCs { get; set; }
+        public MapEntityCollectionHashSet<NPC.NPC> NPCs { get; set; }
 
         public MapEntityCollectionHashSet<MapItem> MapItems { get; set; }
 
@@ -110,9 +110,9 @@ namespace EOLib.Domain.Map
 
         public HashSet<int> UnknownNPCIndexes { get; set; }
 
-        IReadOnlyDictionary<int, Character.Character> ICurrentMapStateProvider.Characters => Characters;
+        IReadOnlyMapEntityCollection<Character.Character> ICurrentMapStateProvider.Characters => Characters;
 
-        IReadOnlyCollection<NPC.NPC> ICurrentMapStateProvider.NPCs => NPCs;
+        IReadOnlyMapEntityCollection<NPC.NPC> ICurrentMapStateProvider.NPCs => NPCs;
 
         IReadOnlyMapEntityCollection<MapItem> ICurrentMapStateProvider.MapItems => MapItems;
 
@@ -133,8 +133,8 @@ namespace EOLib.Domain.Map
             ShowMiniMap = false;
             JailMapID = 0;
 
-            Characters = new Dictionary<int, Character.Character>();
-            NPCs = new HashSet<NPC.NPC>();
+            Characters = new MapEntityCollectionHashSet<Character.Character>(x => x.ID, x => new MapCoordinate(x.X, x.Y));
+            NPCs = new MapEntityCollectionHashSet<NPC.NPC>(x => x.Index, x => new MapCoordinate(x.X, x.Y));
             MapItems = new MapEntityCollectionHashSet<MapItem>(x => x.UniqueID, x => new MapCoordinate(x.X, x.Y));
             OpenDoors = new HashSet<Warp>();
             PendingDoors = new HashSet<Warp>();

--- a/EOLib/Domain/Map/MapCellStateProvider.cs
+++ b/EOLib/Domain/Map/MapCellStateProvider.cs
@@ -6,6 +6,7 @@ using EOLib.IO.Map;
 using EOLib.IO.Repositories;
 using Optional;
 using Optional.Collections;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace EOLib.Domain.Map
@@ -43,7 +44,9 @@ namespace EOLib.Domain.Map
                 .Where(c => CharacterAtCoordinates(c, x, y))
                 .ToList();
             var npc = _mapStateProvider.NPCs.FirstOrNone(n => NPCAtCoordinates(n, x, y));
-            var items = _mapStateProvider.MapItems.Where(i => i.X == x && i.Y == y).OrderByDescending(i => i.UniqueID);
+            var items = _mapStateProvider.MapItems.TryGetValues(new MapCoordinate(x, y), out var mapItems)
+                ? mapItems.OrderByDescending(i => i.UniqueID)
+                : Enumerable.Empty<MapItem>();
 
             return new MapCellState
             {

--- a/EOLib/Domain/Map/MapCellStateProvider.cs
+++ b/EOLib/Domain/Map/MapCellStateProvider.cs
@@ -39,11 +39,14 @@ namespace EOLib.Domain.Map
             var chest = CurrentMap.Chests.Where(c => c.X == x && c.Y == y && c.Key != ChestKey.None).Select(c => c.Key).FirstOrDefault();
             var sign = CurrentMap.Signs.FirstOrDefault(s => s.X == x && s.Y == y);
 
-            var characters = _mapStateProvider.Characters.Values
-                .Concat(new[] { _characterProvider.MainCharacter })
-                .Where(c => CharacterAtCoordinates(c, x, y))
-                .ToList();
-            var npc = _mapStateProvider.NPCs.FirstOrNone(n => NPCAtCoordinates(n, x, y));
+            _mapStateProvider.Characters.TryGetValues(new MapCoordinate(x, y), out var characters);
+            if (_characterProvider.MainCharacter.X == x && _characterProvider.MainCharacter.Y == y)
+                characters.Add(_characterProvider.MainCharacter);
+
+            Option<NPC.NPC> npc = Option.None<NPC.NPC>();
+            if (_mapStateProvider.NPCs.TryGetValues(new MapCoordinate(x, y), out var npcs))
+                npc = npcs.FirstOrNone();
+
             var items = _mapStateProvider.MapItems.TryGetValues(new MapCoordinate(x, y), out var mapItems)
                 ? mapItems.OrderByDescending(i => i.UniqueID)
                 : Enumerable.Empty<MapItem>();
@@ -58,23 +61,9 @@ namespace EOLib.Domain.Map
                 ChestKey   = chest.SomeNotNull(),
                 Sign       = sign.SomeNotNull().Map(s => new Sign(s)),
                 Character  = characters.FirstOrNone(),
-                Characters = characters,
+                Characters = characters.ToList(),
                 NPC        = npc
             };
-        }
-
-        private static bool CharacterAtCoordinates(Character.Character character, int x, int y)
-        {
-            return character.RenderProperties.IsActing(CharacterActionState.Walking)
-                ? character.RenderProperties.GetDestinationX() == x && character.RenderProperties.GetDestinationY() == y
-                : character.RenderProperties.MapX == x && character.RenderProperties.MapY == y;
-        }
-
-        private static bool NPCAtCoordinates(NPC.NPC npc, int x, int y)
-        {
-            return npc.IsActing(NPCActionState.Walking)
-                ? npc.GetDestinationX() == x && npc.GetDestinationY() == y
-                : npc.X == x && npc.Y == y;
         }
 
         private IMapFile CurrentMap => _mapFileProvider.MapFiles[_mapStateProvider.CurrentMapID];

--- a/EOLib/Domain/Map/MapEntityCollectionHashSet.cs
+++ b/EOLib/Domain/Map/MapEntityCollectionHashSet.cs
@@ -56,9 +56,11 @@ namespace EOLib.Domain.Map
             _valueSet[hash] = value;
         }
 
-        public IEnumerator<TValue> GetEnumerator() => _valueSet.Values.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        public void Update(TValue oldValue, TValue newValue)
+        {
+            Remove(oldValue);
+            Add(newValue);
+        }
 
         public void Remove(TValue value)
         {
@@ -73,6 +75,10 @@ namespace EOLib.Domain.Map
 
             _valueSet.Remove(hash);
         }
+
+        public bool ContainsKey(int uniqueId) => _uniqueIdToHash.ContainsKey(uniqueId);
+
+        public bool ContainsKey(MapCoordinate coordinate) => _mapCoordinateToHashList.ContainsKey(coordinate);
 
         public bool TryGetValue(int uniqueId, out TValue value)
         {
@@ -92,7 +98,7 @@ namespace EOLib.Domain.Map
 
         public bool TryGetValues(MapCoordinate mapCoordinate, out HashSet<TValue> values)
         {
-            values = default;
+            values = new HashSet<TValue>();
 
             if (!_mapCoordinateToHashList.ContainsKey(mapCoordinate))
                 return false;
@@ -101,16 +107,23 @@ namespace EOLib.Domain.Map
             if (!_valueSet.Any(x => hashes.Contains(x.Key)))
                 return false;
 
-            values = new HashSet<TValue>(_mapCoordinateToHashList[mapCoordinate].Select(x => _valueSet[x]));
+            values = this[mapCoordinate];
 
             return true;
         }
+
+        public IEnumerator<TValue> GetEnumerator() => _valueSet.Values.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
     public interface IReadOnlyMapEntityCollection<TValue> : IEnumerable<TValue>
     {
         TValue this[int key1] { get; }
         HashSet<TValue> this[MapCoordinate key2] { get; }
+
+        bool ContainsKey(int characterID);
+        bool ContainsKey(MapCoordinate mapCoordinate);
 
         bool TryGetValue(int key1, out TValue value);
         bool TryGetValues(MapCoordinate key2, out HashSet<TValue> values);

--- a/EOLib/Domain/Map/MapEntityCollectionHashSet.cs
+++ b/EOLib/Domain/Map/MapEntityCollectionHashSet.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EOLib.Domain.Map
+{
+    public class MapEntityCollectionHashSet<TValue> : IReadOnlyMapEntityCollection<TValue>
+    {
+        private readonly Dictionary<int, int> _uniqueIdToHash;
+        private readonly Dictionary<MapCoordinate, HashSet<int>> _mapCoordinateToHashList;
+
+        private readonly Dictionary<int, TValue> _valueSet;
+
+        private readonly Func<TValue, int> _uniqueIdSelector;
+        private readonly Func<TValue, MapCoordinate> _mapCoordinateSelector;
+
+        public MapEntityCollectionHashSet(Func<TValue, int> uniqueIdSelector,
+                                          Func<TValue, MapCoordinate> mapCoordinateSelector)
+        {
+            _uniqueIdToHash = new Dictionary<int, int>();
+            _mapCoordinateToHashList = new Dictionary<MapCoordinate, HashSet<int>>();
+            _valueSet = new Dictionary<int, TValue>();
+
+            _uniqueIdSelector = uniqueIdSelector;
+            _mapCoordinateSelector = mapCoordinateSelector;
+        }
+
+        public MapEntityCollectionHashSet(Func<TValue, int> uniqueIdSelector,
+                                          Func<TValue, MapCoordinate> mapCoordinateSelector,
+                                          IEnumerable<TValue> values)
+            : this(uniqueIdSelector, mapCoordinateSelector)
+        {
+            foreach (var value in values)
+            {
+                Add(value);
+            }
+        }
+
+        public TValue this[int key1] => _valueSet[_uniqueIdToHash[key1]];
+
+        public HashSet<TValue> this[MapCoordinate key2] => new HashSet<TValue>(_mapCoordinateToHashList[key2].Select(x => _valueSet[x]));
+
+        public void Add(TValue value)
+        {
+            var key1 = _uniqueIdSelector.Invoke(value);
+
+            var hash = value.GetHashCode();
+            _uniqueIdToHash[key1] = hash;
+
+            var key2 = _mapCoordinateSelector.Invoke(value);
+            if (!_mapCoordinateToHashList.ContainsKey(key2))
+                _mapCoordinateToHashList.Add(key2, new HashSet<int>());
+
+            _mapCoordinateToHashList[key2].Add(hash);
+            _valueSet[hash] = value;
+        }
+
+        public IEnumerator<TValue> GetEnumerator() => _valueSet.Values.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public void Remove(TValue value)
+        {
+            var key1 = _uniqueIdSelector.Invoke(value);
+            var key2 = _mapCoordinateSelector.Invoke(value);
+            _uniqueIdToHash.Remove(key1);
+
+            var hash = value.GetHashCode();
+            _mapCoordinateToHashList[key2].Remove(hash);
+            if (_mapCoordinateToHashList[key2].Count == 0)
+                _mapCoordinateToHashList.Remove(key2);
+
+            _valueSet.Remove(hash);
+        }
+
+        public bool TryGetValue(int uniqueId, out TValue value)
+        {
+            value = default;
+
+            if (!_uniqueIdToHash.ContainsKey(uniqueId))
+                return false;
+
+            var hash = _uniqueIdToHash[uniqueId];
+            if (!_valueSet.ContainsKey(hash))
+                return false;
+
+            value = _valueSet[hash];
+
+            return true;
+        }
+
+        public bool TryGetValues(MapCoordinate mapCoordinate, out HashSet<TValue> values)
+        {
+            values = default;
+
+            if (!_mapCoordinateToHashList.ContainsKey(mapCoordinate))
+                return false;
+
+            var hashes = _mapCoordinateToHashList[mapCoordinate];
+            if (!_valueSet.Any(x => hashes.Contains(x.Key)))
+                return false;
+
+            values = new HashSet<TValue>(_mapCoordinateToHashList[mapCoordinate].Select(x => _valueSet[x]));
+
+            return true;
+        }
+    }
+
+    public interface IReadOnlyMapEntityCollection<TValue> : IEnumerable<TValue>
+    {
+        TValue this[int key1] { get; }
+        HashSet<TValue> this[MapCoordinate key2] { get; }
+
+        bool TryGetValue(int key1, out TValue value);
+        bool TryGetValues(MapCoordinate key2, out HashSet<TValue> values);
+    }
+}

--- a/EOLib/Domain/Map/MapItem.cs
+++ b/EOLib/Domain/Map/MapItem.cs
@@ -1,11 +1,12 @@
 ﻿using Amadevus.RecordGenerator;
+using EOLib.IO.Map;
 using Optional;
 using System;
 
 namespace EOLib.Domain.Map
 {
     [Record]
-    public sealed partial class MapItem
+    public sealed partial class MapItem : IMapEntity
     {
         public int UniqueID { get; }
 

--- a/EOLib/PacketHandlers/AdminInteract/AdminInteractAgree.cs
+++ b/EOLib/PacketHandlers/AdminInteract/AdminInteractAgree.cs
@@ -36,12 +36,10 @@ namespace EOLib.PacketHandlers.AdminInteract
                 _characterRepository.MainCharacter = Shown(_characterRepository.MainCharacter);
             else
             {
-                if (_currentMapStateRepository.Characters.ContainsKey(id))
+                if (_currentMapStateRepository.Characters.TryGetValue(id, out var character))
                 {
-                    var character = _currentMapStateRepository.Characters[id];
-
                     var updatedCharacter = Shown(character);
-                    _currentMapStateRepository.Characters[id] = updatedCharacter;
+                    _currentMapStateRepository.Characters.Update(character, updatedCharacter);
                 }
                 else
                 {

--- a/EOLib/PacketHandlers/AdminInteract/AdminInteractRemove.cs
+++ b/EOLib/PacketHandlers/AdminInteract/AdminInteractRemove.cs
@@ -36,12 +36,10 @@ namespace EOLib.PacketHandlers.AdminInteract
                 _characterRepository.MainCharacter = Hidden(_characterRepository.MainCharacter);
             else
             {
-                if (_currentMapStateRepository.Characters.ContainsKey(id))
+                if (_currentMapStateRepository.Characters.TryGetValue(id, out var character))
                 {
-                    var character = _currentMapStateRepository.Characters[id];
-
                     var updatedCharacter = Hidden(character);
-                    _currentMapStateRepository.Characters[id] = updatedCharacter;
+                    _currentMapStateRepository.Characters.Update(character, updatedCharacter);
                 }
                 else
                 {

--- a/EOLib/PacketHandlers/Attack/AttackPlayerHandler.cs
+++ b/EOLib/PacketHandlers/Attack/AttackPlayerHandler.cs
@@ -35,13 +35,12 @@ namespace EOLib.PacketHandlers.Attack
             var playerID = packet.ReadShort();
             var direction = (EODirection)packet.ReadChar();
 
-            if (_currentMapStateRepository.Characters.ContainsKey(playerID))
+            if (_currentMapStateRepository.Characters.TryGetValue(playerID, out var character))
             {
-                var character = _currentMapStateRepository.Characters[playerID];
                 if (character.RenderProperties.Direction != direction)
                 {
                     var renderProperties = character.RenderProperties.WithDirection(direction);
-                    _currentMapStateRepository.Characters[playerID] = character.WithRenderProperties(renderProperties);
+                    _currentMapStateRepository.Characters.Update(character, character.WithRenderProperties(renderProperties));
                 }
 
                 foreach (var notifier in _otherCharacterAnimationNotifiers)

--- a/EOLib/PacketHandlers/Avatar/AvatarAdminHandler.cs
+++ b/EOLib/PacketHandlers/Avatar/AvatarAdminHandler.cs
@@ -49,11 +49,10 @@ namespace EOLib.PacketHandlers.Avatar
                 var renderProps = _characterRepository.MainCharacter.RenderProperties.WithDirection(sourcePlayerDirection);
                 _characterRepository.MainCharacter = _characterRepository.MainCharacter.WithRenderProperties(renderProps);
             }
-            else if (_currentMapStateRepository.Characters.ContainsKey(sourcePlayerId))
+            else if (_currentMapStateRepository.Characters.TryGetValue(sourcePlayerId, out var sourceCharacter))
             {
-                var character = _currentMapStateRepository.Characters[sourcePlayerId];
-                var updatedCharacter = character.WithRenderProperties(character.RenderProperties.WithDirection(sourcePlayerDirection));
-                _currentMapStateRepository.Characters[sourcePlayerId] = updatedCharacter;
+                var updatedCharacter = sourceCharacter.WithRenderProperties(sourceCharacter.RenderProperties.WithDirection(sourcePlayerDirection));
+                _currentMapStateRepository.Characters.Update(sourceCharacter, updatedCharacter);
             }
             else
             {
@@ -72,16 +71,14 @@ namespace EOLib.PacketHandlers.Avatar
                     .WithStats(stats)
                     .WithRenderProperties(renderProps);
             }
-            else if (_currentMapStateRepository.Characters.ContainsKey(targetPlayerId))
+            else if (_currentMapStateRepository.Characters.TryGetValue(targetPlayerId, out var targetCharacter))
             {
-                var c = _currentMapStateRepository.Characters[targetPlayerId];
+                var renderProps = targetCharacter.RenderProperties.WithIsDead(targetIsDead);
 
-                var renderProps = c.RenderProperties.WithIsDead(targetIsDead);
-
-                var stats = c.Stats;
+                var stats = targetCharacter.Stats;
                 stats = stats.WithNewStat(CharacterStat.HP, stats[CharacterStat.HP] - damage);
 
-                _currentMapStateRepository.Characters[targetPlayerId] = c.WithStats(stats).WithRenderProperties(renderProps);
+                _currentMapStateRepository.Characters.Update(targetCharacter, targetCharacter.WithStats(stats).WithRenderProperties(renderProps));
             }
             else
             {

--- a/EOLib/PacketHandlers/Avatar/AvatarAgreeHandler.cs
+++ b/EOLib/PacketHandlers/Avatar/AvatarAgreeHandler.cs
@@ -43,11 +43,7 @@ namespace EOLib.PacketHandlers.Avatar
             {
                 currentCharacter = _characterRepository.MainCharacter;
             }
-            else if (_currentMapStateRepository.Characters.ContainsKey(playerID))
-            {
-                currentCharacter = _currentMapStateRepository.Characters[playerID];
-            }
-            else
+            else if (!_currentMapStateRepository.Characters.TryGetValue(playerID, out currentCharacter))
             {
                 _currentMapStateRepository.UnknownPlayerIDs.Add(playerID);
                 return true;
@@ -106,7 +102,7 @@ namespace EOLib.PacketHandlers.Avatar
             }
             else
             {
-                _currentMapStateRepository.Characters[playerID] = updatedCharacter;
+                _currentMapStateRepository.Characters.Update(currentCharacter, updatedCharacter);
             }
 
             return true;

--- a/EOLib/PacketHandlers/Avatar/AvatarRemoveHandler.cs
+++ b/EOLib/PacketHandlers/Avatar/AvatarRemoveHandler.cs
@@ -51,10 +51,9 @@ namespace EOLib.PacketHandlers.Avatar
                 _characterRepository.HasAvatar = false;
                 _currentMapStateRepository.VisibleSpikeTraps.Remove(_characterRepository.MainCharacter.RenderProperties.Coordinates());
             }
-            else if (_currentMapStateRepository.Characters.ContainsKey(id))
+            else if (_currentMapStateRepository.Characters.TryGetValue(id, out var character))
             {
-                var character = _currentMapStateRepository.Characters[id];
-                _currentMapStateRepository.Characters.Remove(id);
+                _currentMapStateRepository.Characters.Remove(character);
                 _currentMapStateRepository.VisibleSpikeTraps.Remove(character.RenderProperties.Coordinates());
             }
             else

--- a/EOLib/PacketHandlers/Chat/PlayerChatByIDHandler.cs
+++ b/EOLib/PacketHandlers/Chat/PlayerChatByIDHandler.cs
@@ -22,10 +22,10 @@ namespace EOLib.PacketHandlers.Chat
         public override bool HandlePacket(IPacket packet)
         {
             var fromPlayerID = packet.ReadShort();
-            if (!_currentMapStateProvider.Characters.ContainsKey(fromPlayerID))
+            if (!_currentMapStateProvider.Characters.TryGetValue(fromPlayerID, out var character))
                 return false;
 
-            DoTalk(packet, _currentMapStateProvider.Characters[fromPlayerID]);
+            DoTalk(packet, character);
 
             return true;
         }

--- a/EOLib/PacketHandlers/Effects/PlayerSpikeDamageHandler.cs
+++ b/EOLib/PacketHandlers/Effects/PlayerSpikeDamageHandler.cs
@@ -35,10 +35,10 @@ namespace EOLib.PacketHandlers.Effects
             var isDead = packet.ReadChar() != 0;
             var damageTaken = packet.ReadThree();
 
-            if (_currentMapStateRepository.Characters.ContainsKey(characterId))
+            if (_currentMapStateRepository.Characters.TryGetValue(characterId, out var character))
             {
-                var updatedCharacter = _currentMapStateRepository.Characters[characterId].WithDamage(damageTaken, isDead);
-                _currentMapStateRepository.Characters[characterId] = updatedCharacter;
+                var updatedCharacter = character.WithDamage(damageTaken, isDead);
+                _currentMapStateRepository.Characters.Update(character, updatedCharacter);
 
                 foreach (var notifier in _otherCharacterEventNotifiers)
                 {

--- a/EOLib/PacketHandlers/Face/FacePlayerHandler.cs
+++ b/EOLib/PacketHandlers/Face/FacePlayerHandler.cs
@@ -31,14 +31,17 @@ namespace EOLib.PacketHandlers.Face
             var direction = (EODirection)packet.ReadChar();
 
             if (!_mapStateRepository.Characters.ContainsKey(id))
-                return false;
+            {
+                _mapStateRepository.UnknownPlayerIDs.Add(id);
+                return true;
+            }
 
             var character = _mapStateRepository.Characters[id];
 
             var newRenderProps = character.RenderProperties.WithDirection(direction);
             var newCharacter = character.WithRenderProperties(newRenderProps);
 
-            _mapStateRepository.Characters[id] = newCharacter;
+            _mapStateRepository.Characters.Update(character, newCharacter);
 
             return true;
         }

--- a/EOLib/PacketHandlers/Items/ItemGetHandler.cs
+++ b/EOLib/PacketHandlers/Items/ItemGetHandler.cs
@@ -46,10 +46,10 @@ namespace EOLib.PacketHandlers.Items
             var weight = packet.ReadChar();
             var maxWeight = packet.ReadChar();
 
-            var existing = _characterInventoryRepository.ItemInventory.SingleOrNone(x => x.ItemID == id);
-            existing.MatchSome(x => _characterInventoryRepository.ItemInventory.Remove(x));
+            var existingInventoryItem = _characterInventoryRepository.ItemInventory.SingleOrNone(x => x.ItemID == id);
+            existingInventoryItem.MatchSome(x => _characterInventoryRepository.ItemInventory.Remove(x));
 
-            existing.Map(x => x.WithAmount(x.Amount + amountTaken))
+            existingInventoryItem.Map(x => x.WithAmount(x.Amount + amountTaken))
                 .Match(some: _characterInventoryRepository.ItemInventory.Add,
                        none: () => _characterInventoryRepository.ItemInventory.Add(new InventoryItem(id, amountTaken)));
 
@@ -58,7 +58,7 @@ namespace EOLib.PacketHandlers.Items
                 .WithNewStat(CharacterStat.MaxWeight, maxWeight);
             _characterRepository.MainCharacter = _characterRepository.MainCharacter.WithStats(newStats);
 
-            _mapStateRepository.MapItems.RemoveWhere(x => x.UniqueID == uid);
+            _mapStateRepository.MapItems.Remove(_mapStateRepository.MapItems[uid]);
 
             foreach (var notifier in _mainCharacterEventNotifiers)
             {

--- a/EOLib/PacketHandlers/Items/ItemGetHandler.cs
+++ b/EOLib/PacketHandlers/Items/ItemGetHandler.cs
@@ -58,7 +58,8 @@ namespace EOLib.PacketHandlers.Items
                 .WithNewStat(CharacterStat.MaxWeight, maxWeight);
             _characterRepository.MainCharacter = _characterRepository.MainCharacter.WithStats(newStats);
 
-            _mapStateRepository.MapItems.Remove(_mapStateRepository.MapItems[uid]);
+            if (_mapStateRepository.MapItems.ContainsKey(uid))
+                _mapStateRepository.MapItems.Remove(_mapStateRepository.MapItems[uid]);
 
             foreach (var notifier in _mainCharacterEventNotifiers)
             {

--- a/EOLib/PacketHandlers/Items/ItemRemoveHandler.cs
+++ b/EOLib/PacketHandlers/Items/ItemRemoveHandler.cs
@@ -28,7 +28,7 @@ namespace EOLib.PacketHandlers.Items
         public override bool HandlePacket(IPacket packet)
         {
             var uid = packet.ReadShort();
-            _currentMapStateRepository.MapItems.RemoveWhere(x => x.UniqueID == uid);
+            _currentMapStateRepository.MapItems.Remove(_currentMapStateRepository.MapItems[uid]);
             return true;
         }
     }

--- a/EOLib/PacketHandlers/Jukebox/JukeboxMessageHandler.cs
+++ b/EOLib/PacketHandlers/Jukebox/JukeboxMessageHandler.cs
@@ -34,14 +34,12 @@ namespace EOLib.PacketHandlers.Jukebox
             var instrument = packet.ReadChar();
             var note = packet.ReadChar();
 
-            if (_currentMapStateRepository.Characters.ContainsKey(playerId))
+            if (_currentMapStateRepository.Characters.TryGetValue(playerId, out var character))
             {
-                var c = _currentMapStateRepository.Characters[playerId];
-
-                if (c.RenderProperties.WeaponGraphic == instrument)
+                if (character.RenderProperties.WeaponGraphic == instrument)
                 {
-                    c = c.WithRenderProperties(c.RenderProperties.WithDirection(direction));
-                    _currentMapStateRepository.Characters[playerId] = c;
+                    var updatedCharacter = character.WithRenderProperties(character.RenderProperties.WithDirection(direction));
+                    _currentMapStateRepository.Characters.Update(character, updatedCharacter);
 
                     foreach (var notifier in _otherCharacterAnimationNotifiers)
                         notifier.StartOtherCharacterAttackAnimation(playerId, note - 1);

--- a/EOLib/PacketHandlers/MapInfo/MapInfoReplyHandler.cs
+++ b/EOLib/PacketHandlers/MapInfo/MapInfoReplyHandler.cs
@@ -45,13 +45,13 @@ namespace EOLib.PacketHandlers.MapInfo
                 for (var i = 0; i < numberOfCharacters; i++)
                 {
                     var character = _characterFromPacketFactory.CreateCharacter(packet);
-                    if (_currentMapStateRepository.Characters.ContainsKey(character.ID))
+                    if (_currentMapStateRepository.Characters.TryGetValue(character.ID, out var existingCharacter))
                     {
-                        var existingCharacter = _currentMapStateRepository.Characters[character.ID];
                         var isRangedWeapon = _eifFileProvider.EIFFile.IsRangedWeapon(character.RenderProperties.WeaponGraphic);
                         character = existingCharacter.WithAppliedData(character, isRangedWeapon);
                     }
-                    _currentMapStateRepository.Characters[character.ID] = character;
+
+                    _currentMapStateRepository.Characters.Update(existingCharacter, character);
                     if (packet.ReadByte() != byte.MaxValue)
                         throw new MalformedPacketException("Missing 255 byte after character data", packet);
                 }
@@ -60,8 +60,10 @@ namespace EOLib.PacketHandlers.MapInfo
             while (packet.ReadPosition < packet.Length)
             {
                 var npc = _npcFromPacketFactory.CreateNPC(packet);
-                _currentMapStateRepository.NPCs.RemoveWhere(n => n.Index == npc.Index);
-                _currentMapStateRepository.NPCs.Add(npc);
+                if (_currentMapStateRepository.NPCs.ContainsKey(npc.Index))
+                    _currentMapStateRepository.NPCs.Update(_currentMapStateRepository.NPCs[npc.Index], npc);
+                else
+                    _currentMapStateRepository.NPCs.Add(npc);
             }
 
             return true;

--- a/EOLib/PacketHandlers/NPC/NPCJunkHandler.cs
+++ b/EOLib/PacketHandlers/NPC/NPCJunkHandler.cs
@@ -53,7 +53,8 @@ namespace EOLib.PacketHandlers.NPC
                 }
             }
 
-            _currentMapStateRepository.NPCs.RemoveWhere(npc => npc.ID == childNpcId);
+            foreach (var npc in _currentMapStateRepository.NPCs.Where(npc => npc.ID == childNpcId))
+                _currentMapStateRepository.NPCs.Remove(npc);
 
             return true;
         }

--- a/EOLib/PacketHandlers/NPC/NPCPlayerHandler.cs
+++ b/EOLib/PacketHandlers/NPC/NPCPlayerHandler.cs
@@ -142,10 +142,10 @@ namespace EOLib.PacketHandlers.NPC
                     foreach (var notifier in _mainCharacterNotifiers)
                         notifier.NotifyTakeDamage(damageTaken, playerPercentHealth, isHeal: false);
                 }
-                else if (_currentMapStateRepository.Characters.ContainsKey(characterID))
+                else if (_currentMapStateRepository.Characters.TryGetValue(characterID, out var character))
                 {
-                    var updatedCharacter = _currentMapStateRepository.Characters[characterID].WithDamage(damageTaken, isDead);
-                    _currentMapStateRepository.Characters[characterID] = updatedCharacter;
+                    var updatedCharacter = character.WithDamage(damageTaken, isDead);
+                    _currentMapStateRepository.Characters.Update(character, updatedCharacter);
 
                     foreach (var notifier in _otherCharacterNotifiers)
                         notifier.OtherCharacterTakeDamage(characterID, playerPercentHealth, damageTaken, isHeal: false);

--- a/EOLib/PacketHandlers/NPC/NPCSpecHandler.cs
+++ b/EOLib/PacketHandlers/NPC/NPCSpecHandler.cs
@@ -8,7 +8,6 @@ using EOLib.Net.Handlers;
 using Optional;
 using System;
 using System.Collections.Generic;
-using System.Security.Cryptography;
 
 namespace EOLib.PacketHandlers.NPC
 {
@@ -113,7 +112,8 @@ namespace EOLib.PacketHandlers.NPC
             foreach (var notifier in _npcActionNotifiers)
                 notifier.RemoveNPCFromView(deadNPCIndex, playerId, spellId, damage, showDeathAnimation);
 
-            _currentMapStateRepository.NPCs.RemoveWhere(npc => npc.Index == deadNPCIndex);
+            if (_currentMapStateRepository.NPCs.TryGetValue(deadNPCIndex, out var npc))
+                _currentMapStateRepository.NPCs.Remove(npc);
         }
 
         private void UpdatePlayerDirection(int playerID, EODirection playerDirection)
@@ -127,11 +127,11 @@ namespace EOLib.PacketHandlers.NPC
 
                 _characterRepository.MainCharacter = updatedCharacter;
             }
-            else if (_currentMapStateRepository.Characters.ContainsKey(playerID))
+            else if (_currentMapStateRepository.Characters.TryGetValue(playerID, out var character))
             {
-                var updatedRenderProps = _currentMapStateRepository.Characters[playerID].RenderProperties.WithDirection(playerDirection);
-                var updatedCharacter = _currentMapStateRepository.Characters[playerID].WithRenderProperties(updatedRenderProps);
-                _currentMapStateRepository.Characters[playerID] = updatedCharacter;
+                var updatedRenderProps = character.RenderProperties.WithDirection(playerDirection);
+                var updatedCharacter = character.WithRenderProperties(updatedRenderProps);
+                _currentMapStateRepository.Characters.Update(character, updatedCharacter);
             }
             else
             {

--- a/EOLib/PacketHandlers/NPC/NPCSpecHandler.cs
+++ b/EOLib/PacketHandlers/NPC/NPCSpecHandler.cs
@@ -8,6 +8,7 @@ using EOLib.Net.Handlers;
 using Optional;
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 
 namespace EOLib.PacketHandlers.NPC
 {
@@ -152,7 +153,9 @@ namespace EOLib.PacketHandlers.NPC
                 .WithDropTime(Option.Some(DateTime.Now))
                 .WithOwningPlayerID(Option.Some(playerID));
 
-            _currentMapStateRepository.MapItems.RemoveWhere(item => item.UniqueID == droppedItemUID);
+            if (_currentMapStateRepository.MapItems.TryGetValue(droppedItemID, out var oldItem))
+                _currentMapStateRepository.MapItems.Remove(oldItem);
+
             _currentMapStateRepository.MapItems.Add(mapItem);
 
             foreach (var notifier in _npcActionNotifiers)

--- a/EOLib/PacketHandlers/NPC/NPCTakeDamageHandler.cs
+++ b/EOLib/PacketHandlers/NPC/NPCTakeDamageHandler.cs
@@ -40,7 +40,7 @@ namespace EOLib.PacketHandlers.NPC
         {
             var spellId = Family
                 .SomeWhen(x => x == PacketFamily.Cast)
-                .Map<int>(_ => packet.ReadShort());
+                .Map(_ => packet.ReadShort());
 
             var fromPlayerId = packet.ReadShort();
             var fromDirection = (EODirection)packet.ReadChar();
@@ -67,11 +67,11 @@ namespace EOLib.PacketHandlers.NPC
 
                 _characterRepository.MainCharacter = character;
             }
-            else if (_currentMapStateRepository.Characters.ContainsKey(fromPlayerId))
+            else if (_currentMapStateRepository.Characters.TryGetValue(fromPlayerId, out var character))
             {
-                var renderProps = _currentMapStateRepository.Characters[fromPlayerId].RenderProperties.WithDirection(fromDirection);
-                var updatedCharacter = _currentMapStateRepository.Characters[fromPlayerId].WithRenderProperties(renderProps);
-                _currentMapStateRepository.Characters[fromPlayerId] = updatedCharacter;
+                var renderProps = character.RenderProperties.WithDirection(fromDirection);
+                var updatedCharacter = character.WithRenderProperties(renderProps);
+                _currentMapStateRepository.Characters.Update(character, updatedCharacter);
             }
             else
             {
@@ -81,10 +81,10 @@ namespace EOLib.PacketHandlers.NPC
             // todo: this has the potential to bug out if the opponent ID is never reset and the player dies/leaves
             try
             {
-                var npc = _currentMapStateRepository.NPCs.Single(x => x.Index == npcIndex);
+                var npc = _currentMapStateRepository.NPCs[npcIndex];
                 var newNpc = npc.WithOpponentID(Option.Some(fromPlayerId));
-                _currentMapStateRepository.NPCs.Remove(npc);
-                _currentMapStateRepository.NPCs.Add(newNpc);
+                _currentMapStateRepository.NPCs.Update(npc, newNpc);
+
                 foreach (var notifier in _npcNotifiers)
                     notifier.NPCTakeDamage(npcIndex, fromPlayerId, damageToNpc, npcPctHealth, spellId);
             }

--- a/EOLib/PacketHandlers/Paperdoll/ItemEquipHandler.cs
+++ b/EOLib/PacketHandlers/Paperdoll/ItemEquipHandler.cs
@@ -71,8 +71,8 @@ namespace EOLib.PacketHandlers.Paperdoll
 
             var update = _characterRepository.MainCharacter.ID == playerId
                 ? Option.Some(_characterRepository.MainCharacter)
-                : _currentMapStateRepository.Characters.ContainsKey(playerId)
-                    ? Option.Some(_currentMapStateRepository.Characters[playerId])
+                : _currentMapStateRepository.Characters.TryGetValue(playerId, out var character)
+                    ? Option.Some(character)
                     : Option.None<Character>();
 
             update.MatchSome(c =>
@@ -108,7 +108,7 @@ namespace EOLib.PacketHandlers.Paperdoll
                 }
                 else
                 {
-                    _currentMapStateRepository.Characters[playerId] = c.WithStats(stats);
+                    _currentMapStateRepository.Characters.Update(c, c.WithStats(stats));
                 }
             });
 

--- a/EOLib/PacketHandlers/Players/PlayersAgreeHandler.cs
+++ b/EOLib/PacketHandlers/Players/PlayersAgreeHandler.cs
@@ -73,15 +73,14 @@ namespace EOLib.PacketHandlers.Players
                 _characterRepository.MainCharacter = existingCharacter.WithAppliedData(character, isRangedWeapon);
                 _characterRepository.HasAvatar = true;
             }
-            else if (_mapStateRepository.Characters.ContainsKey(character.ID))
+            else if (_mapStateRepository.Characters.TryGetValue(character.ID, out var existingCharacter))
             {
-                var existingCharacter = _mapStateRepository.Characters[character.ID];
                 var isRangedWeapon = _eifFileProvider.EIFFile.IsRangedWeapon(character.RenderProperties.WeaponGraphic);
-                _mapStateRepository.Characters[character.ID] = existingCharacter.WithAppliedData(character, isRangedWeapon);
+                _mapStateRepository.Characters.Update(existingCharacter, existingCharacter.WithAppliedData(character, isRangedWeapon));
             }
             else
             {
-                _mapStateRepository.Characters[character.ID] = character;
+                _mapStateRepository.Characters.Add(character);
             }
 
             return true;

--- a/EOLib/PacketHandlers/Refresh/RefreshReplyHandler.cs
+++ b/EOLib/PacketHandlers/Refresh/RefreshReplyHandler.cs
@@ -58,7 +58,7 @@ namespace EOLib.PacketHandlers.Refresh
 
             _currentMapStateRepository.Characters = withoutMainCharacter.ToDictionary(k => k.ID, v => v);
             _currentMapStateRepository.NPCs = new HashSet<DomainNPC>(data.NPCs);
-            _currentMapStateRepository.MapItems = new HashSet<MapItem>(data.Items);
+            _currentMapStateRepository.MapItems = new MapEntityCollectionHashSet<MapItem>(item => item.UniqueID, item => new MapCoordinate(item.X, item.Y), data.Items);
 
             _currentMapStateRepository.OpenDoors.Clear();
             _currentMapStateRepository.PendingDoors.Clear();

--- a/EOLib/PacketHandlers/Refresh/RefreshReplyHandler.cs
+++ b/EOLib/PacketHandlers/Refresh/RefreshReplyHandler.cs
@@ -46,18 +46,18 @@ namespace EOLib.PacketHandlers.Refresh
         {
             var data = _refreshReplyTranslator.TranslatePacket(packet);
 
-            var updatedMainCharacter = data.Characters.Single(IDMatches);
+            var updatedMainCharacter = data.Characters.Single(MainCharacterIDMatches);
             var updatedRenderProperties = _characterRepository.MainCharacter.RenderProperties
                 .WithMapX(updatedMainCharacter.RenderProperties.MapX)
                 .WithMapY(updatedMainCharacter.RenderProperties.MapY);
 
-            var withoutMainCharacter = data.Characters.Where(x => !IDMatches(x));
+            var withoutMainCharacter = data.Characters.Where(x => !MainCharacterIDMatches(x));
 
             _characterRepository.MainCharacter = _characterRepository.MainCharacter
                 .WithRenderProperties(updatedRenderProperties);
 
-            _currentMapStateRepository.Characters = withoutMainCharacter.ToDictionary(k => k.ID, v => v);
-            _currentMapStateRepository.NPCs = new HashSet<DomainNPC>(data.NPCs);
+            _currentMapStateRepository.Characters = new MapEntityCollectionHashSet<Character>(c => c.ID, c => new MapCoordinate(c.X, c.Y),  withoutMainCharacter);
+            _currentMapStateRepository.NPCs = new MapEntityCollectionHashSet<DomainNPC>(n => n.Index, n => new MapCoordinate(n.X, n.Y), data.NPCs);
             _currentMapStateRepository.MapItems = new MapEntityCollectionHashSet<MapItem>(item => item.UniqueID, item => new MapCoordinate(item.X, item.Y), data.Items);
 
             _currentMapStateRepository.OpenDoors.Clear();
@@ -72,7 +72,7 @@ namespace EOLib.PacketHandlers.Refresh
             return true;
         }
 
-        private bool IDMatches(Character x)
+        private bool MainCharacterIDMatches(Character x)
         {
             return x.ID == _characterRepository.MainCharacter.ID;
         }

--- a/EOLib/PacketHandlers/Sit/PlayerSitHandlerBase.cs
+++ b/EOLib/PacketHandlers/Sit/PlayerSitHandlerBase.cs
@@ -47,21 +47,19 @@ namespace EOLib.PacketHandlers.Sit
                     .WithDirection(direction);
                 _characterRepository.MainCharacter = _characterRepository.MainCharacter.WithRenderProperties(updatedRenderProperties);
             }
-            else if (_currentMapStateRepository.Characters.ContainsKey(playerId))
+            else if (_currentMapStateRepository.Characters.TryGetValue(playerId, out var oldCharacter))
             {
-                var oldCharacter = _currentMapStateRepository.Characters[playerId];
                 var renderProperties = oldCharacter.RenderProperties.WithSitState(sitState)
                     .WithCurrentAction(sitState == SitState.Standing ? CharacterActionState.Standing : CharacterActionState.Sitting)
                     .WithMapX(x)
                     .WithMapY(y)
                     .WithDirection(direction);
 
-                _currentMapStateRepository.Characters[playerId] = oldCharacter.WithRenderProperties(renderProperties);
+                _currentMapStateRepository.Characters.Update(oldCharacter, oldCharacter.WithRenderProperties(renderProperties));
             }
             else
             {
                 _currentMapStateRepository.UnknownPlayerIDs.Add(playerId);
-                return true;
             }
 
             return true;

--- a/EOLib/PacketHandlers/Sit/PlayerStandHandlerBase.cs
+++ b/EOLib/PacketHandlers/Sit/PlayerStandHandlerBase.cs
@@ -40,15 +40,14 @@ namespace EOLib.PacketHandlers.Sit
                     .WithMapY(y);
                 _characterRepository.MainCharacter = _characterRepository.MainCharacter.WithRenderProperties(updatedRenderProperties);
             }
-            else if (_currentMapStateRepository.Characters.ContainsKey(playerId))
+            else if (_currentMapStateRepository.Characters.TryGetValue(playerId, out var oldCharacter))
             {
-                var oldCharacter = _currentMapStateRepository.Characters[playerId];
                 var renderProperties = oldCharacter.RenderProperties.WithSitState(SitState.Standing)
                     .WithCurrentAction(CharacterActionState.Standing)
                     .WithMapX(x)
                     .WithMapY(y);
 
-                _currentMapStateRepository.Characters[playerId] = oldCharacter.WithRenderProperties(renderProperties);
+                _currentMapStateRepository.Characters.Update(oldCharacter, oldCharacter.WithRenderProperties(renderProperties));
             }
             else
             {

--- a/EOLib/PacketHandlers/Spell/SpellTargetOtherHandler.cs
+++ b/EOLib/PacketHandlers/Spell/SpellTargetOtherHandler.cs
@@ -47,11 +47,10 @@ namespace EOLib.PacketHandlers.Spell
                 var renderProps = _characterRepository.MainCharacter.RenderProperties.WithDirection(sourcePlayerDirection);
                 _characterRepository.MainCharacter = _characterRepository.MainCharacter.WithRenderProperties(renderProps);
             }
-            else if (_currentMapStateRepository.Characters.ContainsKey(sourcePlayerId))
+            else if (_currentMapStateRepository.Characters.TryGetValue(sourcePlayerId, out var character))
             {
-                var character = _currentMapStateRepository.Characters[sourcePlayerId];
                 var updatedCharacter = character.WithRenderProperties(character.RenderProperties.WithDirection(sourcePlayerDirection));
-                _currentMapStateRepository.Characters[sourcePlayerId] = updatedCharacter;
+                _currentMapStateRepository.Characters.Update(character, updatedCharacter);
             }
             else
             {

--- a/EOLib/PacketHandlers/Walk/WalkPlayerHandler.cs
+++ b/EOLib/PacketHandlers/Walk/WalkPlayerHandler.cs
@@ -36,20 +36,18 @@ namespace EOLib.PacketHandlers.Walk
         {
             var characterID = packet.ReadShort();
 
-            if (_currentMapStateRepository.Characters.ContainsKey(characterID))
+            if (_currentMapStateRepository.Characters.TryGetValue(characterID, out var character))
             {
                 var dir = (EODirection)packet.ReadChar();
                 var x = packet.ReadChar();
                 var y = packet.ReadChar();
-
-                var character = _currentMapStateRepository.Characters[characterID];
 
                 // if character is walking, that means animator is handling position of character
                 // if character is not walking (this is true in EOBot), update the domain model here
                 if (!character.RenderProperties.IsActing(CharacterActionState.Walking))
                 {
                     var renderProperties = EnsureCorrectXAndY(character.RenderProperties.WithDirection(dir), x, y);
-                    _currentMapStateRepository.Characters[characterID] = character.WithRenderProperties(renderProperties);
+                    _currentMapStateRepository.Characters.Update(character, character.WithRenderProperties(renderProperties));
                 }
 
                 foreach (var notifier in _otherCharacterAnimationNotifiers)

--- a/EOLib/PacketHandlers/Warp/WarpAgreeHandler.cs
+++ b/EOLib/PacketHandlers/Warp/WarpAgreeHandler.cs
@@ -75,7 +75,7 @@ namespace EOLib.PacketHandlers.Warp
 
             _currentMapStateRepository.Characters = warpAgreePacketData.Characters.ToDictionary(k => k.ID, v => v);
             _currentMapStateRepository.NPCs = new HashSet<DomainNPC>(warpAgreePacketData.NPCs);
-            _currentMapStateRepository.MapItems = new HashSet<MapItem>(warpAgreePacketData.Items);
+            _currentMapStateRepository.MapItems = new MapEntityCollectionHashSet<MapItem>(item => item.UniqueID, item => new MapCoordinate(item.X, item.Y), warpAgreePacketData.Items);
             _currentMapStateRepository.OpenDoors.Clear();
             _currentMapStateRepository.VisibleSpikeTraps.Clear();
             _currentMapStateRepository.ShowMiniMap = _currentMapStateRepository.ShowMiniMap &&

--- a/EOLib/PacketHandlers/Warp/WarpAgreeHandler.cs
+++ b/EOLib/PacketHandlers/Warp/WarpAgreeHandler.cs
@@ -73,8 +73,8 @@ namespace EOLib.PacketHandlers.Warp
             var withoutMainCharacter = warpAgreePacketData.Characters.Where(x => !MainCharacterIDMatches(x));
             warpAgreePacketData = warpAgreePacketData.WithCharacters(withoutMainCharacter.ToList());
 
-            _currentMapStateRepository.Characters = warpAgreePacketData.Characters.ToDictionary(k => k.ID, v => v);
-            _currentMapStateRepository.NPCs = new HashSet<DomainNPC>(warpAgreePacketData.NPCs);
+            _currentMapStateRepository.Characters = new MapEntityCollectionHashSet<Character>(c => c.ID, c => new MapCoordinate(c.X, c.Y), warpAgreePacketData.Characters);
+            _currentMapStateRepository.NPCs = new MapEntityCollectionHashSet<DomainNPC>(n => n.Index, n => new MapCoordinate(n.X, n.Y), warpAgreePacketData.NPCs);
             _currentMapStateRepository.MapItems = new MapEntityCollectionHashSet<MapItem>(item => item.UniqueID, item => new MapCoordinate(item.X, item.Y), warpAgreePacketData.Items);
             _currentMapStateRepository.OpenDoors.Clear();
             _currentMapStateRepository.VisibleSpikeTraps.Clear();

--- a/EndlessClient/Controllers/MapInteractionController.cs
+++ b/EndlessClient/Controllers/MapInteractionController.cs
@@ -254,9 +254,9 @@ namespace EndlessClient.Controllers
                     item.OwningPlayerID.MatchSome(playerId =>
                     {
                         message = EOResourceID.STATUS_LABEL_ITEM_PICKUP_PROTECTED_BY;
-                        if (_currentMapStateProvider.Characters.ContainsKey(playerId))
+                        if (_currentMapStateProvider.Characters.TryGetValue(playerId, out var character))
                         {
-                            extra = $" {_currentMapStateProvider.Characters[playerId].Name}";
+                            extra = $" {character.Name}";
                         }
                     });
 

--- a/EndlessClient/Dialogs/ShopDialog.cs
+++ b/EndlessClient/Dialogs/ShopDialog.cs
@@ -303,7 +303,7 @@ namespace EndlessClient.Dialogs
                 }
             }
 
-            var needItemTransferDialog = (buying && shopItem.MaxBuy == 1) || (!buying && inventoryItem.Match(x => x.Amount != 1, () => false));
+            var needItemTransferDialog = (buying && shopItem.MaxBuy != 1) || (!buying && inventoryItem.Match(x => x.Amount != 1, () => false));
 
             if (needItemTransferDialog)
             {

--- a/EndlessClient/HUD/Panels/StatsPanel.cs
+++ b/EndlessClient/HUD/Panels/StatsPanel.cs
@@ -172,8 +172,8 @@ namespace EndlessClient.HUD.Panels
                 _characterStats[TP].Text = $"{_lastCharacterStats[CharacterStat.TP]}";
                 _characterStats[DAM].Text = $"{_lastCharacterStats[CharacterStat.MinDam]} - {_lastCharacterStats[CharacterStat.MaxDam]}";
                 _characterStats[ACC].Text = $"{_lastCharacterStats[CharacterStat.Accuracy]}";
-                _characterStats[ARM].Text = $"{_lastCharacterStats[CharacterStat.Evade]}";
-                _characterStats[EVA].Text = $"{_lastCharacterStats[CharacterStat.Armor]}";
+                _characterStats[EVA].Text = $"{_lastCharacterStats[CharacterStat.Evade]}";
+                _characterStats[ARM].Text = $"{_lastCharacterStats[CharacterStat.Armor]}";
 
                 _otherInfo[WEIGHT].Text = $"{_lastCharacterStats[CharacterStat.Weight]} / {_lastCharacterStats[CharacterStat.MaxWeight]}";
                 _otherInfo[STATPTS].Text = $"{_lastCharacterStats[CharacterStat.StatPoints]}";

--- a/EndlessClient/Network/UnknownEntitiesRequester.cs
+++ b/EndlessClient/Network/UnknownEntitiesRequester.cs
@@ -3,16 +3,22 @@ using EndlessClient.Rendering;
 using EOLib.Domain.Character;
 using EOLib.Domain.Map;
 using EOLib.Domain.NPC;
+using EOLib.IO.Map;
 using EOLib.Net;
 using EOLib.Net.Communication;
 using Microsoft.Xna.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Metadata.Ecma335;
 
 namespace EndlessClient.Network
 {
     public class UnknownEntitiesRequester : GameComponent
     {
+        private const int UPPER_SEE_DISTANCE = 11;
+        private const int LOWER_SEE_DISTANCE = 14;
+
         private const double REQUEST_INTERVAL_SECONDS = 1.0;
 
         private readonly IClientWindowSizeProvider _clientWindowSizeProvider;
@@ -119,55 +125,41 @@ namespace EndlessClient.Network
 
         private void ClearOutOfRangeActors()
         {
-            // todo: the server should communicate the "seedistance" to clients
-            // for now, disable auto remove of entities in Resizable mode
-            if (_clientWindowSizeProvider.Resizable)
-            {
-                return;
-            }
-
             var mc = _characterProvider.MainCharacter;
 
-            var idsToRemove = new List<int>();
-            foreach (var id in _currentMapStateRepository.Characters.Keys)
+            var entities = _currentMapStateRepository.MapItems.Cast<IMapEntity>()
+                .Concat(_currentMapStateRepository.NPCs)
+                .Concat(_currentMapStateRepository.Characters.Values);
+
+            var seeDistanceUpper = (int)((_clientWindowSizeProvider.Height / 480.0) * UPPER_SEE_DISTANCE);
+            var seeDistanceLower = (int)((_clientWindowSizeProvider.Height / 480.0) * LOWER_SEE_DISTANCE);
+
+            var entitiesToRemove = new List<IMapEntity>();
+            foreach (var entity in entities)
             {
-                var c = _currentMapStateRepository.Characters[id];
+                var xDiff = Math.Abs(mc.X - entity.X);
+                var yDiff = Math.Abs(mc.Y - entity.Y);
 
-                var xDiff = Math.Abs(mc.X - c.X);
-                var yDiff = Math.Abs(mc.Y - c.Y);
-
-                if (c.X < mc.X || c.Y < mc.Y)
+                if (entity.X < mc.X || entity.Y < mc.Y)
                 {
-                    if (xDiff + yDiff > 11)
-                        idsToRemove.Add(id);
+                    if (xDiff + yDiff > seeDistanceUpper)
+                        entitiesToRemove.Add(entity);
                 }
-                else if (xDiff + yDiff > 14)
+                else if (xDiff + yDiff > seeDistanceLower)
                 {
-                    idsToRemove.Add(id);
+                    entitiesToRemove.Add(entity);
                 }
             }
 
-            foreach (var id in idsToRemove)
-                _currentMapStateRepository.Characters.Remove(id);
-
-            var npcsToRemove = new List<NPC>();
-            foreach (var npc in _currentMapStateRepository.NPCs)
+            foreach (var entity in entitiesToRemove)
             {
-                var xDiff = Math.Abs(mc.X - npc.X);
-                var yDiff = Math.Abs(mc.Y - npc.Y);
-
-                if (npc.X < mc.X || npc.Y < mc.Y)
-                {
-                    if (xDiff + yDiff > 11)
-                        npcsToRemove.Add(npc);
-                }
-                else if (xDiff + yDiff > 14)
-                {
-                    npcsToRemove.Add(npc);
-                }
+                if (entity is Character c)
+                    _currentMapStateRepository.Characters.Remove(c.ID);
+                else if (entity is NPC n)
+                    _currentMapStateRepository.NPCs.Remove(n);
+                else if (entity is MapItem i)
+                    _currentMapStateRepository.MapItems.Remove(i);
             }
-
-            _currentMapStateRepository.NPCs.RemoveWhere(npcsToRemove.Contains);
         }
     }
 }

--- a/EndlessClient/Network/UnknownEntitiesRequester.cs
+++ b/EndlessClient/Network/UnknownEntitiesRequester.cs
@@ -127,12 +127,12 @@ namespace EndlessClient.Network
         {
             var mc = _characterProvider.MainCharacter;
 
-            var entities = _currentMapStateRepository.MapItems.Cast<IMapEntity>()
+            var entities = new List<IMapEntity>(_currentMapStateRepository.Characters)
                 .Concat(_currentMapStateRepository.NPCs)
-                .Concat(_currentMapStateRepository.Characters.Values);
+                .Concat(_currentMapStateRepository.MapItems);
 
-            var seeDistanceUpper = (int)((_clientWindowSizeProvider.Height / 480.0) * UPPER_SEE_DISTANCE);
-            var seeDistanceLower = (int)((_clientWindowSizeProvider.Height / 480.0) * LOWER_SEE_DISTANCE);
+            var seeDistanceUpper = (int)(_clientWindowSizeProvider.Height / 480.0 * UPPER_SEE_DISTANCE);
+            var seeDistanceLower = (int)(_clientWindowSizeProvider.Height / 480.0 * LOWER_SEE_DISTANCE);
 
             var entitiesToRemove = new List<IMapEntity>();
             foreach (var entity in entities)
@@ -154,7 +154,7 @@ namespace EndlessClient.Network
             foreach (var entity in entitiesToRemove)
             {
                 if (entity is Character c)
-                    _currentMapStateRepository.Characters.Remove(c.ID);
+                    _currentMapStateRepository.Characters.Remove(c);
                 else if (entity is NPC n)
                     _currentMapStateRepository.NPCs.Remove(n);
                 else if (entity is MapItem i)

--- a/EndlessClient/Rendering/Character/CharacterAnimationActions.cs
+++ b/EndlessClient/Rendering/Character/CharacterAnimationActions.cs
@@ -122,7 +122,7 @@ namespace EndlessClient.Rendering.Character
 
         public void StartOtherCharacterWalkAnimation(int characterID, MapCoordinate destination, EODirection direction)
         {
-            if (!_hudControlProvider.IsInGame || !_currentMapStateProvider.Characters.ContainsKey(characterID))
+            if (!_hudControlProvider.IsInGame || !_currentMapStateProvider.Characters.TryGetValue(characterID, out var character))
                 return;
 
             Animator.StartOtherCharacterWalkAnimation(characterID, destination, direction);
@@ -131,19 +131,19 @@ namespace EndlessClient.Rendering.Character
             _spikeTrapActions.HideSpikeTrap(characterID);
             _spikeTrapActions.ShowSpikeTrap(characterID);
 
-            if (IsSteppingStone(_currentMapStateProvider.Characters[characterID].RenderProperties))
+            if (IsSteppingStone(character.RenderProperties))
                 _sfxPlayer.PlaySfx(SoundEffectID.JumpStone);
         }
 
         public void StartOtherCharacterAttackAnimation(int characterID, int noteIndex = -1)
         {
-            if (!_hudControlProvider.IsInGame || !_currentMapStateProvider.Characters.ContainsKey(characterID))
+            if (!_hudControlProvider.IsInGame || !_currentMapStateProvider.Characters.TryGetValue(characterID, out var character))
                 return;
 
-            if (noteIndex >= 0 || IsInstrumentWeapon(_currentMapStateProvider.Characters[characterID].RenderProperties.WeaponGraphic))
+            if (noteIndex >= 0 || IsInstrumentWeapon(character.RenderProperties.WeaponGraphic))
                 Animator.Emote(characterID, EOLib.Domain.Character.Emote.MusicNotes);
 
-            Animator.StartOtherCharacterAttackAnimation(characterID, () => PlayWeaponSound(_currentMapStateProvider.Characters[characterID], noteIndex));
+            Animator.StartOtherCharacterAttackAnimation(characterID, () => PlayWeaponSound(character, noteIndex));
             ShowWaterSplashiesIfNeeded(CharacterActionState.Attacking, characterID);
         }
 

--- a/EndlessClient/Rendering/Character/CharacterRendererUpdater.cs
+++ b/EndlessClient/Rendering/Character/CharacterRendererUpdater.cs
@@ -74,9 +74,9 @@ namespace EndlessClient.Rendering.Character
 
         private void CreateOtherCharacterRenderersAndCacheProperties()
         {
-            foreach (var id in _currentMapStateRepository.Characters.Keys)
+            foreach (var character in _currentMapStateRepository.Characters)
             {
-                var character = _currentMapStateRepository.Characters[id];
+                var id = character.ID;
 
                 _characterStateCache.HasCharacterWithID(id)
                     .SomeWhen(b => b)
@@ -146,9 +146,9 @@ namespace EndlessClient.Rendering.Character
 
         private void UpdateDeadCharacters()
         {
-            var deadCharacters = new List<int>();
+            var deadCharacters = new List<EOLib.Domain.Character.Character>();
 
-            foreach (var character in _currentMapStateRepository.Characters.Values.Where(x => x.RenderProperties.IsDead))
+            foreach (var character in _currentMapStateRepository.Characters.Where(x => x.RenderProperties.IsDead))
             {
                 _characterStateCache.DeathStartTimes.SingleOrNone(x => x.UniqueID == character.ID)
                     .Match(
@@ -166,13 +166,13 @@ namespace EndlessClient.Rendering.Character
                                     _characterRendererRepository.CharacterRenderers.Remove(character.ID);
                                 }
 
-                                deadCharacters.Add(character.ID);
+                                deadCharacters.Add(character);
                             }
                         });
             }
 
-            foreach (var id in deadCharacters)
-                _currentMapStateRepository.Characters.Remove(id);
+            foreach (var dead in deadCharacters)
+                _currentMapStateRepository.Characters.Remove(dead);
         }
 
         private ICharacterRenderer InitializeRendererForCharacter(EOLib.Domain.Character.Character character)

--- a/EndlessClient/Rendering/Map/ClickDispatcher.cs
+++ b/EndlessClient/Rendering/Map/ClickDispatcher.cs
@@ -107,7 +107,7 @@ namespace EndlessClient.Rendering.Map
 
         private bool CheckForEntityClicks(MouseEventArgs eventArgs)
         {
-            var entities = new List<IMapEntity>(_currentMapStateProvider.Characters.Select(x => x.Value));
+            var entities = new List<IMapEntity>(_currentMapStateProvider.Characters);
             entities.Add(_characterProvider.MainCharacter);
             entities.AddRange(_currentMapStateProvider.NPCs);
             entities.AddRange(_currentMapProvider.CurrentMap.Signs);

--- a/EndlessClient/Rendering/Map/DynamicMapObjectUpdater.cs
+++ b/EndlessClient/Rendering/Map/DynamicMapObjectUpdater.cs
@@ -100,7 +100,7 @@ namespace EndlessClient.Rendering.Map
 
             foreach (var spikeTrap in _currentMapStateRepository.VisibleSpikeTraps)
             {
-                if (_currentMapStateRepository.Characters.Values
+                if (_currentMapStateRepository.Characters
                     .Concat(new[] { _characterProvider.MainCharacter })
                     .Select(x => x.RenderProperties)
                     .All(x => x.MapX != spikeTrap.X && x.MapY != spikeTrap.Y))

--- a/EndlessClient/Rendering/Map/MapChangedActions.cs
+++ b/EndlessClient/Rendering/Map/MapChangedActions.cs
@@ -189,7 +189,7 @@ namespace EndlessClient.Rendering.Map
 
         private void AddSpikeTraps()
         {
-            foreach (var character in _currentMapStateRepository.Characters.Values)
+            foreach (var character in _currentMapStateRepository.Characters)
             {
                 if (_currentMapProvider.CurrentMap.Tiles[character.RenderProperties.MapY, character.RenderProperties.MapX] == TileSpec.SpikesTrap)
                     _currentMapStateRepository.VisibleSpikeTraps.Add(new MapCoordinate(character.RenderProperties.MapX, character.RenderProperties.MapY));

--- a/EndlessClient/Rendering/Map/MapEntityRendererProvider.cs
+++ b/EndlessClient/Rendering/Map/MapEntityRendererProvider.cs
@@ -28,8 +28,7 @@ namespace EndlessClient.Rendering.Map
                                          IClientWindowSizeProvider clientWindowSizeProvider,
                                          IConfigurationProvider configurationProvider,
                                          ICharacterRendererProvider characterRendererProvider,
-                                         INPCRendererProvider npcRendererProvider,
-                                         ICharacterStateCache characterStateCache)
+                                         INPCRendererProvider npcRendererProvider)
         {
             GroundRenderer =
                 new GroundLayerRenderer(nativeGraphicsManager,
@@ -90,13 +89,14 @@ namespace EndlessClient.Rendering.Map
                                            currentMapStateProvider),
                 new OtherCharacterEntityRenderer(characterProvider,
                                                  characterRendererProvider,
-                                                 characterStateCache,
+                                                 currentMapStateProvider,
                                                  gridDrawCoordinateCalculator,
                                                  clientWindowSizeProvider),
                 new NPCEntityRenderer(characterProvider,
                                       gridDrawCoordinateCalculator,
                                       clientWindowSizeProvider,
-                                      npcRendererProvider),
+                                      npcRendererProvider,
+                                      currentMapStateProvider),
                 new Overlay2LayerRenderer(nativeGraphicsManager,
                                           currentMapProvider,
                                           characterProvider,

--- a/EndlessClient/Rendering/Map/MiniMapRenderer.cs
+++ b/EndlessClient/Rendering/Map/MiniMapRenderer.cs
@@ -110,7 +110,7 @@ namespace EndlessClient.Rendering.Map
                 _spriteBatch.Draw(_miniMapTarget, baseTargetDrawLoc, Color.White);
 
                 var entities = new IMapEntity[] { _characterProvider.MainCharacter }
-                    .Concat(_currentMapStateProvider.Characters.Values)
+                    .Concat(_currentMapStateProvider.Characters)
                     .Concat(_currentMapStateProvider.NPCs);
 
                 foreach (var entity in entities)

--- a/EndlessClient/Rendering/Map/SpikeTrapActions.cs
+++ b/EndlessClient/Rendering/Map/SpikeTrapActions.cs
@@ -38,13 +38,10 @@ namespace EndlessClient.Rendering.Map
 
         public void ShowSpikeTrap(int characterId)
         {
-            if (!_currentMapStateRepository.Characters.ContainsKey(characterId))
+            if (!_currentMapStateRepository.Characters.TryGetValue(characterId, out var character))
                 return;
 
-            var character = _currentMapStateRepository.Characters[characterId];
-            ShowSpikeTrap(new MapCoordinate(
-                character.RenderProperties.GetDestinationX(),
-                character.RenderProperties.GetDestinationY()));
+            ShowSpikeTrap(new MapCoordinate(character.X, character.Y));
         }
 
         public void HideSpikeTrap(MapCoordinate coordinate)
@@ -54,13 +51,10 @@ namespace EndlessClient.Rendering.Map
 
         public void HideSpikeTrap(int characterId)
         {
-            if (!_currentMapStateRepository.Characters.ContainsKey(characterId))
+            if (!_currentMapStateRepository.Characters.TryGetValue(characterId, out var character))
                 return;
 
-            var character = _currentMapStateRepository.Characters[characterId];
-            HideSpikeTrap(new MapCoordinate(
-                character.RenderProperties.MapX,
-                character.RenderProperties.MapY));
+            HideSpikeTrap(new MapCoordinate(character.X, character.Y));
         }
     }
 

--- a/EndlessClient/Rendering/MapEntityRenderers/MapItemLayerRenderer.cs
+++ b/EndlessClient/Rendering/MapEntityRenderers/MapItemLayerRenderer.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.Linq;
-using EndlessClient.Rendering.Map;
-using EOLib;
+﻿using EndlessClient.Rendering.Map;
 using EOLib.Domain.Character;
-using EOLib.Domain.Extensions;
 using EOLib.Domain.Map;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Linq;
 
 namespace EndlessClient.Rendering.MapEntityRenderers
 {
@@ -32,18 +30,14 @@ namespace EndlessClient.Rendering.MapEntityRenderers
 
         protected override bool ElementExistsAt(int row, int col)
         {
-            return _currentMapStateProvider.MapItems.Any(IsItemAt);
-            bool IsItemAt(MapItem item) => item.X == col && item.Y == row;
+            return _currentMapStateProvider.MapItems.TryGetValues(new MapCoordinate(col, row), out var mapItems) && mapItems.Count > 0;
         }
 
         public override void RenderElementAt(SpriteBatch spriteBatch, int row, int col, int alpha, Vector2 additionalOffset = default)
         {
-            var items = _currentMapStateProvider
-                .MapItems
-                .Where(IsItemAt)
-                .OrderBy(item => item.UniqueID);
+            var items = _currentMapStateProvider.MapItems[new MapCoordinate(col, row)];
 
-            foreach (var item in items)
+            foreach (var item in items.OrderBy(item => item.UniqueID))
             {
                 var itemPos = GetDrawCoordinatesFromGridUnits(col, row);
                 var itemTexture = _mapItemGraphicProvider.GetItemGraphic(item.ItemID, item.Amount);
@@ -53,8 +47,6 @@ namespace EndlessClient.Rendering.MapEntityRenderers
                                              itemPos.Y - (int) Math.Round(itemTexture.Height/2.0)) + additionalOffset,
                                  Color.FromNonPremultiplied(255, 255, 255, alpha));
             }
-
-            bool IsItemAt(MapItem item) => item.X == col && item.Y == row;
         }
     }
 }

--- a/EndlessClient/Rendering/MapEntityRenderers/NPCEntityRenderer.cs
+++ b/EndlessClient/Rendering/MapEntityRenderers/NPCEntityRenderer.cs
@@ -1,11 +1,9 @@
 ﻿using EndlessClient.Rendering.Map;
 using EndlessClient.Rendering.NPC;
 using EOLib.Domain.Character;
-using EOLib.Domain.Extensions;
-using EOLib.Domain.NPC;
+using EOLib.Domain.Map;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using System;
 using System.Linq;
 
 namespace EndlessClient.Rendering.MapEntityRenderers
@@ -13,14 +11,17 @@ namespace EndlessClient.Rendering.MapEntityRenderers
     public class NPCEntityRenderer : BaseMapEntityRenderer
     {
         private readonly INPCRendererProvider _npcRendererProvider;
+        private readonly ICurrentMapStateProvider _currentMapStateProvider;
 
         public NPCEntityRenderer(ICharacterProvider characterProvider,
                                  IGridDrawCoordinateCalculator gridDrawCoordinateCalculator,
                                  IClientWindowSizeProvider clientWindowSizeProvider,
-                                 INPCRendererProvider npcRendererProvider)
+                                 INPCRendererProvider npcRendererProvider,
+                                 ICurrentMapStateProvider currentMapStateProvider)
             : base(characterProvider, gridDrawCoordinateCalculator, clientWindowSizeProvider)
         {
             _npcRendererProvider = npcRendererProvider;
+            _currentMapStateProvider = currentMapStateProvider;
         }
 
         public override MapRenderLayer RenderLayer => MapRenderLayer.Npc;
@@ -29,34 +30,21 @@ namespace EndlessClient.Rendering.MapEntityRenderers
 
         protected override bool ElementExistsAt(int row, int col)
         {
-            return _npcRendererProvider.NPCRenderers.Values.Any(IsNpcAt);
-            bool IsNpcAt(INPCRenderer rend) => NPCEntityRenderer.IsNpcAt(rend.NPC, row, col);
+            return _currentMapStateProvider.NPCs.ContainsKey(new MapCoordinate(col, row));
         }
 
         public override void RenderElementAt(SpriteBatch spriteBatch, int row, int col, int alpha, Vector2 additionalOffset = default)
         {
-            var indicesToRender = _npcRendererProvider.NPCRenderers.Values
-                .Where(IsNpcAt)
-                .Select(n => n.NPC.Index);
+            var indicesToRender = _currentMapStateProvider.NPCs[new MapCoordinate(col, row)].Select(n => n.Index);
 
             foreach (var index in indicesToRender)
             {
                 if (!_npcRendererProvider.NPCRenderers.ContainsKey(index) ||
                     _npcRendererProvider.NPCRenderers[index] == null)
-                    throw new InvalidOperationException(
-                        $"NPC renderer for ID {index} is null or missing! Did you call MapRenderer.Update() before calling MapRenderer.Draw()?");
+                    return;
 
-                var renderer = _npcRendererProvider.NPCRenderers[index];
-                renderer.DrawToSpriteBatch(spriteBatch);
+                _npcRendererProvider.NPCRenderers[index].DrawToSpriteBatch(spriteBatch);
             }
-
-            bool IsNpcAt(INPCRenderer rend) => NPCEntityRenderer.IsNpcAt(rend.NPC, row, col);
-        }
-
-        private static bool IsNpcAt(EOLib.Domain.NPC.NPC npc, int row, int col)
-        {
-            return (npc.IsActing(NPCActionState.Walking) && npc.GetDestinationX() == col && npc.GetDestinationY() == row) ||
-                (npc.X == col && npc.Y == row);
         }
     }
 }

--- a/EndlessClient/Rendering/MapEntityRenderers/NPCEntityRenderer.cs
+++ b/EndlessClient/Rendering/MapEntityRenderers/NPCEntityRenderer.cs
@@ -30,18 +30,24 @@ namespace EndlessClient.Rendering.MapEntityRenderers
 
         protected override bool ElementExistsAt(int row, int col)
         {
-            return _currentMapStateProvider.NPCs.ContainsKey(new MapCoordinate(col, row));
+            var coordinate = new MapCoordinate(col, row);
+            return _currentMapStateProvider.NPCs.ContainsKey(coordinate) || _npcRendererProvider.DyingNPCs.ContainsKey(coordinate);
         }
 
         public override void RenderElementAt(SpriteBatch spriteBatch, int row, int col, int alpha, Vector2 additionalOffset = default)
         {
-            var indicesToRender = _currentMapStateProvider.NPCs[new MapCoordinate(col, row)].Select(n => n.Index);
+            var coordinate = new MapCoordinate(col, row);
+            var indicesToRender = _npcRendererProvider.DyingNPCs.ContainsKey(coordinate)
+                ? _currentMapStateProvider.NPCs.ContainsKey(coordinate)
+                    ? Enumerable.Repeat(_npcRendererProvider.DyingNPCs[coordinate], 1).Concat(_currentMapStateProvider.NPCs[coordinate].Select(n => n.Index))
+                    : Enumerable.Repeat(_npcRendererProvider.DyingNPCs[coordinate], 1)
+                : _currentMapStateProvider.NPCs[coordinate].Select(n => n.Index);
 
             foreach (var index in indicesToRender)
             {
                 if (!_npcRendererProvider.NPCRenderers.ContainsKey(index) ||
                     _npcRendererProvider.NPCRenderers[index] == null)
-                    return;
+                    continue;
 
                 _npcRendererProvider.NPCRenderers[index].DrawToSpriteBatch(spriteBatch);
             }

--- a/EndlessClient/Rendering/NPC/NPCActions.cs
+++ b/EndlessClient/Rendering/NPC/NPCActions.cs
@@ -80,15 +80,19 @@ namespace EndlessClient.Rendering.NPC
 
             if (hasRenderer)
             {
+                var renderer = _npcRendererRepository.NPCRenderers[npcIndex];
+
                 if (!showDeathAnimation)
                 {
-                    _npcRendererRepository.NPCRenderers[npcIndex].Dispose();
+                    renderer.Dispose();
                     _npcRendererRepository.NPCRenderers.Remove(npcIndex);
                 }
                 else
                 {
-                    _npcRendererRepository.NPCRenderers[npcIndex].StartDying();
-                    damage.MatchSome(d => _npcRendererRepository.NPCRenderers[npcIndex].ShowDamageCounter(d, 0, isHeal: false));
+                    renderer.StartDying();
+                    _npcRendererRepository.DyingNPCs[new MapCoordinate(renderer.NPC.X, renderer.NPC.Y)] = npcIndex;
+
+                    damage.MatchSome(d => renderer.ShowDamageCounter(d, 0, isHeal: false));
                 }
             }
 

--- a/EndlessClient/Rendering/NPC/NPCRendererRepository.cs
+++ b/EndlessClient/Rendering/NPC/NPCRendererRepository.cs
@@ -1,4 +1,5 @@
 ﻿using AutomaticTypeMapper;
+using EOLib.Domain.Map;
 using System;
 using System.Collections.Generic;
 
@@ -7,11 +8,15 @@ namespace EndlessClient.Rendering.NPC
     public interface INPCRendererRepository : IDisposable
     {
         Dictionary<int, INPCRenderer> NPCRenderers { get; set; }
+
+        Dictionary<MapCoordinate, int> DyingNPCs { get; set; }
     }
 
     public interface INPCRendererProvider
     {
         IReadOnlyDictionary<int, INPCRenderer> NPCRenderers { get; }
+
+        IReadOnlyDictionary<MapCoordinate, int> DyingNPCs { get; }
     }
 
     [AutoMappedType(IsSingleton = true)]
@@ -19,11 +24,16 @@ namespace EndlessClient.Rendering.NPC
     {
         public Dictionary<int, INPCRenderer> NPCRenderers { get; set; }
 
+        public Dictionary<MapCoordinate, int> DyingNPCs { get; set; }
+
         IReadOnlyDictionary<int, INPCRenderer> INPCRendererProvider.NPCRenderers => NPCRenderers;
+
+        IReadOnlyDictionary<MapCoordinate, int> INPCRendererProvider.DyingNPCs => DyingNPCs;
 
         public NPCRendererRepository()
         {
             NPCRenderers = new Dictionary<int, INPCRenderer>();
+            DyingNPCs = new Dictionary<MapCoordinate, int>();
         }
 
         public void Dispose()
@@ -31,6 +41,8 @@ namespace EndlessClient.Rendering.NPC
             foreach (var renderer in NPCRenderers.Values)
                 renderer.Dispose();
             NPCRenderers.Clear();
+
+            DyingNPCs.Clear();
         }
     }
 }

--- a/EndlessClient/Rendering/NPC/NPCRendererUpdater.cs
+++ b/EndlessClient/Rendering/NPC/NPCRendererUpdater.cs
@@ -44,6 +44,7 @@ namespace EndlessClient.Rendering.NPC
             {
                 npc.Dispose();
                 _npcRendererRepository.NPCRenderers.Remove(npc.NPC.Index);
+                _npcRendererRepository.DyingNPCs.Remove(new MapCoordinate(npc.NPC.X, npc.NPC.Y));
                 _npcStateCache.RemoveStateByIndex(npc.NPC.Index);
             }
         }


### PR DESCRIPTION
Map entities are now stored in a dual-key collection that is indexed by both map coordinates and unique ID based on the type of entity (item uid, npc index, character id). This allows rendering of map entities to do an O(1) lookup rather than O(N) when determining if a grid space has a renderable element, which significantly improves performance when there are many entities to render (especially considering resizable window mode).

Additionally, map items are now culled unconditionally when the main character gets out of range, similar to how Characters/NPCs are culled by `UnknownEntitiesRequester`. This is due to the fact that there is no server packet that despawns an item.

Minor bugs fixed:
- Shop dialog only allowed MaxBuy of 1 when the shop defined a MaxBuy amount (logic incorrectly reversed)
- Display of stats 'evade' and 'armor' were swapped in the stat panel