### PR TITLE
Chat fixes

### DIFF
--- a/EOLib/PacketHandlers/Chat/GroupChatHandler.cs
+++ b/EOLib/PacketHandlers/Chat/GroupChatHandler.cs
@@ -7,9 +7,6 @@ using EOLib.Domain.Party;
 using EOLib.Net.Handlers;
 using Moffat.EndlessOnline.SDK.Protocol.Net;
 using Moffat.EndlessOnline.SDK.Protocol.Net.Server;
-using System.Collections.Generic;
-using System.Linq;
-using Optional;
 using Optional.Collections;
 
 namespace EOLib.PacketHandlers.Chat

--- a/EOLib/PacketHandlers/Chat/GroupChatHandler.cs
+++ b/EOLib/PacketHandlers/Chat/GroupChatHandler.cs
@@ -40,7 +40,7 @@ namespace EOLib.PacketHandlers.Chat
 
         public override bool HandlePacket(TalkOpenServerPacket packet)
         {
-            _partyDataProvider.Members.FirstOrNone(member => member.CharacterID == packet.PlayerId)
+            _partyDataProvider.Members.SingleOrNone(member => member.CharacterID == packet.PlayerId)
                 .MatchSome(member =>
                 {
                     var localChatData = new ChatData(ChatTab.Local, member.Name, packet.Message, ChatIcon.PlayerPartyDark, ChatColor.PM);

--- a/EOLib/PacketHandlers/Chat/GroupChatHandler.cs
+++ b/EOLib/PacketHandlers/Chat/GroupChatHandler.cs
@@ -1,55 +1,60 @@
 ﻿using System.Collections.Generic;
 using AutomaticTypeMapper;
-using EOLib.Domain.Character;
 using EOLib.Domain.Chat;
 using EOLib.Domain.Login;
-using EOLib.Domain.Map;
 using EOLib.Domain.Notifiers;
+using EOLib.Domain.Party;
+using EOLib.Net.Handlers;
 using Moffat.EndlessOnline.SDK.Protocol.Net;
 using Moffat.EndlessOnline.SDK.Protocol.Net.Server;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace EOLib.PacketHandlers.Chat
 {
     [AutoMappedType]
-    public class GroupChatHandler : PlayerChatByIDHandler<TalkOpenServerPacket>
+    public class GroupChatHandler : InGameOnlyPacketHandler<TalkOpenServerPacket>
     {
         private readonly IChatRepository _chatRepository;
+        private readonly IPartyDataProvider _partyDataProvider;
         private readonly IEnumerable<IOtherCharacterEventNotifier> _otherCharacterEventNotifiers;
         private readonly IEnumerable<IChatEventNotifier> _chatEventNotifiers;
 
+        public override PacketFamily Family => PacketFamily.Talk;
         public override PacketAction Action => PacketAction.Open;
 
         public GroupChatHandler(IPlayerInfoProvider playerInfoProvider,
-                                ICurrentMapStateRepository currentMapStateRepository,
-                                ICharacterProvider characterProvider,
                                 IChatRepository chatRepository,
+                                IPartyDataProvider partyDataProvider,
                                 IEnumerable<IOtherCharacterEventNotifier> otherCharacterEventNotifiers,
                                 IEnumerable<IChatEventNotifier> chatEventNotifiers)
-            : base(playerInfoProvider, currentMapStateRepository, characterProvider)
+            : base(playerInfoProvider)
         {
             _chatRepository = chatRepository;
+            _partyDataProvider = partyDataProvider;
             _otherCharacterEventNotifiers = otherCharacterEventNotifiers;
             _chatEventNotifiers = chatEventNotifiers;
         }
 
         public override bool HandlePacket(TalkOpenServerPacket packet)
         {
-            return Handle(packet, packet.PlayerId);
-        }
+            var member = _partyDataProvider.Members.FirstOrDefault(member => member.CharacterID == packet.PlayerId);
+            if (member == null)
+                return true;
 
-        protected override void DoTalk(TalkOpenServerPacket packet, Character character)
-        {
-            var localChatData = new ChatData(ChatTab.Local, character.Name, packet.Message, ChatIcon.PlayerPartyDark, ChatColor.PM);
+            var localChatData = new ChatData(ChatTab.Local, member.Name, packet.Message, ChatIcon.PlayerPartyDark, ChatColor.PM);
             _chatRepository.AllChat[ChatTab.Local].Add(localChatData);
 
-            var chatData = new ChatData(ChatTab.Group, character.Name, packet.Message, ChatIcon.PlayerPartyDark);
+            var chatData = new ChatData(ChatTab.Group, member.Name, packet.Message, ChatIcon.PlayerPartyDark);
             _chatRepository.AllChat[ChatTab.Group].Add(chatData);
 
             foreach (var notifier in _otherCharacterEventNotifiers)
-                notifier.OtherCharacterSaySomethingToGroup(character.ID, packet.Message);
+                notifier.OtherCharacterSaySomethingToGroup(member.CharacterID, packet.Message);
 
             foreach (var notifier in _chatEventNotifiers)
                 notifier.NotifyChatReceived(ChatEventType.Group);
+
+            return true;
         }
     }
 }

--- a/EndlessClient/Audio/SoundEffectID.cs
+++ b/EndlessClient/Audio/SoundEffectID.cs
@@ -24,7 +24,7 @@
         PrivateMessageReceived,
         PunchAttack,
         UnknownWarpSound,
-        UnknownPingSound = 12,
+        PrivateMessageTargetNotFound = 12,
         HudStatusBarClick,
         AdminAnnounceReceived,
         MeleeWeaponAttack,

--- a/EndlessClient/Audio/SoundEffectID.cs
+++ b/EndlessClient/Audio/SoundEffectID.cs
@@ -43,6 +43,7 @@
         Craft,
         UnknownBuzzSound = 28,
         AdminChatReceived,
+        AdminChatSent = AdminChatReceived,
         AlternateMeleeAttack,
         PotionOfFlamesEffect,
         AdminWarp = 32,

--- a/EndlessClient/Controllers/ChatController.cs
+++ b/EndlessClient/Controllers/ChatController.cs
@@ -60,6 +60,12 @@ namespace EndlessClient.Controllers
                 }
 
                 var chatType = _chatTypeCalculator.CalculateChatType(localTypedText);
+
+                if (chatType == ChatType.Admin)
+                {
+                    _sfxPlayer.PlaySfx(SoundEffectID.AdminChatSent);
+                }
+
                 var (result, updatedChat) = _chatActions.SendChatToServer(localTypedText, targetCharacter, chatType);
                 switch (result)
                 {

--- a/EndlessClient/Controllers/LoginController.cs
+++ b/EndlessClient/Controllers/LoginController.cs
@@ -290,6 +290,9 @@ namespace EndlessClient.Controllers
             {
                 chat.Clear();
             }
+
+            _chatRepository.PMTarget1 = string.Empty;
+            _chatRepository.PMTarget2 = string.Empty;
         }
 
         private void AddDefaultTextToChat()

--- a/EndlessClient/HUD/Chat/ChatNotificationActions.cs
+++ b/EndlessClient/HUD/Chat/ChatNotificationActions.cs
@@ -72,6 +72,8 @@ namespace EndlessClient.HUD.Chat
                 var chatPanel = _hudControlProvider.GetComponent<ChatPanel>(HudControlIdentifier.ChatPanel);
                 chatPanel.ClosePMTab(tab);
             });
