### PR TITLE
Fixes for v1 release

### DIFF
--- a/EOLib/Domain/Character/AttackValidationActions.cs
+++ b/EOLib/Domain/Character/AttackValidationActions.cs
@@ -3,6 +3,8 @@ using AutomaticTypeMapper;
 using EOLib.Domain.Extensions;
 using EOLib.Domain.Map;
 using EOLib.IO.Repositories;
+using Optional;
+using Optional.Collections;
 
 namespace EOLib.Domain.Character
 {
@@ -39,12 +41,13 @@ namespace EOLib.Domain.Character
 
             var rp = _characterProvider.MainCharacter.RenderProperties;
 
-            var isRangedWeapon = _eifFileProvider.EIFFile
-                .Where(x => x.Type == IO.ItemType.Weapon && x.SubType == IO.ItemSubType.Ranged)
-                .Any(x => x.DollGraphic == rp.WeaponGraphic);
-            var isArrows = _eifFileProvider.EIFFile
-                .Where(x => x.Type == IO.ItemType.Shield && x.SubType == IO.ItemSubType.Arrows)
-                .Any(x => x.DollGraphic == rp.ShieldGraphic);
+            var matchingWeapon = _eifFileProvider.EIFFile
+                .SingleOrNone(x => x.DollGraphic == rp.WeaponGraphic && x.Type == IO.ItemType.Weapon);
+            var matchingArrows = _eifFileProvider.EIFFile
+                .SingleOrNone(x => x.DollGraphic == rp.ShieldGraphic && x.Type == IO.ItemType.Shield);
+
+            var isRangedWeapon = matchingWeapon.Map(x => x.SubType == IO.ItemSubType.Ranged).ValueOr(false);
+            var isArrows = matchingArrows.Map(x => x.SubType == IO.ItemSubType.Arrows).ValueOr(false);
 
             if (isRangedWeapon && (rp.ShieldGraphic == 0 || !isArrows))
                 return AttackValidationError.MissingArrows;

--- a/EndlessClient/.config/dotnet-tools.json
+++ b/EndlessClient/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
     "isRoot": true,
     "tools": {
       "dotnet-mgcb": {
-        "version": "3.8.1.303",
+        "version": "3.8.2.1105",
         "commands": [
           "mgcb"
         ]
       },
       "dotnet-mgcb-editor": {
-        "version": "3.8.1.303",
+        "version": "3.8.2.1105",
         "commands": [
           "mgcb-editor"
         ]
       },
       "dotnet-mgcb-editor-linux": {
-        "version": "3.8.1.303",
+        "version": "3.8.2.1105",
         "commands": [
           "mgcb-editor-linux"
         ]
       },
       "dotnet-mgcb-editor-windows": {
-        "version": "3.8.1.303",
+        "version": "3.8.2.1105",
         "commands": [
           "mgcb-editor-windows"
         ]
       },
       "dotnet-mgcb-editor-mac": {
-        "version": "3.8.1.303",
+        "version": "3.8.2.1105",
         "commands": [
           "mgcb-editor-mac"
         ]

--- a/EndlessClient/ControlSets/BackButtonControlSet.cs
+++ b/EndlessClient/ControlSets/BackButtonControlSet.cs
@@ -50,7 +50,7 @@ namespace EndlessClient.ControlSets
                 DrawOrder = 100,
                 ClickArea = new Rectangle(4, 16, 16, 16)
             };
-            button.OnClick += DoBackButtonClick;
+            button.OnMouseDown += DoBackButtonClick;
 
             _clientWindowSizeRepository.GameWindowSizeChanged += (o, e) =>
             {

--- a/EndlessClient/ControlSets/CreateAccountControlSet.cs
+++ b/EndlessClient/ControlSets/CreateAccountControlSet.cs
@@ -6,6 +6,7 @@ using EndlessClient.Controllers;
 using EndlessClient.GameExecution;
 using EndlessClient.Input;
 using EndlessClient.Rendering;
+using EndlessClient.UIControls;
 using EOLib;
 using EOLib.Domain.Account;
 using EOLib.Graphics;
@@ -148,7 +149,7 @@ namespace EndlessClient.ControlSets
             //set the second 3 Y coord to start at 260 and move up by 51 each time
             var txtYCoord = (i < 3 ? 69 : 260) + i % 3 * 51;
             var drawArea = new Rectangle(358, txtYCoord, 240, _textBoxBackground.Height);
-            return new XNATextBox(drawArea,
+            return new ClearableTextBox(drawArea,
                 Constants.FontSize08,
                 _textBoxBackground,
                 _textBoxLeft,

--- a/EndlessClient/ControlSets/CreateAccountControlSet.cs
+++ b/EndlessClient/ControlSets/CreateAccountControlSet.cs
@@ -207,7 +207,12 @@ namespace EndlessClient.ControlSets
                                                 _tbRealName.Text,
                                                 _tbLocation.Text,
                                                 _tbEmail.Text));
-                _createAccountTask.ContinueWith(_ => _createAccountTask = null);
+                _createAccountTask
+                    .ContinueWith(t =>
+                    {
+                        _createAccountTask = null;
+                        t.ThrowIfFaulted();
+                    });
             }
         }
     }

--- a/EndlessClient/ControlSets/CreateAccountControlSet.cs
+++ b/EndlessClient/ControlSets/CreateAccountControlSet.cs
@@ -170,7 +170,7 @@ namespace EndlessClient.ControlSets
                                        new Vector2(481, 417),
                                        new Rectangle(0, 40, 120, 40),
                                        new Rectangle(120, 40, 120, 40));
-            button.OnClick += (o, e) => _mainButtonController.GoToInitialState();
+            button.OnMouseDown += (o, e) => _mainButtonController.GoToInitialState();
             return button;
         }
 
@@ -193,7 +193,7 @@ namespace EndlessClient.ControlSets
         protected override IXNAButton GetCreateButton()
         {
             var button = base.GetCreateButton();
-            button.OnClick += DoCreateAccount;
+            button.OnMouseDown += DoCreateAccount;
             return button;
         }
 

--- a/EndlessClient/ControlSets/InitialControlSet.cs
+++ b/EndlessClient/ControlSets/InitialControlSet.cs
@@ -113,7 +113,12 @@ namespace EndlessClient.ControlSets
             if (_mainButtonClickTask == null)
             {
                 _mainButtonClickTask = clickHandler();
-                _mainButtonClickTask.ContinueWith(_ => _mainButtonClickTask = null);
+                _mainButtonClickTask
+                    .ContinueWith(t =>
+                    {
+                        _mainButtonClickTask = null;
+                        t.ThrowIfFaulted();
+                    });
             }
         }
 

--- a/EndlessClient/ControlSets/InitialControlSet.cs
+++ b/EndlessClient/ControlSets/InitialControlSet.cs
@@ -83,28 +83,28 @@ namespace EndlessClient.ControlSets
         private IXNAButton GetMainCreateAccountButton()
         {
             var button = MainButtonCreationHelper(GameControlIdentifier.InitialCreateAccount);
-            button.OnClick += (o, e) => AsyncMainButtonClick(_mainButtonController.ClickCreateAccount);
+            button.OnMouseDown += (o, e) => AsyncMainButtonClick(_mainButtonController.ClickCreateAccount);
             return button;
         }
 
         private IXNAButton GetMainLoginButton()
         {
             var button = MainButtonCreationHelper(GameControlIdentifier.InitialLogin);
-            button.OnClick += (o, e) => AsyncMainButtonClick(_mainButtonController.ClickLogin);
+            button.OnMouseDown += (o, e) => AsyncMainButtonClick(_mainButtonController.ClickLogin);
             return button;
         }
 
         private IXNAButton GetViewCreditsButton()
         {
             var button = MainButtonCreationHelper(GameControlIdentifier.InitialViewCredits);
-            button.OnClick += (o, e) => _mainButtonController.ClickViewCredits();
+            button.OnMouseDown += (o, e) => _mainButtonController.ClickViewCredits();
             return button;
         }
 
         private IXNAButton GetExitButton()
         {
             var button = MainButtonCreationHelper(GameControlIdentifier.InitialExitGame);
-            button.OnClick += (o, e) => _mainButtonController.ClickExit();
+            button.OnMouseDown += (o, e) => _mainButtonController.ClickExit();
             return button;
         }
 

--- a/EndlessClient/ControlSets/LoggedInControlSet.cs
+++ b/EndlessClient/ControlSets/LoggedInControlSet.cs
@@ -99,7 +99,12 @@ namespace EndlessClient.ControlSets
             if (_loggedInActionTask == null)
             {
                 _loggedInActionTask = clickHandler();
-                _loggedInActionTask.ContinueWith(_ => _loggedInActionTask = null);
+                _loggedInActionTask
+                    .ContinueWith(t =>
+                    {
+                        _loggedInActionTask = null;
+                        t.ThrowIfFaulted();
+                    });
             }
         }
     }

--- a/EndlessClient/ControlSets/LoggedInControlSet.cs
+++ b/EndlessClient/ControlSets/LoggedInControlSet.cs
@@ -78,14 +78,14 @@ namespace EndlessClient.ControlSets
                 new Vector2(454, 417),
                 new Rectangle(0, 120, 120, 40),
                 new Rectangle(120, 120, 120, 40));
-            button.OnClick += (o, e) => AsyncButtonAction(_accountController.ChangePassword);
+            button.OnMouseDown += (o, e) => AsyncButtonAction(_accountController.ChangePassword);
             return button;
         }
 
         protected override IXNAButton GetCreateButton()
         {
             var button = base.GetCreateButton();
-            button.OnClick += (o, e) => AsyncButtonAction(_characterManagementController.CreateCharacter);
+            button.OnMouseDown += (o, e) => AsyncButtonAction(_characterManagementController.CreateCharacter);
             return button;
         }
 

--- a/EndlessClient/ControlSets/LoginPromptControlSet.cs
+++ b/EndlessClient/ControlSets/LoginPromptControlSet.cs
@@ -149,7 +149,12 @@ namespace EndlessClient.ControlSets
             {
                 var loginParameters = new LoginParameters(_tbUsername.Text, _tbPassword.Text);
                 _loginTask = _loginController.LoginToAccount(loginParameters);
-                _loginTask.ContinueWith(_ => _loginTask = null);
+                _loginTask
+                    .ContinueWith(t =>
+                    {
+                        _loginTask = null;
+                        t.ThrowIfFaulted();
+                    });
             }
         }
 

--- a/EndlessClient/ControlSets/LoginPromptControlSet.cs
+++ b/EndlessClient/ControlSets/LoginPromptControlSet.cs
@@ -5,6 +5,7 @@ using EndlessClient.Content;
 using EndlessClient.Controllers;
 using EndlessClient.GameExecution;
 using EndlessClient.Input;
+using EndlessClient.UIControls;
 using EOLib;
 using EOLib.Config;
 using EOLib.Domain.Login;
