### PR TITLE
Block character login keyboard shortcut when any dialogs are open

### DIFF
--- a/EndlessClient/UIControls/CharacterInfoPanel.cs
+++ b/EndlessClient/UIControls/CharacterInfoPanel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using EndlessClient.Controllers;
 using EndlessClient.Dialogs.Services;
@@ -163,7 +164,8 @@ namespace EndlessClient.UIControls
 
             var previousKeyState = _userInputProvider.PreviousKeyState;
             var currentKeyState = _userInputProvider.CurrentKeyState;
-            if (currentKeyState.IsKeyPressedOnce(previousKeyState, Keys.D1 + _characterIndex))
+            if (currentKeyState.IsKeyPressedOnce(previousKeyState, Keys.D1 + _characterIndex) &&
+                !Game.Components.OfType<IXNADialog>().Any())
             {
                 AsyncButtonClick(() => _loginController.LoginToCharacter(_character));
             }


### PR DESCRIPTION
Fixes issue #360 where login shortcut would be activated if typing 1/2/3 shortcut keys as part of a password.