+
+            _sfxPlayer.PlaySfx(SoundEffectID.PrivateMessageTargetNotFound);
         }
 
         public void NotifyPlayerMutedByAdmin(string adminName)

--- a/EndlessClient/HUD/Chat/ChatPanelTab.cs
+++ b/EndlessClient/HUD/Chat/ChatPanelTab.cs
@@ -85,22 +85,22 @@ namespace EndlessClient.HUD.Chat
 
             DrawArea = new Rectangle(0, 0, _parentPanel.DrawArea.Width, _parentPanel.DrawArea.Height);
 
+            _tab = new ClickableArea(GetTabClickableArea());
+            _tab.OnClick += (_, _) => SelectThisTab();
+            _tab.SetParentControl(this);
+
             if (Tab == ChatTab.Private1)
             {
-                _closeButton = new ClickableArea(new Rectangle(23, 102, 11, 11));
+                _closeButton = new ClickableArea(new Rectangle(26, 105, 11, 11));
                 _closeButton.OnClick += (_, _) => CloseTab();
                 _closeButton.SetParentControl(this);
             }
             else if (Tab == ChatTab.Private2)
             {
-                _closeButton = new ClickableArea(new Rectangle(156, 102, 11, 11));
+                _closeButton = new ClickableArea(new Rectangle(159, 105, 11, 11));
                 _closeButton.OnClick += (_, _) => CloseTab();
                 _closeButton.SetParentControl(this);
             }