@@ -90,7 +91,7 @@ namespace EndlessClient.ControlSets
 
         private IXNATextBox GetLoginUserNameTextBox()
         {
-            var textBox = new XNATextBox(
+            var textBox = new ClearableTextBox(
                 new Rectangle(402, 322, 140, _textBoxBackground.Height),
                 Constants.FontSize08,
                 _textBoxBackground,
@@ -112,7 +113,7 @@ namespace EndlessClient.ControlSets
 
         private IXNATextBox GetLoginPasswordTextBox()
         {
-            var textBox = new XNATextBox(
+            var textBox = new ClearableTextBox(
                 new Rectangle(402, 358, 140, _textBoxBackground.Height),
                 Constants.FontSize08,
                 _textBoxBackground,

--- a/EndlessClient/ControlSets/LoginPromptControlSet.cs
+++ b/EndlessClient/ControlSets/LoginPromptControlSet.cs
@@ -140,7 +140,7 @@ namespace EndlessClient.ControlSets
             {
                 DrawOrder = _personPicture.DrawOrder + 2
             };
-            button.OnClick += DoLogin;
+            button.OnMouseDown += DoLogin;
             return button;
         }
 
@@ -165,7 +165,7 @@ namespace EndlessClient.ControlSets
             {
                 DrawOrder = _personPicture.DrawOrder + 2
             };
-            button.OnClick += (o, e) => _mainButtonController.GoToInitialState();
+            button.OnMouseDown += (o, e) => _mainButtonController.GoToInitialState();
             return button;
         }
     }

--- a/EndlessClient/Controllers/TaskExtensions.cs
+++ b/EndlessClient/Controllers/TaskExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading.Tasks;
+using EndlessClient.Rendering;
+
+namespace EndlessClient.Controllers
+{
+    public static class TaskExtensions
+    {
+        public static Task ThrowIfFaulted(this Task t)
+        {
+            if (t.IsFaulted)
+            {
+                // Invoke any exception on the main game thread
+                // Exceptions thrown by tasks are quietly swallowed
+                // Invoking this on the main thread ensures the Update() loop catches it and
+                //   handles it in the global exception handler (see EndlessGame::Update)
+                Task.Run(DispatcherGameComponent.Invoke(() => throw t.Exception).RunSynchronously);
+            }
+
+            return t;
+        }
+    }
+}

--- a/EndlessClient/Dialogs/Actions/InGameDialogActions.cs
+++ b/EndlessClient/Dialogs/Actions/InGameDialogActions.cs
@@ -491,7 +491,7 @@ namespace EndlessClient.Dialogs.Actions
             UseDefaultDialogSounds((BaseEODialog)dialog);
 
             foreach (var button in dialog.ChildControls.OfType<IXNAButton>())
-                button.OnClick += Handler;
+                button.OnMouseDown += Handler;
 
             void Handler(object sender, EventArgs e) => _sfxPlayer.PlaySfx(SoundEffectID.DialogButtonClick);
         }

--- a/EndlessClient/Dialogs/BarberDialog.cs
+++ b/EndlessClient/Dialogs/BarberDialog.cs
@@ -76,7 +76,7 @@ namespace EndlessClient.Dialogs
         private void InitializeDialogItems(IEODialogButtonService dialogButtonService)
         {
             var cancel = CreateButton(dialogButtonService, new Vector2(215, 151), SmallButton.Cancel);
-            cancel.OnClick += (_, _) => Close(XNADialogResult.Cancel);
+            cancel.OnMouseDown += (_, _) => Close(XNADialogResult.Cancel);
 
             _changeHairItem = new ListDialogItem(this, ListDialogItem.ListItemStyle.Large, 0)
             {

--- a/EndlessClient/Dialogs/BardDialog.cs
+++ b/EndlessClient/Dialogs/BardDialog.cs
@@ -37,7 +37,7 @@ namespace EndlessClient.Dialogs
                 dialogButtonService.GetSmallDialogButtonOverSource(SmallButton.Cancel));
             cancel.Initialize();
             cancel.SetParentControl(this);
-            cancel.OnClick += (_, _) => Close(XNADialogResult.Cancel);
+            cancel.OnMouseDown += (_, _) => Close(XNADialogResult.Cancel);
 
             CenterInGameView();
 
@@ -63,7 +63,7 @@ namespace EndlessClient.Dialogs
             });
         }
 
-        protected override bool HandleClick(IXNAControl control, MouseEventArgs eventArgs)
+        protected override bool HandleMouseDown(IXNAControl control, MouseEventArgs eventArgs)
         {
             if (eventArgs.Button == MouseButton.Left && _currentTick > 8)
             {

--- a/EndlessClient/Dialogs/BoardDialog.cs
+++ b/EndlessClient/Dialogs/BoardDialog.cs
@@ -67,7 +67,7 @@ namespace EndlessClient.Dialogs
             _state = BoardDialogState.ViewList;
             _cachedPostInfo = new HashSet<BoardPostInfo>();
 
-            _subject = new XNATextBox(new Rectangle(150, 44, 315, 19), Constants.FontSize08, caretTexture: contentProvider.Textures[ContentProvider.Cursor])
+            _subject = new ClearableTextBox(new Rectangle(150, 44, 315, 19), Constants.FontSize08, caretTexture: contentProvider.Textures[ContentProvider.Cursor])
             {
                 TextAlignment = LabelAlignment.MiddleLeft,
                 TextColor = ColorConstants.LightGrayText,
@@ -77,7 +77,7 @@ namespace EndlessClient.Dialogs
             _subject.SetScrollWheelHandler(_scrollBar);
             _subject.SetParentControl(this);
 
-            _message = new XNATextBox(new Rectangle(18, 80, 430, 168), Constants.FontSize08, caretTexture: contentProvider.Textures[ContentProvider.Cursor])
+            _message = new ClearableTextBox(new Rectangle(18, 80, 430, 168), Constants.FontSize08, caretTexture: contentProvider.Textures[ContentProvider.Cursor])
             {
                 TextAlignment = LabelAlignment.TopLeft,
                 TextColor = ColorConstants.LightGrayText,

--- a/EndlessClient/Dialogs/BoardDialog.cs
+++ b/EndlessClient/Dialogs/BoardDialog.cs
@@ -91,8 +91,8 @@ namespace EndlessClient.Dialogs
             _message.SetScrollWheelHandler(_scrollBar);
             _message.SetParentControl(this);
 
-            _add.OnClick += AddButton_Click;
-            _delete.OnClick += DeleteButton_Click;
+            _add.OnMouseDown += AddButton_Click;
+            _delete.OnMouseDown += DeleteButton_Click;
         }
 
         public override void Initialize()

--- a/EndlessClient/Dialogs/ChangePasswordDialog.cs
+++ b/EndlessClient/Dialogs/ChangePasswordDialog.cs
@@ -70,14 +70,14 @@ namespace EndlessClient.Dialogs
                 new Vector2(157, 195),
                 dialogButtonService.GetSmallDialogButtonOutSource(SmallButton.Ok),
                 dialogButtonService.GetSmallDialogButtonOverSource(SmallButton.Ok));
-            _ok.OnClick += OnButtonPressed;
+            _ok.OnMouseDown += OnButtonPressed;
 
             _cancel = new XNAButton(
                 dialogButtonService.SmallButtonSheet,
                 new Vector2(250, 195),
                 dialogButtonService.GetSmallDialogButtonOutSource(SmallButton.Cancel),
                 dialogButtonService.GetSmallDialogButtonOverSource(SmallButton.Cancel));
-            _cancel.OnClick += (s, e) => Close(XNADialogResult.Cancel);
+            _cancel.OnMouseDown += (s, e) => Close(XNADialogResult.Cancel);
 
             CenterInGameView();
         }

--- a/EndlessClient/Dialogs/ChangePasswordDialog.cs
+++ b/EndlessClient/Dialogs/ChangePasswordDialog.cs
@@ -51,7 +51,7 @@ namespace EndlessClient.Dialogs
             _inputBoxes = new IXNATextBox[4];
             for (int i = 0; i < _inputBoxes.Length; ++i)
             {
-                var tb = new XNATextBox(new Rectangle(198, 60 + i * 30, 137, 19), Constants.FontSize08, caretTexture: cursorTexture)
+                var tb = new ClearableTextBox(new Rectangle(198, 60 + i * 30, 137, 19), Constants.FontSize08, caretTexture: cursorTexture)
                 {
                     LeftPadding = 5,
                     DefaultText = " ",

--- a/EndlessClient/Dialogs/CreateCharacterDialog.cs
+++ b/EndlessClient/Dialogs/CreateCharacterDialog.cs
@@ -74,7 +74,7 @@ namespace EndlessClient.Dialogs
                     new Vector2(196, 85 + i * 26),
                     new Rectangle(185, 38, 19, 19),
                     new Rectangle(206, 38, 19, 19));
-                btn.OnClick += ArrowButtonClick;
+                btn.OnMouseDown += ArrowButtonClick;
                 btn.SetParentControl(this);
                 _arrowButtons[i] = btn;
             }
@@ -94,14 +94,14 @@ namespace EndlessClient.Dialogs
                 new Vector2(157, 195),
                 eoDialogButtonService.GetSmallDialogButtonOutSource(SmallButton.Ok),
                 eoDialogButtonService.GetSmallDialogButtonOverSource(SmallButton.Ok));
-            _ok.OnClick += (s, e) => ClickOk();
+            _ok.OnMouseDown += (s, e) => ClickOk();
             _ok.SetParentControl(this);
 
             _cancel = new XNAButton(eoDialogButtonService.SmallButtonSheet,
                 new Vector2(250, 195),
                 eoDialogButtonService.GetSmallDialogButtonOutSource(SmallButton.Cancel),
                 eoDialogButtonService.GetSmallDialogButtonOverSource(SmallButton.Cancel));
-            _cancel.OnClick += (s, e) => Close(XNADialogResult.Cancel);
+            _cancel.OnMouseDown += (s, e) => Close(XNADialogResult.Cancel);
             _cancel.SetParentControl(this);
 
             CenterInGameView();

--- a/EndlessClient/Dialogs/CreateCharacterDialog.cs
+++ b/EndlessClient/Dialogs/CreateCharacterDialog.cs
@@ -55,7 +55,7 @@ namespace EndlessClient.Dialogs
             _charCreateSheet = GraphicsManager.TextureFromResource(GFXTypes.PreLoginUI, 22);
 
             var cursorTexture = contentProvider.Textures[ContentProvider.Cursor];
