### PR TITLE
fix: correct name notation

### DIFF
--- a/EndlessClient/UIControls/CharacterInfoPanel.cs
+++ b/EndlessClient/UIControls/CharacterInfoPanel.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Threading.Tasks;
 using EndlessClient.Controllers;
 using EndlessClient.Dialogs.Services;

--- a/EndlessClient/UIControls/CharacterInfoPanel.cs
+++ b/EndlessClient/UIControls/CharacterInfoPanel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using EndlessClient.Controllers;
 using EndlessClient.Dialogs.Services;
@@ -198,7 +199,7 @@ namespace EndlessClient.UIControls
 
         private static string CapitalizeName(string name)
         {
-            return string.IsNullOrEmpty(name) ? string.Empty : (char)(name[0] - 32) + name.Substring(1);
+            return string.IsNullOrEmpty(name) ? string.Empty : char.ToUpper(name[0]) + name[1..];
         }
 
         private ISpriteSheet CreateAdminGraphic(AdminLevel adminLevel)


### PR DESCRIPTION
before
![image](https://github.com/user-attachments/assets/535f7ce1-17f6-41ff-a464-04ea8127bcf6)

after
![image](https://github.com/user-attachments/assets/fd644d5e-cea8-435b-8b05-eeb86e3bf391)
