### PR TITLE
Add --debug command line option

### DIFF
--- a/EOLib.Config/IConfigurationRepository.cs
+++ b/EOLib.Config/IConfigurationRepository.cs
@@ -36,6 +36,8 @@ namespace EOLib.Config
 
         int InGameWidth { get; set; }
         int InGameHeight { get; set; }
+
+        bool DebugCrashes { get; set; }
     }
 
     public interface IConfigurationProvider
@@ -71,6 +73,8 @@ namespace EOLib.Config
 
         int InGameWidth { get; }
         int InGameHeight { get; }
+
+        bool DebugCrashes { get; }
     }
 
     [AutoMappedType(IsSingleton = true)]
@@ -107,5 +111,7 @@ namespace EOLib.Config
 
         public int InGameWidth { get; set; }
         public int InGameHeight { get; set; }
+
+        public bool DebugCrashes { get; set; }
     }
 }

--- a/EndlessClient/GameExecution/EndlessGame.cs
+++ b/EndlessClient/GameExecution/EndlessGame.cs
@@ -205,14 +205,25 @@ namespace EndlessClient.GameExecution
 #endif
                 _fixedTimeStepRepository.Tick();
 
+#if !DEBUG
                 try
                 {
                     base.Update(gameTime);
                 }
                 catch
                 {
-                    _mainButtonController.GoToInitialStateAndDisconnect(showLostConnection: true);
+                    if (_configurationProvider.DebugCrashes)
+                    {
+                        throw;
+                    }
+                    else
+                    {
+                        _mainButtonController.GoToInitialStateAndDisconnect(showLostConnection: true);
+                    }
                 }
+#else
+                base.Update(gameTime);
+#endif
 
                 _lastFrameUpdate = gameTime.TotalGameTime;
             }

--- a/EndlessClient/GameExecution/GameRunnerBase.cs
+++ b/EndlessClient/GameExecution/GameRunnerBase.cs
@@ -117,6 +117,10 @@ namespace EndlessClient.GameExecution
 
                     i++;
                 }
+                else if (string.Equals(arg, "--debug"))
+                {
+                    _registry.Resolve<IConfigurationRepository>().DebugCrashes = true;
+                }
                 else
                 {
                     Debug.WriteLine($"Unrecognized argument: {arg}. Will be ignored.");


### PR DESCRIPTION
Allows for debugging exceptions in Release builds instead of closing the connection and returning to the main menu.