-            _inputBox = new XNATextBox(new Rectangle(80, 57, 138, 19), Constants.FontSize08, caretTexture: cursorTexture)
+            _inputBox = new ClearableTextBox(new Rectangle(80, 57, 138, 19), Constants.FontSize08, caretTexture: cursorTexture)
             {
                 LeftPadding = 5,
                 DefaultText = " ",

--- a/EndlessClient/Dialogs/EOMessageBox.cs
+++ b/EndlessClient/Dialogs/EOMessageBox.cs
@@ -74,23 +74,23 @@ namespace EndlessClient.Dialogs
             {
                 case EODialogButtons.Ok:
                     _ok = new XNAButton(smallButtonSheet, new Vector2(181, 113), okOut, okOver);
-                    _ok.OnClick += (sender, e) => Close(XNADialogResult.OK);
+                    _ok.OnMouseDown += (sender, e) => Close(XNADialogResult.OK);
                     _ok.SetParentControl(this);
                     break;
                 case EODialogButtons.Cancel:
                     _cancel = new XNAButton(smallButtonSheet, new Vector2(181, 113), cancelOut, cancelOver);
-                    _cancel.OnClick += (sender, e) => Close(XNADialogResult.Cancel);
+                    _cancel.OnMouseDown += (sender, e) => Close(XNADialogResult.Cancel);
                     _cancel.SetParentControl(this);
                     break;
                 case EODialogButtons.OkCancel:
                     //implement this more fully when it is needed
                     //update draw location of ok button to be on left?
                     _ok = new XNAButton(smallButtonSheet, new Vector2(89, 113), okOut, okOver);
-                    _ok.OnClick += (sender, e) => Close(XNADialogResult.OK);
+                    _ok.OnMouseDown += (sender, e) => Close(XNADialogResult.OK);
                     _ok.SetParentControl(this);
 
                     _cancel = new XNAButton(smallButtonSheet, new Vector2(181, 113), cancelOut, cancelOver);
-                    _cancel.OnClick += (s, e) => Close(XNADialogResult.Cancel);
+                    _cancel.OnMouseDown += (s, e) => Close(XNADialogResult.Cancel);
                     _cancel.SetParentControl(this);
                     break;
             }

--- a/EndlessClient/Dialogs/ItemTransferDialog.cs
+++ b/EndlessClient/Dialogs/ItemTransferDialog.cs
@@ -75,7 +75,7 @@ namespace EndlessClient.Dialogs
             {
                 Visible = true
             };
-            _okButton.OnClick += (s, e) => Close(XNADialogResult.OK);
+            _okButton.OnMouseDown += (s, e) => Close(XNADialogResult.OK);
 
             _cancelButton = new XNAButton(eoDialogButtonService.SmallButtonSheet,
                 new Vector2(153, 125),
@@ -84,7 +84,7 @@ namespace EndlessClient.Dialogs
             {
                 Visible = true
             };
-            _cancelButton.OnClick += (s, e) => Close(XNADialogResult.Cancel);
+            _cancelButton.OnMouseDown += (s, e) => Close(XNADialogResult.Cancel);
 
             _descLabel = new XNALabel(Constants.FontSize10)
             {

--- a/EndlessClient/Dialogs/ItemTransferDialog.cs
+++ b/EndlessClient/Dialogs/ItemTransferDialog.cs
@@ -2,6 +2,7 @@
 using EndlessClient.Content;
 using EndlessClient.Dialogs.Services;
 using EndlessClient.HUD.Chat;
+using EndlessClient.UIControls;
 using EOLib;
 using EOLib.Graphics;
 using EOLib.Localization;
@@ -93,7 +94,7 @@ namespace EndlessClient.Dialogs
                 Text = $"{localizedStringFinder.GetString(EOResourceID.DIALOG_TRANSFER_HOW_MUCH)} {itemName} {localizedStringFinder.GetString(message)}"
             };
 
-            _amount = new XNATextBox(new Rectangle(163, 95, 77, 19), Constants.FontSize08, caretTexture: contentProvider.Textures[ContentProvider.Cursor])
+            _amount = new ClearableTextBox(new Rectangle(163, 95, 77, 19), Constants.FontSize08, caretTexture: contentProvider.Textures[ContentProvider.Cursor])
             {
                 Visible = true,
                 Enabled = true,

--- a/EndlessClient/Dialogs/ListDialogItem.cs
+++ b/EndlessClient/Dialogs/ListDialogItem.cs
@@ -194,7 +194,7 @@ namespace EndlessClient.Dialogs
                 Underline = UnderlineLinks
             };
 
-            ((XNAHyperLink)_primaryText).OnClick += onClickAction;
+            ((XNAHyperLink)_primaryText).OnMouseDown += onClickAction;
 
             _primaryText.SetParentControl(this);
             _primaryText.Initialize();
@@ -223,7 +223,7 @@ namespace EndlessClient.Dialogs
                 Underline = UnderlineLinks
             };
 
-            ((XNAHyperLink)_subText).OnClick += onClickAction;
+            ((XNAHyperLink)_subText).OnMouseDown += onClickAction;
 
             _subText.SetParentControl(this);
             _subText.Initialize();
@@ -270,7 +270,7 @@ namespace EndlessClient.Dialogs
             _spriteBatch.End();
         }
 
-        protected override bool HandleClick(IXNAControl control, MouseEventArgs eventArgs)
+        protected override bool HandleMouseDown(IXNAControl control, MouseEventArgs eventArgs)
         {
             if (eventArgs.Button == MouseButton.Left)
             {

--- a/EndlessClient/Dialogs/PaperdollDialogItem.cs
+++ b/EndlessClient/Dialogs/PaperdollDialogItem.cs
@@ -50,7 +50,7 @@ namespace EndlessClient.Dialogs
             StretchMode = StretchMode.CenterInFrame;
         }
 
-        protected override bool HandleClick(IXNAControl control, MouseEventArgs eventArgs)
+        protected override bool HandleMouseDown(IXNAControl control, MouseEventArgs eventArgs)
         {
             if (!_isMainCharacter || !_itemInfo.HasValue)
                 return false;

--- a/EndlessClient/Dialogs/PlayerInfoDialog.cs
+++ b/EndlessClient/Dialogs/PlayerInfoDialog.cs
@@ -79,7 +79,7 @@ namespace EndlessClient.Dialogs
             new Vector2(276, 253),
                 eoDialogButtonService.GetSmallDialogButtonOutSource(SmallButton.Ok),
                 eoDialogButtonService.GetSmallDialogButtonOverSource(SmallButton.Ok));
-            okButton.OnClick += (_, _) => Close(XNADialogResult.OK);
+            okButton.OnMouseDown += (_, _) => Close(XNADialogResult.OK);
             okButton.Initialize();
             okButton.SetParentControl(this);
 

--- a/EndlessClient/Dialogs/ProgressDialog.cs
+++ b/EndlessClient/Dialogs/ProgressDialog.cs
@@ -57,7 +57,7 @@ namespace EndlessClient.Dialogs
                 new Vector2(181, 113),
                 eoDialogButtonService.GetSmallDialogButtonOutSource(SmallButton.Cancel),
                 eoDialogButtonService.GetSmallDialogButtonOverSource(SmallButton.Cancel));
-            _cancelButton.OnClick += DoCancel;
+            _cancelButton.OnMouseDown += DoCancel;
             _cancelButton.SetParentControl(this);
 
             _pbBackgroundTexture = GraphicsManager.TextureFromResource(GFXTypes.PreLoginUI, 19);

--- a/EndlessClient/Dialogs/QuestDialog.cs
+++ b/EndlessClient/Dialogs/QuestDialog.cs
@@ -71,8 +71,8 @@ namespace EndlessClient.Dialogs
             {
                 Visible = false,
             };
-            _questSwitcher.OnClick += (_, _) => ToggleSwitcherState();
-            _questSwitcher.OnClick += (_, _) => ClickSoundEffect?.Invoke(this, EventArgs.Empty);
+            _questSwitcher.OnMouseDown += (_, _) => ToggleSwitcherState();
+            _questSwitcher.OnMouseDown += (_, _) => ClickSoundEffect?.Invoke(this, EventArgs.Empty);
             _questSwitcher.SetParentControl(this);
         }
 

--- a/EndlessClient/Dialogs/ScrollingListDialog.cs
+++ b/EndlessClient/Dialogs/ScrollingListDialog.cs
@@ -231,7 +231,7 @@ namespace EndlessClient.Dialogs
                 UpdateOrder = 1,
             };
             _add.SetParentControl(this);
-            _add.OnClick += (o, e) => AddAction?.Invoke(o, e);
+            _add.OnMouseDown += (o, e) => AddAction?.Invoke(o, e);
 
             _back = new XNAButton(dialogButtonService.SmallButtonSheet, Vector2.Zero,
                 dialogButtonService.GetSmallDialogButtonOutSource(SmallButton.Back),
@@ -241,7 +241,7 @@ namespace EndlessClient.Dialogs
                 UpdateOrder = 1,
             };
             _back.SetParentControl(this);
-            _back.OnClick += (o, e) => BackAction?.Invoke(o, e);
+            _back.OnMouseDown += (o, e) => BackAction?.Invoke(o, e);
 
             _next = new XNAButton(dialogButtonService.SmallButtonSheet, Vector2.Zero,
                 dialogButtonService.GetSmallDialogButtonOutSource(SmallButton.Next),
@@ -251,7 +251,7 @@ namespace EndlessClient.Dialogs
                 UpdateOrder = 1,
             };
             _next.SetParentControl(this);
-            _next.OnClick += (o, e) => NextAction?.Invoke(o, e);
+            _next.OnMouseDown += (o, e) => NextAction?.Invoke(o, e);
 
             _history = new XNAButton(dialogButtonService.SmallButtonSheet, Vector2.Zero,
                 dialogButtonService.GetSmallDialogButtonOutSource(SmallButton.History),
@@ -261,7 +261,7 @@ namespace EndlessClient.Dialogs
                 UpdateOrder = 1,
             };
             _history.SetParentControl(this);
-            _history.OnClick += (o, e) => HistoryAction?.Invoke(o, e);
+            _history.OnMouseDown += (o, e) => HistoryAction?.Invoke(o, e);
 
             _progress = new XNAButton(dialogButtonService.SmallButtonSheet, Vector2.Zero,
                 dialogButtonService.GetSmallDialogButtonOutSource(SmallButton.Progress),
@@ -271,7 +271,7 @@ namespace EndlessClient.Dialogs
                 UpdateOrder = 1,
             };
             _progress.SetParentControl(this);
-            _progress.OnClick += (o, e) => ProgressAction?.Invoke(o, e);
+            _progress.OnMouseDown += (o, e) => ProgressAction?.Invoke(o, e);
 
             _delete = new XNAButton(dialogButtonService.SmallButtonSheet, Vector2.Zero,
                 dialogButtonService.GetSmallDialogButtonOutSource(SmallButton.Delete),
@@ -281,7 +281,7 @@ namespace EndlessClient.Dialogs
                 UpdateOrder = 1,
             };
             _delete.SetParentControl(this);