-
-            _tab = new ClickableArea(GetTabClickableArea());
-            _tab.OnClick += (_, _) => SelectThisTab();
-            _tab.SetParentControl(this);
 
             _label = new XNALabel(Constants.FontSize08)
             {

--- a/EndlessClient/HUD/Panels/ChatPanel.cs
+++ b/EndlessClient/HUD/Panels/ChatPanel.cs
@@ -11,6 +11,8 @@ using EOLib.Domain.Chat;
 using EOLib.Graphics;
 using Microsoft.Xna.Framework;
 using MonoGame.Extended.BitmapFonts;
+using MonoGame.Extended.Input;
+using MonoGame.Extended.Input.InputListeners;
 using XNAControls;
 
 namespace EndlessClient.HUD.Panels
@@ -131,6 +133,16 @@ namespace EndlessClient.HUD.Panels
         public void ClosePMTab(ChatTab whichTab)
         {
             _tabs[whichTab].CloseTab();
+        }
+
+        protected override bool HandleClick(IXNAControl control, MouseEventArgs eventArgs)
+        {
+            if (eventArgs.Button == MouseButton.Right)
+            {
+                _tabs[CurrentTab].HandleRightClick(eventArgs);
+            }
+
+            return base.HandleClick(control, eventArgs);
         }
     }
 }

--- a/EndlessClient/Subscribers/OtherCharacterEventSubscriber.cs
+++ b/EndlessClient/Subscribers/OtherCharacterEventSubscriber.cs
@@ -59,11 +59,8 @@ namespace EndlessClient.Subscribers
 
         private void SaySomethingShared(int characterID, string message, bool isGroupChat)
         {
-            if (_characterRendererProvider.CharacterRenderers.TryGetValue(characterID, out var characterRenderer) ||
-                _characterRendererProvider.MainCharacterRenderer.HasValue)
+            if (_characterRendererProvider.CharacterRenderers.TryGetValue(characterID, out var characterRenderer))
             {
-                _characterRendererProvider.MainCharacterRenderer.MatchSome(x => characterRenderer = x);
-
                 var name = characterRenderer.Character.Name;
 
                 var ignoreList = _friendIgnoreListService.LoadList(Constants.IgnoreListFile);


### PR DESCRIPTION
Closes #352 

> PM recipient not found doesn't play the SFX

I couldn't replicate this. The SFX played for me


> Public and Group chat always shows speech bubble over the main character

This was a bug where we were always overwriting the render character with the main character. Now we always find one in `_characterRendererProvider.CharacterRenderers` with the matching player id

> Admin chat does not play sfx when you send a message, only when you receive one

Added sound effect to chat controller when sending message

> Group chat does not play sfx when you are on a different map as the sender

We were only looking at party members in the local map repository instead of the party repository before. Now it shows messages from members no matter where they are in game.

> PM tab [x] button doesn't work in resizable display mode

I believe this was a render order bug? Seemed like some kinda z-index kind of thing. Adding the `Tab` clickable area before the close buttons fixed it. I also adjusted the dimensions a bit to match the gfx.
 
