### PR TITLE
Reboot handler

### DIFF
--- a/EOLib/Domain/Notifiers/IServerRebootNotifier.cs
+++ b/EOLib/Domain/Notifiers/IServerRebootNotifier.cs
@@ -1,0 +1,15 @@
+﻿using AutomaticTypeMapper;
+
+namespace EOLib.Domain.Notifiers
+{
+    public interface IServerRebootNotifier
+    {
+        void NotifyServerReboot();
+    }
+
+    [AutoMappedType]
+    public class NoOpServerRebootNotifier : IServerRebootNotifier
+    {
+        public void NotifyServerReboot() { }
+    }
+}

--- a/EOLib/PacketHandlers/Message/MessageCloseHandler.cs
+++ b/EOLib/PacketHandlers/Message/MessageCloseHandler.cs
@@ -1,0 +1,39 @@
+﻿using AutomaticTypeMapper;
+using EOLib.Domain.Login;
+using EOLib.Domain.Notifiers;
+using EOLib.Net.Handlers;
+using Moffat.EndlessOnline.SDK.Protocol.Net;
+using Moffat.EndlessOnline.SDK.Protocol.Net.Server;
+using System.Collections.Generic;
+
+namespace EOLib.PacketHandlers.Message
+{
+    /// <summary>
+    /// Shows the server reboot message
+    /// </summary>
+    [AutoMappedType]
+    public class MessageCloseHandler : InGameOnlyPacketHandler<MessageCloseServerPacket>
+    {
+        private readonly IEnumerable<IServerRebootNotifier> _serverRebootNotifiers;
+
+        public override PacketFamily Family => PacketFamily.Message;
+
+        public override PacketAction Action => PacketAction.Close;
+
+        public MessageCloseHandler(IPlayerInfoProvider playerInfoProvider,
+                                    IEnumerable<IServerRebootNotifier> serverRebootNotifiers)
+            : base(playerInfoProvider)
+        {
+            _serverRebootNotifiers = serverRebootNotifiers;
+        }
+        
+
+        public override bool HandlePacket(MessageCloseServerPacket packet)
+        {
+            foreach (var notifier in _serverRebootNotifiers)
+                notifier.NotifyServerReboot();
+
+            return true;
+        }
+    }
+}

--- a/EndlessClient/Audio/SoundEffectID.cs
+++ b/EndlessClient/Audio/SoundEffectID.cs
@@ -19,6 +19,7 @@
         DeleteCharacter,
         MapMutation = DeleteCharacter,
         Banned,
+        Reboot = Banned,
         ScreenCapture = 8,
         PrivateMessageReceived,
         PunchAttack,

--- a/EndlessClient/Subscribers/ServerRebootEventSubscriber.cs
+++ b/EndlessClient/Subscribers/ServerRebootEventSubscriber.cs
@@ -1,0 +1,34 @@
+﻿using AutomaticTypeMapper;
+using EndlessClient.Audio;
+using EndlessClient.HUD;
+using EndlessClient.HUD.Chat;
+using EOLib.Domain.Notifiers;
+using EOLib.Localization;
+
+namespace EndlessClient.Subscribers
+{
+    [AutoMappedType]
+    public class ServerRebootEventNotifier : IServerRebootNotifier
+    {
+        private readonly ILocalizedStringFinder _localizedStringFinder;
+        private readonly IServerMessageHandler _serverMessageHandler;
+        private readonly IStatusLabelSetter _statusLabelSetter;
+
+        public ServerRebootEventNotifier(ILocalizedStringFinder localizedStringFinder,
+                                    IServerMessageHandler serverMessageHandler,
+                                    IStatusLabelSetter statusLabelSetter,
+                                    ISfxPlayer sfxPlayer)
+        {
+            _localizedStringFinder = localizedStringFinder;
+            _serverMessageHandler = serverMessageHandler;
+            _statusLabelSetter = statusLabelSetter;
+        }
+
+        public void NotifyServerReboot()
+        {
+            var message = _localizedStringFinder.GetString(EOResourceID.REBOOT_SEQUENCE_STARTED);
+            _serverMessageHandler.AddServerMessage(message, SoundEffectID.Reboot);
+            _statusLabelSetter.ShowWarning(message);
+        }
+    }
+}


### PR DESCRIPTION
Adds packet handler for Message_Close and event notifier/subscriber.

Also tried making disconnect detection better but it doesn't really work for some reason.

Found this lengthy thread of people discussing the problem
https://stackoverflow.com/questions/722240/instantly-detect-client-disconnection-from-server-socket

In reoserv I do this
```rust
match self.socket.try_read(&mut buf) {
	Ok(0) => { // <- This means the client disconnected
		return Some(Err(std::io::Error::new(
			std::io::ErrorKind::BrokenPipe,
			"Connection closed",
		)));
	}
	Ok(_) => {}
	Err(_) => {
		return None;
	}
}
```

I tried doing something similar in EndlessClient but it was getting false positives :\
```c#
!(_socket.Poll(1, SelectMode.SelectRead) && _socket.Available == 0);
```

edit: actually that method would probably work but the polling timeout needs to be higher and we probably wouldn't want that in the main thread.. idk something to think about

Anyway.. this handler/sfx/server message is wired up now :)