-            _delete.OnClick += (o, e) => ProgressAction?.Invoke(o, e);
+            _delete.OnMouseDown += (o, e) => ProgressAction?.Invoke(o, e);
 
             _ok = new XNAButton(dialogButtonService.SmallButtonSheet, Vector2.Zero,
                 dialogButtonService.GetSmallDialogButtonOutSource(SmallButton.Ok),
@@ -291,7 +291,7 @@ namespace EndlessClient.Dialogs
                 UpdateOrder = 2,
             };
             _ok.SetParentControl(this);
-            _ok.OnClick += CloseButton_Click;
+            _ok.OnMouseDown += CloseButton_Click;
 
             _cancel = new XNAButton(dialogButtonService.SmallButtonSheet, Vector2.Zero,
                 dialogButtonService.GetSmallDialogButtonOutSource(SmallButton.Cancel),
@@ -301,7 +301,7 @@ namespace EndlessClient.Dialogs
                 UpdateOrder = 2,
             };
             _cancel.SetParentControl(this);
-            _cancel.OnClick += CloseButton_Click;
+            _cancel.OnMouseDown += CloseButton_Click;
 
             _button1Position = GetButton1Position(DrawArea, _ok.DrawArea, DialogType);
             _button2Position = GetButton2Position(DrawArea, _ok.DrawArea, DialogType);

--- a/EndlessClient/Dialogs/ScrollingMessageDialog.cs
+++ b/EndlessClient/Dialogs/ScrollingMessageDialog.cs
@@ -73,7 +73,7 @@ namespace EndlessClient.Dialogs
                 new Vector2(138, 197),
                 eoDialogButtonService.GetSmallDialogButtonOutSource(SmallButton.Ok),
                 eoDialogButtonService.GetSmallDialogButtonOverSource(SmallButton.Ok));
-            _ok.OnClick += (sender, e) => Close(XNADialogResult.OK);
+            _ok.OnMouseDown += (sender, e) => Close(XNADialogResult.OK);
             _ok.SetParentControl(this);
 
             _scrollBar = new ScrollBar(new Vector2(320, 66), new Vector2(16, 119),

--- a/EndlessClient/Dialogs/SessionExpDialog.cs
+++ b/EndlessClient/Dialogs/SessionExpDialog.cs
@@ -39,7 +39,7 @@ namespace EndlessClient.Dialogs
                 new Vector2(98, 214),
                 dialogButtonService.GetSmallDialogButtonOutSource(SmallButton.Ok),
                 dialogButtonService.GetSmallDialogButtonOverSource(SmallButton.Ok));
-            okButton.OnClick += (_, _) => Close(XNADialogResult.OK);
+            okButton.OnMouseDown += (_, _) => Close(XNADialogResult.OK);
             okButton.SetParentControl(this);
             okButton.Initialize();
 

--- a/EndlessClient/Dialogs/TextInputDialog.cs
+++ b/EndlessClient/Dialogs/TextInputDialog.cs
@@ -1,6 +1,7 @@
 ﻿using EndlessClient.Content;
 using EndlessClient.Dialogs.Services;
 using EndlessClient.HUD.Chat;
+using EndlessClient.UIControls;
 using EOLib;
 using EOLib.Graphics;
 using Microsoft.Xna.Framework;
@@ -40,7 +41,7 @@ namespace EndlessClient.Dialogs
             lblPrompt.Initialize();
             lblPrompt.SetParentControl(this);
 
-            _inputBox = new XNATextBox(new Rectangle(37, 74, 180, 19), Constants.FontSize08, caretTexture: contentProvider.Textures[ContentProvider.Cursor])
+            _inputBox = new ClearableTextBox(new Rectangle(37, 74, 180, 19), Constants.FontSize08, caretTexture: contentProvider.Textures[ContentProvider.Cursor])
             {
                 MaxChars = maxInputChars,
                 LeftPadding = 4,

--- a/EndlessClient/Dialogs/TextInputDialog.cs
+++ b/EndlessClient/Dialogs/TextInputDialog.cs
@@ -67,14 +67,14 @@ namespace EndlessClient.Dialogs
                 new Vector2(41, 103),
                 eoDialogButtonService.GetSmallDialogButtonOutSource(SmallButton.Ok),
                 eoDialogButtonService.GetSmallDialogButtonOverSource(SmallButton.Ok));
-            ok.OnClick += (_, _) => Close(XNADialogResult.OK);
+            ok.OnMouseDown += (_, _) => Close(XNADialogResult.OK);
             ok.SetParentControl(this);
 
             var cancel = new XNAButton(eoDialogButtonService.SmallButtonSheet,
                 new Vector2(134, 103),
                 eoDialogButtonService.GetSmallDialogButtonOutSource(SmallButton.Cancel),
                 eoDialogButtonService.GetSmallDialogButtonOverSource(SmallButton.Cancel));
-            cancel.OnClick += (_, _) => Close(XNADialogResult.Cancel);
+            cancel.OnMouseDown += (_, _) => Close(XNADialogResult.Cancel);
             cancel.SetParentControl(this);
 
             DialogClosed += (_, _) => chatTextBoxActions.FocusChatTextBox();

--- a/EndlessClient/Dialogs/TextMultiInputDialog.cs
+++ b/EndlessClient/Dialogs/TextMultiInputDialog.cs
@@ -48,7 +48,7 @@ namespace EndlessClient.Dialogs
         private readonly Vector2 _rightOverlayDrawPosition;
         private readonly Rectangle _rightOverlaySource;
         private readonly ScrollBar _scrollBar;
-        private readonly XNATextBox[] _inputBoxes;
+        private readonly ClearableTextBox[] _inputBoxes;
         private XNALabel[] _inputLabels;
         private readonly DialogSize _dialogSize;
         private readonly INativeGraphicsManager _nativeGraphicsManager;
@@ -90,7 +90,7 @@ namespace EndlessClient.Dialogs
                     _bottomOverlaySource = new Rectangle(0, 240, 330, 59);
 
                     _inputLabels = new XNALabel[2];
-                    _inputBoxes = new XNATextBox[2];
+                    _inputBoxes = new ClearableTextBox[2];
 
                     okButtonPosition = new Vector2(73, 125);
                     cancelButtonPosition = new Vector2(166, 125);
@@ -109,7 +109,7 @@ namespace EndlessClient.Dialogs
                     _bottomOverlaySource = new Rectangle(0, 240, 330, 59);
 
                     _inputLabels = new XNALabel[3];
-                    _inputBoxes = new XNATextBox[3];
+                    _inputBoxes = new ClearableTextBox[3];
 
                     okButtonPosition = new Vector2(73, 148);
                     cancelButtonPosition = new Vector2(166, 148);
@@ -138,7 +138,7 @@ namespace EndlessClient.Dialogs
                     SetScrollWheelHandler(_scrollBar);
 
                     _inputLabels = new XNALabel[9];
-                    _inputBoxes = new XNATextBox[9];
+                    _inputBoxes = new ClearableTextBox[9];
 
                     okButtonPosition = new Vector2(73, 195);
                     cancelButtonPosition = new Vector2(166, 195);
@@ -182,7 +182,7 @@ namespace EndlessClient.Dialogs
                 };
                 _inputLabels[i].SetParentControl(this);
 
-                _inputBoxes[i] = new XNATextBox(new Rectangle(126, yCoord, 168, 19), Constants.FontSize08, caretTexture: contentProvider.Textures[ContentProvider.Cursor])
+                _inputBoxes[i] = new ClearableTextBox(new Rectangle(126, yCoord, 168, 19), Constants.FontSize08, caretTexture: contentProvider.Textures[ContentProvider.Cursor])
                 {
                     MaxChars = inputInfo[i].MaxChars,
                     LeftPadding = 4,

--- a/EndlessClient/Dialogs/TextMultiInputDialog.cs
+++ b/EndlessClient/Dialogs/TextMultiInputDialog.cs
@@ -232,14 +232,14 @@ namespace EndlessClient.Dialogs
                 okButtonPosition,
                 eoDialogButtonService.GetSmallDialogButtonOutSource(SmallButton.Ok),
                 eoDialogButtonService.GetSmallDialogButtonOverSource(SmallButton.Ok));
-            ok.OnClick += (_, _) => Close(XNADialogResult.OK);
+            ok.OnMouseDown += (_, _) => Close(XNADialogResult.OK);
             ok.SetParentControl(this);
 
             var cancel = new XNAButton(eoDialogButtonService.SmallButtonSheet,
                 cancelButtonPosition,
                 eoDialogButtonService.GetSmallDialogButtonOutSource(SmallButton.Cancel),
                 eoDialogButtonService.GetSmallDialogButtonOverSource(SmallButton.Cancel));
-            cancel.OnClick += (_, _) => Close(XNADialogResult.Cancel);
+            cancel.OnMouseDown += (_, _) => Close(XNADialogResult.Cancel);
             cancel.SetParentControl(this);
 
             DialogClosed += (_, _) => chatTextBoxActions.FocusChatTextBox();

--- a/EndlessClient/Dialogs/TradeDialog.cs
+++ b/EndlessClient/Dialogs/TradeDialog.cs
@@ -140,13 +140,13 @@ namespace EndlessClient.Dialogs
             _ok = new XNAButton(dialogButtonService.SmallButtonSheet, new Vector2(356, 252),
                 dialogButtonService.GetSmallDialogButtonOutSource(SmallButton.Ok),
                 dialogButtonService.GetSmallDialogButtonOverSource(SmallButton.Ok));
-            _ok.OnClick += OkButtonClicked;
+            _ok.OnMouseDown += OkButtonClicked;
             _ok.SetParentControl(this);
 
             _cancel = new XNAButton(dialogButtonService.SmallButtonSheet, new Vector2(449, 252),
                 dialogButtonService.GetSmallDialogButtonOutSource(SmallButton.Cancel),
                 dialogButtonService.GetSmallDialogButtonOverSource(SmallButton.Cancel));
-            _cancel.OnClick += CancelButtonClicked;
+            _cancel.OnMouseDown += CancelButtonClicked;
             _cancel.SetParentControl(this);
 
             _leftItems = new List<ListDialogItem>();

--- a/EndlessClient/EndlessClient.csproj
+++ b/EndlessClient/EndlessClient.csproj
@@ -88,6 +88,6 @@
     <PackageReference Include="MonoGame.Extended.Input" Version="3.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.10" />
-    <PackageReference Include="XNAControls" Version="2.2.0" />
+    <PackageReference Include="XNAControls" Version="2.3.0" />
   </ItemGroup>
 </Project>

--- a/EndlessClient/GameExecution/DebugGameRunner.cs
+++ b/EndlessClient/GameExecution/DebugGameRunner.cs
@@ -1,4 +1,5 @@
 ﻿using AutomaticTypeMapper;
+using EOLib.Config;
 
 namespace EndlessClient.GameExecution
 {
@@ -9,5 +10,12 @@ namespace EndlessClient.GameExecution
     {
         public DebugGameRunner(ITypeRegistry registry, string[] args)
             : base(registry, args) { }
+
+        public override bool SetupDependencies()
+        {
+            var result = base.SetupDependencies();
+            _registry.Resolve<IConfigurationRepository>().DebugCrashes = true;
+            return result;
+        }
     }
 }

--- a/EndlessClient/GameExecution/EndlessGame.cs
+++ b/EndlessClient/GameExecution/EndlessGame.cs
@@ -297,7 +297,7 @@ namespace EndlessClient.GameExecution
             foreach (var xnaControl in _controlSetRepository.CurrentControlSet.AllComponents)
                 xnaControl.Initialize();
         }
-    
+
         private void ShowExceptionDetailDialog(Exception ex)
         {
             var dlg = _scrollingListDialogFactory.Create(Dialogs.DialogType.Message);

--- a/EndlessClient/GameExecution/EndlessGame.cs
+++ b/EndlessClient/GameExecution/EndlessGame.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
 using AutomaticTypeMapper;
 using EndlessClient.Audio;
 using EndlessClient.Content;
@@ -21,8 +18,13 @@ using EOLib.Logger;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
+using EndlessClient.Dialogs.Factories;
+
+#if DEBUG
+using System.Diagnostics;
 using MonoGame.Extended.BitmapFonts;
 using MonoGame.Extended.Input;
+#endif
 
 namespace EndlessClient.GameExecution
 {
@@ -44,6 +46,7 @@ namespace EndlessClient.GameExecution
         private readonly IXnaControlSoundMapper _soundMapper;
         private readonly IFixedTimeStepRepository _fixedTimeStepRepository;
         private readonly IMainButtonController _mainButtonController;
+        private readonly IScrollingListDialogFactory _scrollingListDialogFactory;
 
         private GraphicsDeviceManager _graphicsDeviceManager;
 
@@ -71,7 +74,8 @@ namespace EndlessClient.GameExecution
                            IMfxPlayer mfxPlayer,
                            IXnaControlSoundMapper soundMapper,
                            IFixedTimeStepRepository fixedTimeStepRepository,
-                           IMainButtonController mainButtonController)
+                           IMainButtonController mainButtonController,
+                           IScrollingListDialogFactory scrollingListDialogFactory)
         {
             _windowSizeRepository = windowSizeRepository;
             _contentProvider = contentProvider;
@@ -88,6 +92,7 @@ namespace EndlessClient.GameExecution
             _soundMapper = soundMapper;
             _fixedTimeStepRepository = fixedTimeStepRepository;
             _mainButtonController = mainButtonController;
+            _scrollingListDialogFactory = scrollingListDialogFactory;
 
             _graphicsDeviceManager = new GraphicsDeviceManager(this)
             {
@@ -192,12 +197,11 @@ namespace EndlessClient.GameExecution
 #endif
                 _fixedTimeStepRepository.Tick();
 
-#if !DEBUG
                 try
                 {
                     base.Update(gameTime);
                 }
-                catch
+                catch (Exception ex)
                 {
                     if (_configurationProvider.DebugCrashes)
                     {
@@ -205,12 +209,10 @@ namespace EndlessClient.GameExecution
                     }
                     else
                     {
-                        _mainButtonController.GoToInitialStateAndDisconnect(showLostConnection: true);
+                        _mainButtonController.GoToInitialStateAndDisconnect(showLostConnection: false);
+                        ShowExceptionDetailDialog(ex);
                     }
                 }
-#else
-                base.Update(gameTime);
-#endif
 
                 _lastFrameUpdate = gameTime.TotalGameTime;
             }
@@ -295,6 +297,23 @@ namespace EndlessClient.GameExecution
             //  doesn't call the Initialize() method on any controls, so it must be done here
             foreach (var xnaControl in _controlSetRepository.CurrentControlSet.AllComponents)
                 xnaControl.Initialize();
+        }
+    
+        private void ShowExceptionDetailDialog(Exception ex)
+        {
+            var dlg = _scrollingListDialogFactory.Create(Dialogs.DialogType.Message);
+            dlg.Title = "Unhandled Exception";
+            dlg.Buttons = Dialogs.ScrollingListDialogButtons.Ok;
+            dlg.AddTextAsListItems(
+                _contentProvider.Fonts[Constants.FontSize08pt5],
+                insertLineBreaks: true,
+                linkClickActions: [() => GithubIssueGenerator.FileIssue(ex)],
+                $"Client caused an exception: {ex.Message}",
+                ex.StackTrace,
+                $"Inner exception: {ex.InnerException?.Message ?? "(no inner exception)"}",
+                ex.InnerException?.StackTrace ?? "(no innner stacktrace)",
+                "*Report this exception as a GitHub issue");
+            dlg.ShowDialog();
         }
     }
 }

--- a/EndlessClient/GameExecution/EndlessGame.cs
+++ b/EndlessClient/GameExecution/EndlessGame.cs
@@ -218,7 +218,6 @@ namespace EndlessClient.GameExecution
             }
         }
 
-
         protected override void Draw(GameTime gameTime)
         {
             var isTestMode = _controlSetRepository.CurrentControlSet.GameState == GameStates.TestMode;
@@ -308,10 +307,8 @@ namespace EndlessClient.GameExecution
                 _contentProvider.Fonts[Constants.FontSize08pt5],
                 insertLineBreaks: true,
                 linkClickActions: [() => GithubIssueGenerator.FileIssue(ex)],
-                $"Client caused an exception: {ex.Message}",
-                ex.StackTrace,
-                $"Inner exception: {ex.InnerException?.Message ?? "(no inner exception)"}",
-                ex.InnerException?.StackTrace ?? "(no innner stacktrace)",
+                $"Client caused an exception",
+                ex.ToString(),
                 "*Report this exception as a GitHub issue");
             dlg.ShowDialog();
         }

--- a/EndlessClient/GameExecution/GameRunnerBase.cs
+++ b/EndlessClient/GameExecution/GameRunnerBase.cs
@@ -15,7 +15,7 @@ namespace EndlessClient.GameExecution
 {
     public abstract class GameRunnerBase : IGameRunner
     {
-        private readonly ITypeRegistry _registry;
+        protected readonly ITypeRegistry _registry;
         private readonly string[] _args;
 
         protected GameRunnerBase(ITypeRegistry registry, string[] args)

--- a/EndlessClient/GameExecution/GameStateActions.cs
+++ b/EndlessClient/GameExecution/GameStateActions.cs
@@ -66,18 +66,19 @@ namespace EndlessClient.GameExecution
             RemoveOldComponents(currentSet, nextSet);
             AddNewComponents(nextSet);
 
-            _gameStateRepository.CurrentState = newState;
-            _controlSetRepository.CurrentControlSet = nextSet;
-
-            switch (_gameStateRepository.CurrentState)
+            switch (newState)
             {
                 case GameStates.None:
                 case GameStates.Initial:
                     {
-                        _sfxPlayer.StopLoopingSfx();
+                        if (newState == GameStates.None ||
+                            _gameStateRepository.CurrentState == GameStates.PlayingTheGame)
+                        {
+                            _sfxPlayer.StopLoopingSfx();
 
-                        // this replicates behavior of the vanilla client where returning to the main menu stops playing the background music
-                        _mfxPlayer.StopBackgroundMusic();
+                            // this replicates behavior of the vanilla client where returning to the main menu stops playing the background music
+                            _mfxPlayer.StopBackgroundMusic();
+                        }
                     }
                     break;
                 case GameStates.LoggedIn: _sfxPlayer.PlaySfx(SoundEffectID.Login); break;
@@ -87,6 +88,9 @@ namespace EndlessClient.GameExecution
                     }
                     break;
             }
+
+            _gameStateRepository.CurrentState = newState;
+            _controlSetRepository.CurrentControlSet = nextSet;
         }
 
         public void RefreshCurrentState()

--- a/EndlessClient/GameExecution/GithubIssueGenerator.cs
+++ b/EndlessClient/GameExecution/GithubIssueGenerator.cs
@@ -1,0 +1,79 @@
+﻿using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text.Encodings.Web;
+using System.Text;
+using System;
+
+namespace EndlessClient.GameExecution
+{
+    public static class GithubIssueGenerator
+    {
+        public static void FileIssue(Exception ex)
+        {
+            OpenBrowser(BuildIssueUrl(ex));
+        }
+
+        private static void OpenBrowser(string url)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                Process.Start("xdg-open", url);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                Process.Start("open", url); // Not tested
+            }
+        }
+
+        private static string BuildIssueUrl(Exception ex)
+        {
+            var sb = new StringBuilder("https://github.com/ethanmoffat/EndlessClient/issues/new?");
+
+            sb.Append("labels=bug,userreport");
+            sb.Append($"&title=Unhandled+Client+Exception+Needs+Triage");
+            sb.Append("&assignees=ethanmoffat");
+
+            var body = @$"Thank you for your report! Please fill in the following information to help me better triage/resolve this issue.
+**What were you doing when the exception occurred?**
+<Answer>
+
+**What server were you playing on?**
+<Answer>
+
+**Has this crash occurred for you before?**
+<Answer>
+
+**Expected behavior (other than it not crashing)?**
+<Answer>
+
+*Diagnostic Information added automatically. Please do not delete!*
+
+**Exception message**: {ex.Message}
+**Stack Trace**:
+```
+{ex.StackTrace}
+```";
+
+            if (ex.InnerException != null)
+            {
+                body += @$"
+
+**Inner Exception**: {ex.InnerException.Message}
+**Stack Trace**:
+```
+{ex.InnerException.StackTrace}
+```
+";
+            }
+
+            var encoded = UrlEncoder.Default.Encode(body);
+            sb.Append($"&body={encoded}");
+
+            return sb.ToString();
+        }
+    }
+}

--- a/EndlessClient/HUD/Chat/ChatPanelTab.cs
+++ b/EndlessClient/HUD/Chat/ChatPanelTab.cs
@@ -85,19 +85,19 @@ namespace EndlessClient.HUD.Chat
             DrawArea = GetTabClickableArea();
 
             _tab = new ClickableArea(new Rectangle(0, 0, DrawArea.Width, DrawArea.Height));
-            _tab.OnClick += (_, _) => SelectThisTab();
+            _tab.OnMouseDown += (_, _) => SelectThisTab();
             _tab.SetParentControl(this);
 
             if (Tab == ChatTab.Private1)
             {
                 _closeButton = new ClickableArea(new Rectangle(3, 3, 11, 11));
-                _closeButton.OnClick += (_, _) => CloseTab();
+                _closeButton.OnMouseDown += (_, _) => CloseTab();
                 _closeButton.SetParentControl(this);
             }
             else if (Tab == ChatTab.Private2)
             {
                 _closeButton = new ClickableArea(new Rectangle(3, 3, 11, 11));
-                _closeButton.OnClick += (_, _) => CloseTab();
+                _closeButton.OnMouseDown += (_, _) => CloseTab();
                 _closeButton.SetParentControl(this);
             }
 

--- a/EndlessClient/HUD/Controls/DraggablePanelItem.cs
+++ b/EndlessClient/HUD/Controls/DraggablePanelItem.cs
@@ -83,7 +83,7 @@ namespace EndlessClient.HUD.Controls
             return true;
         }
 
-        protected override bool HandleClick(IXNAControl control, MouseEventArgs eventArgs)
+        protected override bool HandleMouseDown(IXNAControl control, MouseEventArgs eventArgs)
         {
             if (_followMouse)
             {

--- a/EndlessClient/HUD/Controls/HudControlsFactory.cs
+++ b/EndlessClient/HUD/Controls/HudControlsFactory.cs
@@ -301,7 +301,7 @@ namespace EndlessClient.HUD.Controls
                 };
             }
 
-            retButton.OnClick += (_, _) => DoHudStateChangeClick(whichState);
+            retButton.OnMouseDown += (_, _) => DoHudStateChangeClick(whichState);
             retButton.OnMouseEnter += (_, _) => _statusLabelSetter.SetStatusLabel(
                 EOResourceID.STATUS_LABEL_TYPE_BUTTON,
                 EOResourceID.STATUS_LABEL_HUD_BUTTON_HOVER_FIRST + buttonIndex);
@@ -319,8 +319,8 @@ namespace EndlessClient.HUD.Controls
             {
                 DrawOrder = HUD_CONTROL_LAYER + 10
             };
-            button.OnClick += (_, _) => _hudButtonController.ClickFriendList();
-            button.OnClick += (_, _) => _sfxPlayer.PlaySfx(SoundEffectID.ButtonClick);
+            button.OnMouseDown += (_, _) => _hudButtonController.ClickFriendList();
+            button.OnMouseDown += (_, _) => _sfxPlayer.PlaySfx(SoundEffectID.ButtonClick);
             button.OnMouseOver += (o, e) => _statusLabelSetter.SetStatusLabel(EOResourceID.STATUS_LABEL_TYPE_BUTTON, EOResourceID.STATUS_LABEL_FRIEND_LIST);
 
             if (_clientWindowSizeRepository.Resizable)
@@ -342,8 +342,8 @@ namespace EndlessClient.HUD.Controls
             {
                 DrawOrder = HUD_CONTROL_LAYER + 10
             };
-            button.OnClick += (_, _) => _hudButtonController.ClickIgnoreList();
-            button.OnClick += (_, _) => _sfxPlayer.PlaySfx(SoundEffectID.ButtonClick);
+            button.OnMouseDown += (_, _) => _hudButtonController.ClickIgnoreList();
+            button.OnMouseDown += (_, _) => _sfxPlayer.PlaySfx(SoundEffectID.ButtonClick);
             button.OnMouseOver += (o, e) => _statusLabelSetter.SetStatusLabel(EOResourceID.STATUS_LABEL_TYPE_BUTTON, EOResourceID.STATUS_LABEL_IGNORE_LIST);
 
             if (_clientWindowSizeRepository.Resizable)
@@ -471,8 +471,8 @@ namespace EndlessClient.HUD.Controls
             {
                 DrawOrder = HUD_CONTROL_LAYER
             };
-            btn.OnClick += (_, _) => _hudButtonController.ClickSessionExp();
-            btn.OnClick += (_, _) => _sfxPlayer.PlaySfx(SoundEffectID.HudStatusBarClick);
+            btn.OnMouseDown += (_, _) => _hudButtonController.ClickSessionExp();
+            btn.OnMouseDown += (_, _) => _sfxPlayer.PlaySfx(SoundEffectID.HudStatusBarClick);
             return btn;
         }
 
@@ -486,8 +486,8 @@ namespace EndlessClient.HUD.Controls
             {
                 DrawOrder = HUD_CONTROL_LAYER
             };
-            btn.OnClick += (_, _) => _hudButtonController.ClickQuestStatus();
-            btn.OnClick += (_, _) => _sfxPlayer.PlaySfx(SoundEffectID.HudStatusBarClick);
+            btn.OnMouseDown += (_, _) => _hudButtonController.ClickQuestStatus();
+            btn.OnMouseDown += (_, _) => _sfxPlayer.PlaySfx(SoundEffectID.HudStatusBarClick);
             return btn;
         }
 

--- a/EndlessClient/HUD/Inventory/InventoryPanelItem.cs
+++ b/EndlessClient/HUD/Inventory/InventoryPanelItem.cs
@@ -168,7 +168,7 @@ namespace EndlessClient.HUD.Inventory
             if (IsDragging)
             {
                 // roll back the first click in the double click
-                base.HandleClick(control, eventArgs);
+                base.HandleMouseDown(control, eventArgs);
             }
 
             DoubleClick?.Invoke(control, Data);

--- a/EndlessClient/HUD/Panels/ActiveSpellsPanel.cs
+++ b/EndlessClient/HUD/Panels/ActiveSpellsPanel.cs
@@ -602,10 +602,11 @@ namespace EndlessClient.HUD.Panels
         private void SaveSpellsFile(object sender, ExitingEventArgs e)
         {
             var spells = new IniReader(Constants.SpellsFile);
+            var spellsKey = $"{_configProvider.Host}:{_playerInfoProvider.LoggedInAccountName}";
 
-            var section = spells.Load() && spells.Sections.ContainsKey(_playerInfoProvider.LoggedInAccountName)
-                ? spells.Sections[_playerInfoProvider.LoggedInAccountName]
-                : new SortedList<string, string>();
+            var section = spells.Load() && spells.Sections.ContainsKey(spellsKey)
+                ? spells.Sections[spellsKey]
+                : [];
 
             var existing = section.Where(x => x.Key.Contains(_characterProvider.MainCharacter.Name)).Select(x => x.Key).ToList();
             foreach (var key in existing)
@@ -614,7 +615,7 @@ namespace EndlessClient.HUD.Panels
             foreach (var item in _childItems.OfType<SpellPanelItem>())
                 section[$"{_characterProvider.MainCharacter.Name}.{item.Slot}"] = $"{item.InventorySpell.ID}";
 
-            spells.Sections[_playerInfoProvider.LoggedInAccountName] = section;
+            spells.Sections[spellsKey] = section;
 
             spells.Save();
         }

--- a/EndlessClient/HUD/Panels/ActiveSpellsPanel.cs
+++ b/EndlessClient/HUD/Panels/ActiveSpellsPanel.cs
@@ -143,14 +143,14 @@ namespace EndlessClient.HUD.Panels
                 FlashSpeed = 500,
                 Visible = false
             };
-            _levelUpButton1.OnClick += LevelUp_Click;
+            _levelUpButton1.OnMouseDown += LevelUp_Click;
 
             _levelUpButton2 = new XNAButton(buttonSheet, new Vector2(71, 95), new Rectangle(215, 386, 19, 15), new Rectangle(234, 386, 19, 15))
             {
                 FlashSpeed = 500,
                 Visible = false
             };
-            _levelUpButton2.OnClick += LevelUp_Click;
+            _levelUpButton2.OnMouseDown += LevelUp_Click;
 
             _scrollBar = new ScrollBar(new Vector2(467, 2), new Vector2(16, 115), ScrollBarColors.LightOnMed, NativeGraphicsManager)
             {

--- a/EndlessClient/HUD/Panels/ChatPanel.cs
+++ b/EndlessClient/HUD/Panels/ChatPanel.cs
@@ -135,14 +135,14 @@ namespace EndlessClient.HUD.Panels
             _tabs[whichTab].CloseTab();
         }
 
-        protected override bool HandleClick(IXNAControl control, MouseEventArgs eventArgs)
+        protected override bool HandleMouseDown(IXNAControl control, MouseEventArgs eventArgs)
         {
             if (eventArgs.Button == MouseButton.Right)
             {
                 _tabs[CurrentTab].HandleRightClick(eventArgs);
             }
 
-            return base.HandleClick(control, eventArgs);
+            return base.HandleMouseDown(control, eventArgs);
         }
     }
 }

--- a/EndlessClient/HUD/Panels/DraggableHudPanel.cs
+++ b/EndlessClient/HUD/Panels/DraggableHudPanel.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using EndlessClient.Rendering;
 using MonoGame.Extended.Input.InputListeners;
 using Optional;
 using XNAControls;
@@ -21,7 +20,7 @@ namespace EndlessClient.HUD.Panels
             _enableDragging = enableDragging;
         }
 
-        protected override bool HandleClick(IXNAControl control, MouseEventArgs eventArgs)
+        protected override bool HandleMouseDown(IXNAControl control, MouseEventArgs eventArgs)
         {
             Activated?.Invoke();
             return true;

--- a/EndlessClient/HUD/Panels/InventoryPanel.cs
+++ b/EndlessClient/HUD/Panels/InventoryPanel.cs
@@ -109,8 +109,6 @@ namespace EndlessClient.HUD.Panels
                 AutoSize = false
             };
 
-            _inventorySlotRepository.SlotMap = GetItemSlotMap(_playerInfoProvider.LoggedInAccountName, _characterProvider.MainCharacter.Name, _configProvider.Host);
-
             var weirdOffsetSheet = NativeGraphicsManager.TextureFromResource(GFXTypes.PostLoginUI, 27);
 
             _paperdoll = new XNAButton(weirdOffsetSheet, new Vector2(385, 9), new Rectangle(39, 385, 88, 19), new Rectangle(126, 385, 88, 19));
@@ -154,8 +152,8 @@ namespace EndlessClient.HUD.Panels
             _junk.Initialize();
             _junk.SetParentControl(this);
 
+            _inventorySlotRepository.SlotMap = GetItemSlotMap(_playerInfoProvider.LoggedInAccountName, _characterProvider.MainCharacter.Name, _configProvider.Host);
             OnUpdateControl(new GameTime());
-            _inventorySlotRepository.SlotMap.Clear();
 
             base.Initialize();
         }

--- a/EndlessClient/HUD/Panels/InventoryPanel.cs
+++ b/EndlessClient/HUD/Panels/InventoryPanel.cs
@@ -113,7 +113,7 @@ namespace EndlessClient.HUD.Panels
 
             _paperdoll = new XNAButton(weirdOffsetSheet, new Vector2(385, 9), new Rectangle(39, 385, 88, 19), new Rectangle(126, 385, 88, 19));
             _paperdoll.OnMouseEnter += MouseOverButton;
-            _paperdoll.OnClick += (_, _) =>
+            _paperdoll.OnMouseDown += (_, _) =>
             {
                 _inventoryController.ShowPaperdollDialog();
                 _sfxPlayer.PlaySfx(SoundEffectID.ButtonClick);
@@ -121,11 +121,11 @@ namespace EndlessClient.HUD.Panels
 
             _drop = new XNAButton(weirdOffsetSheet, new Vector2(389, 68), new Rectangle(0, 15, 38, 37), new Rectangle(0, 52, 38, 37));
             _drop.OnMouseEnter += MouseOverButton;
-            _drop.OnClick += (_, _) => _sfxPlayer.PlaySfx(SoundEffectID.InventoryPlace);
+            _drop.OnMouseDown += (_, _) => _sfxPlayer.PlaySfx(SoundEffectID.InventoryPlace);
 
             _junk = new XNAButton(weirdOffsetSheet, new Vector2(431, 68), new Rectangle(0, 89, 38, 37), new Rectangle(0, 126, 38, 37));
             _junk.OnMouseEnter += MouseOverButton;
-            _junk.OnClick += (_, _) => _sfxPlayer.PlaySfx(SoundEffectID.InventoryPlace);
+            _junk.OnMouseDown += (_, _) => _sfxPlayer.PlaySfx(SoundEffectID.InventoryPlace);
 
             _cachedStats = Option.None<CharacterStats>();
             _cachedInventory = new HashSet<InventoryItem>();

--- a/EndlessClient/HUD/Panels/OnlineListPanel.cs
+++ b/EndlessClient/HUD/Panels/OnlineListPanel.cs
@@ -102,7 +102,7 @@ namespace EndlessClient.HUD.Panels
 
             _filterClickArea = new ClickableArea(new Rectangle(2, 2, 14, 14));
             _filterClickArea.SetParentControl(this);
-            _filterClickArea.OnClick += FilterClickArea_Click;
+            _filterClickArea.OnMouseDown += FilterClickArea_Click;
 
             _weirdOffsetTextureSheet = _nativeGraphicsManager.TextureFromResource(GFXTypes.PostLoginUI, 27, true);
             _chatIconsTexture = _nativeGraphicsManager.TextureFromResource(GFXTypes.PostLoginUI, 32, true);
@@ -182,7 +182,7 @@ namespace EndlessClient.HUD.Panels
             _spriteBatch.End();
         }
 
-        protected override bool HandleClick(IXNAControl control, MouseEventArgs eventArgs)
+        protected override bool HandleMouseDown(IXNAControl control, MouseEventArgs eventArgs)
         {
             if (eventArgs.Button != MouseButton.Right)
                 return false;

--- a/EndlessClient/HUD/Panels/SettingsPanel.cs
+++ b/EndlessClient/HUD/Panels/SettingsPanel.cs
@@ -115,7 +115,7 @@ namespace EndlessClient.HUD.Panels
             foreach (var pair in _buttons)
             {
                 var button = pair.Value;
-                button.OnClick += (_, _) => SettingChange(pair.Key);
+                button.OnMouseDown += (_, _) => SettingChange(pair.Key);
                 button.OnMouseEnter += (_, _) => _statusLabelSetter.SetStatusLabel(EOResourceID.STATUS_LABEL_TYPE_BUTTON, EOResourceID.STATUS_LABEL_SETTINGS_CLICK_TO_CHANGE);
                 button.SetParentControl(this);
                 button.Initialize();

--- a/EndlessClient/HUD/Panels/StatsPanel.cs
+++ b/EndlessClient/HUD/Panels/StatsPanel.cs
@@ -138,7 +138,7 @@ namespace EndlessClient.HUD.Panels
         public override void Initialize()
         {
             foreach (var control in _arrowButtons)
-                control.OnClick += HandleArrowButtonClick;
+                control.OnMouseDown += HandleArrowButtonClick;
 
             var controls = _basicStats.Concat<IXNAControl>(_characterStats)
                                       .Concat(_arrowButtons)

--- a/EndlessClient/HUD/Party/PartyPanelMember.cs
+++ b/EndlessClient/HUD/Party/PartyPanelMember.cs
@@ -71,7 +71,7 @@ namespace EndlessClient.HUD.Party
                     : new Rectangle(0, delta, removeTexture.Width, delta));
 
             if (isRemovable)
-                _removeButton.OnClick += (o, e) => RemoveAction?.Invoke(o, e);
+                _removeButton.OnMouseDown += (o, e) => RemoveAction?.Invoke(o, e);
             _removeButton.SetParentControl(this);
 
             _nameLabel = new XNALabel(Constants.FontSize08)

--- a/EndlessClient/HUD/Spells/SpellPanelItem.cs
+++ b/EndlessClient/HUD/Spells/SpellPanelItem.cs
@@ -97,13 +97,13 @@ namespace EndlessClient.HUD.Spells
             base.OnDrawControl(gameTime);
         }
 
-        protected override bool HandleClick(IXNAControl control, MouseEventArgs eventArgs)
+        protected override bool HandleMouseDown(IXNAControl control, MouseEventArgs eventArgs)
         {
             if (_parentContainer.NoItemsDragging())
                 _sfxPlayer.PlaySfx(SoundEffectID.InventoryPickup);
 
             Click?.Invoke(control, eventArgs);
-            return base.HandleClick(control, eventArgs);
+            return base.HandleMouseDown(control, eventArgs);
         }
 
         protected override bool HandleDragStart(IXNAControl control, MouseEventArgs eventArgs)

--- a/EndlessClient/HUD/StatusBars/StatusBarBase.cs
+++ b/EndlessClient/HUD/StatusBars/StatusBarBase.cs
@@ -100,7 +100,7 @@ namespace EndlessClient.HUD.StatusBars
             base.OnDrawControl(gameTime);
         }
 
-        protected override bool HandleClick(IXNAControl control, MouseEventArgs eventArgs)
+        protected override bool HandleMouseDown(IXNAControl control, MouseEventArgs eventArgs)
         {
             _label.Visible = !_label.Visible;
             _labelShowTime = _label.SomeWhen(x => x.Visible).Map(_ => DateTime.Now);

--- a/EndlessClient/Rendering/ContextMenuRenderer.cs
+++ b/EndlessClient/Rendering/ContextMenuRenderer.cs
@@ -214,7 +214,7 @@ namespace EndlessClient.Rendering
             }
         }
 
-        protected override bool HandleClick(IXNAControl control, MouseEventArgs eventArgs)
+        protected override bool HandleMouseDown(IXNAControl control, MouseEventArgs eventArgs)
         {
             if (eventArgs.Button == MouseButton.Left)
             {

--- a/EndlessClient/Rendering/Map/ClickDispatcher.cs
+++ b/EndlessClient/Rendering/Map/ClickDispatcher.cs
@@ -75,7 +75,7 @@ namespace EndlessClient.Rendering.Map
             _npcInteractionController = npcInteractionController;
         }
 
-        protected override bool HandleClick(IXNAControl control, MouseEventArgs eventArgs)
+        protected override bool HandleMouseDown(IXNAControl control, MouseEventArgs eventArgs)
         {
             _contextMenuRepository.ContextMenu.MatchSome(contextMenu =>
             {

--- a/EndlessClient/UIControls/CharacterInfoPanel.cs
+++ b/EndlessClient/UIControls/CharacterInfoPanel.cs
@@ -154,7 +154,19 @@ namespace EndlessClient.UIControls
             if (_activeTask == null)
             {
                 _activeTask = clickHandler();
-                _activeTask.ContinueWith(_ => _activeTask = null);
+                _activeTask.ContinueWith(t =>
+                {
+                    _activeTask = null;
+
+                    if (t.IsFaulted)
+                    {
+                        // Invoke any exception on the main game thread
+                        // Exceptions thrown by tasks are quietly swallowed
+                        // Invoking this on the main thread ensures the Update() loop catches it and handles it
+                        //   in the global exception handler (see EndlessGame::Update)
+                        Task.Run(DispatcherGameComponent.Invoke(() => throw t.Exception).RunSynchronously);
+                    }
+                });
             }
         }
 

--- a/EndlessClient/UIControls/CharacterInfoPanel.cs
+++ b/EndlessClient/UIControls/CharacterInfoPanel.cs
@@ -53,14 +53,14 @@ namespace EndlessClient.UIControls
                 new Vector2(161, 57),
                 dialogButtonService.GetSmallDialogButtonOutSource(SmallButton.Login),
                 dialogButtonService.GetSmallDialogButtonOverSource(SmallButton.Login));
-            _loginButton.OnClick += (o, e) => AsyncButtonClick(() => _loginController.LoginToCharacter(_character));
+            _loginButton.OnMouseDown += (o, e) => AsyncButtonClick(() => _loginController.LoginToCharacter(_character));
             _loginButton.SetParentControl(this);
 
             _deleteButton = new XNAButton(dialogButtonService.SmallButtonSheet,
                 new Vector2(161, 85),
                 dialogButtonService.GetSmallDialogButtonOutSource(SmallButton.Delete),
                 dialogButtonService.GetSmallDialogButtonOverSource(SmallButton.Delete));
-            _deleteButton.OnClick += (o, e) => AsyncButtonClick(() => _characterManagementController.DeleteCharacter(_character));
+            _deleteButton.OnMouseDown += (o, e) => AsyncButtonClick(() => _characterManagementController.DeleteCharacter(_character));
             _deleteButton.SetParentControl(this);
 
             _backgroundImage = _gfxManager.TextureFromResource(GFXTypes.PreLoginUI, 11);

--- a/EndlessClient/UIControls/CharacterInfoPanel.cs
+++ b/EndlessClient/UIControls/CharacterInfoPanel.cs
@@ -154,19 +154,12 @@ namespace EndlessClient.UIControls
             if (_activeTask == null)
             {
                 _activeTask = clickHandler();
-                _activeTask.ContinueWith(t =>
-                {
-                    _activeTask = null;
-
-                    if (t.IsFaulted)
+                _activeTask
+                    .ContinueWith(t =>
                     {
-                        // Invoke any exception on the main game thread
-                        // Exceptions thrown by tasks are quietly swallowed
-                        // Invoking this on the main thread ensures the Update() loop catches it and handles it
-                        //   in the global exception handler (see EndlessGame::Update)
-                        Task.Run(DispatcherGameComponent.Invoke(() => throw t.Exception).RunSynchronously);
-                    }
-                });
+                        _activeTask = null;
+                        t.ThrowIfFaulted();
+                    });
             }
         }
 

--- a/EndlessClient/UIControls/CharacterInfoPanel.cs
+++ b/EndlessClient/UIControls/CharacterInfoPanel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using EndlessClient.Audio;
 using EndlessClient.Controllers;
 using EndlessClient.Dialogs.Services;
 using EndlessClient.Input;
@@ -29,6 +30,7 @@ namespace EndlessClient.UIControls
         private readonly ISpriteSheet _adminGraphic;
         private readonly IUserInputProvider _userInputProvider;
         private readonly IXnaControlSoundMapper _xnaControlSoundMapper;
+        private readonly ISfxPlayer _sfxPlayer;
         private readonly Texture2D _backgroundImage;
 
         private readonly IXNAButton _loginButton, _deleteButton;
@@ -74,7 +76,8 @@ namespace EndlessClient.UIControls
                                   ICharacterRendererFactory rendererFactory,
                                   IRendererRepositoryResetter rendererRepositoryResetter,
                                   IUserInputProvider userInputProvider,
-                                  IXnaControlSoundMapper xnaControlSoundMapper)
+                                  IXnaControlSoundMapper xnaControlSoundMapper,
+                                  ISfxPlayer sfxPlayer)
             : this(characterIndex, gfxManager, dialogButtonService)
         {
             _character = character;
@@ -83,6 +86,7 @@ namespace EndlessClient.UIControls
             _rendererRepositoryResetter = rendererRepositoryResetter;
             _userInputProvider = userInputProvider;
             _xnaControlSoundMapper = xnaControlSoundMapper;
+            _sfxPlayer = sfxPlayer;
 
             _characterControl = new CharacterControl(character, rendererFactory)
             {
@@ -172,6 +176,7 @@ namespace EndlessClient.UIControls
             if (currentKeyState.IsKeyPressedOnce(previousKeyState, Keys.D1 + _characterIndex) &&
                 !Game.Components.OfType<IXNADialog>().Any())
             {
+                _sfxPlayer.PlaySfx(SoundEffectID.ButtonClick);
                 AsyncButtonClick(() => _loginController.LoginToCharacter(_character));
             }
         }

--- a/EndlessClient/UIControls/CharacterInfoPanelFactory.cs
+++ b/EndlessClient/UIControls/CharacterInfoPanelFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using AutomaticTypeMapper;
+using EndlessClient.Audio;
 using EndlessClient.Controllers;
 using EndlessClient.Dialogs.Services;
 using EndlessClient.Input;
@@ -20,6 +21,8 @@ namespace EndlessClient.UIControls
         private readonly IEODialogButtonService _eoDialogButtonService;
         private readonly IUserInputProvider _userInputProvider;
         private readonly IXnaControlSoundMapper _xnaControlSoundMapper;
+        private readonly ISfxPlayer _sfxPlayer;
+
         private ILoginController _loginController;
         private ICharacterManagementController _characterManagementController;
 
@@ -28,7 +31,8 @@ namespace EndlessClient.UIControls
                                          IRendererRepositoryResetter rendererRepositoryResetter,
                                          IEODialogButtonService eoDialogButtonService,
                                          IUserInputProvider userInputProvider,
-                                         IXnaControlSoundMapper xnaControlSoundMapper)
+                                         IXnaControlSoundMapper xnaControlSoundMapper,
+                                         ISfxPlayer sfxPlayer)
         {
             _nativeGraphicsManager = nativeGraphicsManager;
             _characterRendererFactory = characterRendererFactory;
@@ -36,6 +40,7 @@ namespace EndlessClient.UIControls
             _eoDialogButtonService = eoDialogButtonService;
             _userInputProvider = userInputProvider;
             _xnaControlSoundMapper = xnaControlSoundMapper;
+            _sfxPlayer = sfxPlayer;
         }
 
         public void InjectLoginController(ILoginController loginController)
@@ -65,7 +70,8 @@ namespace EndlessClient.UIControls
                                                     _characterRendererFactory,
                                                     _rendererRepositoryResetter,
                                                     _userInputProvider,
-                                                    _xnaControlSoundMapper);
+                                                    _xnaControlSoundMapper,
+                                                    _sfxPlayer);
             }
 
             for (; i < 3; ++i)

--- a/EndlessClient/UIControls/ChatTextBox.cs
+++ b/EndlessClient/UIControls/ChatTextBox.cs
@@ -8,14 +8,13 @@ using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using MonoGame.Extended.Input.InputListeners;
 using Optional;
-using XNAControls;
 
 namespace EndlessClient.UIControls
 {
     /// <summary>
     /// Special instance of an XNATextBox that should ignore input from the number pad (which is used for Emotes)
     /// </summary>
-    public class ChatTextBox : XNATextBox
+    public class ChatTextBox : ClearableTextBox
     {
         private readonly INativeGraphicsManager _nativeGraphicsManager;
         private readonly IClientWindowSizeProvider _clientWindowSizeProvider;
@@ -114,25 +113,15 @@ namespace EndlessClient.UIControls
             if (_ignoreAllInput)
                 return false;
 
-            if (IsSpecialInput(eventArgs.Key, eventArgs.Modifiers))
-                HandleSpecialInput(eventArgs.Key);
-            else
+            if (!IsSpecialInput(eventArgs.Key, eventArgs.Modifiers))
                 base.HandleTextInput(eventArgs);
 
             return true;
         }
 
-        private void HandleSpecialInput(Keys key)
-        {
-            if (key == Keys.Escape)
-                Text = "";
-        }
-
         private bool IsSpecialInput(Keys k, KeyboardModifiers modifiers)
         {
-            return k == Keys.Escape || k == Keys.Decimal ||
-                   (k >= Keys.NumPad0 && k <= Keys.NumPad9) ||
-                   modifiers == KeyboardModifiers.Alt;
+            return k == Keys.Decimal || (k >= Keys.NumPad0 && k <= Keys.NumPad9) || modifiers == KeyboardModifiers.Alt;
         }
     }
 }

--- a/EndlessClient/UIControls/ClearableTextBox.cs
+++ b/EndlessClient/UIControls/ClearableTextBox.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+using MonoGame.Extended.Input.InputListeners;
+using XNAControls;
+
+namespace EndlessClient.UIControls
+{
+    public class ClearableTextBox : XNATextBox
+    {
+        public ClearableTextBox(Rectangle area,
+                                string spriteFontContentName,
+                                Texture2D backgroundTexture = null,
+                                Texture2D leftSideTexture = null,
+                                Texture2D rightSideTexture = null,
+                                Texture2D caretTexture = null)
+            : base(area, spriteFontContentName, backgroundTexture, leftSideTexture, rightSideTexture, caretTexture)
+        {
+        }
+
+        protected override bool HandleKeyPressed(IXNAControl control, KeyboardEventArgs eventArgs)
+        {
+            if (control != this)
+                return false;
+
+            if (eventArgs.Key == Keys.Escape && Selected)
+            {
+                Text = string.Empty;
+                return true;
+            }
+
+            return base.HandleKeyPressed(control, eventArgs);
+        }
+    }
+}

--- a/EndlessClient/UIControls/ClickableArea.cs
+++ b/EndlessClient/UIControls/ClickableArea.cs
@@ -19,6 +19,10 @@ namespace EndlessClient.UIControls
             set => throw new InvalidOperationException("Unable to get flash speed on clickable area");
         }
 
+        public event EventHandler<MouseEventArgs> OnMouseDown;
+
+        public event EventHandler<MouseEventArgs> OnMouseUp;
+
         public event EventHandler<MouseEventArgs> OnClick;
 
         public event EventHandler<MouseEventArgs> OnClickDrag
@@ -30,6 +34,18 @@ namespace EndlessClient.UIControls
         public ClickableArea(Rectangle area)
         {
             ClickArea = area;
+        }
+
+        protected override bool HandleMouseDown(IXNAControl control, MouseEventArgs eventArgs)
+        {
+            OnMouseDown?.Invoke(control, eventArgs);
+            return true;
+        }
+
+        protected override bool HandleMouseUp(IXNAControl control, MouseEventArgs eventArgs)
+        {
+            OnMouseUp?.Invoke(control, eventArgs);
+            return true;
         }
 
         protected override bool HandleClick(IXNAControl control, MouseEventArgs eventArgs)

--- a/EndlessClient/UIControls/CreateCharacterControl.cs
+++ b/EndlessClient/UIControls/CreateCharacterControl.cs
@@ -43,7 +43,7 @@ namespace EndlessClient.UIControls
             _lastPosition = actualDrawPosition;
         }
 
-        protected override bool HandleClick(IXNAControl control, MouseEventArgs eventArgs)
+        protected override bool HandleMouseDown(IXNAControl control, MouseEventArgs eventArgs)
         {
             var nextDirectionInt = (int)RenderProperties.Direction + 1;
             var nextDirection = (EODirection)(nextDirectionInt % 4);

--- a/EndlessClient/UIControls/ScrollBar.cs
+++ b/EndlessClient/UIControls/ScrollBar.cs
@@ -71,11 +71,11 @@ namespace EndlessClient.UIControls
             var scrollBox = new Rectangle(0, vertOff, 16, 15);
 
             _upButton = new XNAButton(scrollSpriteSheet, Vector2.Zero, upArrows[0], upArrows[1]);
-            _upButton.OnClick += arrowClicked;
+            _upButton.OnMouseDown += arrowClicked;
             _upButton.SetParentControl(this);
 
             _downButton = new XNAButton(scrollSpriteSheet, new Vector2(0, size.Y - 15), downArrows[0], downArrows[1]);
-            _downButton.OnClick += arrowClicked;
+            _downButton.OnMouseDown += arrowClicked;
             _downButton.SetParentControl(this);
 
             _scrollButton = new XNAButton(scrollSpriteSheet, new Vector2(0, 15), scrollBox, scrollBox);

--- a/EndlessClient/UIControls/XnaControlSoundMapper.cs
+++ b/EndlessClient/UIControls/XnaControlSoundMapper.cs
@@ -27,7 +27,7 @@ namespace EndlessClient.UIControls
         }
 
         private void SetupSound(IXNAButton button) => SetupSpecificSound(button, SoundEffectID.ButtonClick);
-        private void SetupSpecificSound(IXNAButton button, SoundEffectID sound) => button.OnClick += (_, _) => _sfxPlayer.PlaySfx(sound);
+        private void SetupSpecificSound(IXNAButton button, SoundEffectID sound) => button.OnMouseDown += (_, _) => _sfxPlayer.PlaySfx(sound);
 
         private void SetupSound(IXNATextBox textBox) => SetupSpecificSound(textBox, SoundEffectID.TextBoxFocus);
         private void SetupSpecificSound(IXNATextBox textBox, SoundEffectID sound) => textBox.OnGotFocus += (_, _) => _sfxPlayer.PlaySfx(sound);


### PR DESCRIPTION
Thanks @cirras for testing! This fixes the following discovered issues:

- Quick repeated click events not activating
    - cause: DoubleClick event was suppressing normal clicks
    - fix: Use MouseDown events for all clicks instead of MouseClick (see next bullet)
- Vanilla client uses MouseDown while EndlessClient uses MouseClick
    - fix: Implement detection of MouseDown, replace MouseClick event handlers with MouseDown handlers
- ESC doesn't clear input boxes
    - fix: Implement KeyPress/KeyRelease event handling, detect Esc key via base ClearableTextBox class in EndlessClient
- Selecting character via keyboard shortcut doesn't play a sound
    - fix: Add sfxPlayer call to keyboard shortcut
- Returning to main menu stops background music
    - fix: Only stop background music on transition from `PlayingTheGame` state
- Unable to get past character select screen
    - fix: TBD
    - improved error handling for async tasks and pop up friendly error message dialog with GitHub report link