### PR TITLE
Use built-in analyzer for code formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -229,6 +229,7 @@ dotnet_naming_style.begins_with_i.required_prefix = I
 dotnet_naming_style.begins_with_i.required_suffix = 
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
+csharp_prefer_system_threading_lock = true:suggestion
 
 [*.{cs,vb}]
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
@@ -267,3 +268,6 @@ dotnet_style_qualification_for_field = false:silent
 dotnet_style_qualification_for_property = false:silent
 dotnet_style_qualification_for_method = false:silent
 dotnet_style_qualification_for_event = false:silent
+
+dotnet_diagnostic.IDE1006.severity = error
+dotnet_diagnostic.IDE0055.severity = error

--- a/BatchMap/BatchMap.csproj
+++ b/BatchMap/BatchMap.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputPath>..\bin\$(Configuration)\utils\BatchMap</OutputPath>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
     <DefineConstants>$(DefineConstants);LINUX</DefineConstants>

--- a/EOBot/EOBot.csproj
+++ b/EOBot/EOBot.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputPath>..\bin\$(Configuration)\utils\EOBot\</OutputPath>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\EOLib.Config\EOLib.Config.csproj" />

--- a/EOLib.Config/EOLib.Config.csproj
+++ b/EOLib.Config/EOLib.Config.csproj
@@ -5,6 +5,7 @@
     <OutputType>Library</OutputType>
     <OutputPath>..\bin\$(Configuration)\lib\</OutputPath>
     <Description>Library for interacting with Endless Online configuration files</Description>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
     <DefineConstants>$(DefineConstants);LINUX</DefineConstants>

--- a/EOLib.Graphics/EOLib.Graphics.csproj
+++ b/EOLib.Graphics/EOLib.Graphics.csproj
@@ -6,6 +6,7 @@
     <OutputPath>..\bin\$(Configuration)\lib\</OutputPath>
     <Description>Library for interacting with Endless Online gfx files</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
     <DefineConstants>$(DefineConstants);LINUX</DefineConstants>

--- a/EOLib.IO/EOLib.IO.csproj
+++ b/EOLib.IO/EOLib.IO.csproj
@@ -5,6 +5,7 @@
     <OutputType>Library</OutputType>
     <OutputPath>..\bin\$(Configuration)\lib\</OutputPath>
     <Description>Library for interacting with Endless Online pub and map files</Description>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
     <DefineConstants>$(DefineConstants);LINUX</DefineConstants>

--- a/EOLib.Localization/EOLib.Localization.csproj
+++ b/EOLib.Localization/EOLib.Localization.csproj
@@ -5,6 +5,7 @@
     <OutputType>Library</OutputType>
     <OutputPath>..\bin\$(Configuration)\lib\</OutputPath>
     <Description>Library for interacting with Endless Online edf files</Description>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
     <DefineConstants>$(DefineConstants);LINUX</DefineConstants>

--- a/EOLib.Logger/EOLib.Logger.csproj
+++ b/EOLib.Logger/EOLib.Logger.csproj
@@ -5,6 +5,7 @@
     <OutputType>Library</OutputType>
     <OutputPath>..\bin\$(Configuration)\lib\</OutputPath>
     <Description>Library for interacting with Endless Online log files</Description>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
     <DefineConstants>$(DefineConstants);LINUX</DefineConstants>

--- a/EOLib.Shared/EOLib.Shared.csproj
+++ b/EOLib.Shared/EOLib.Shared.csproj
@@ -7,6 +7,7 @@
     <OutputPath>..\bin\$(Configuration)\lib\</OutputPath>
     <Nullable>enable</Nullable>
     <Description>Base library for Endless Online development</Description>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
     <DefineConstants>$(DefineConstants);LINUX</DefineConstants>

--- a/EOLib.Shared/PathResolver.cs
+++ b/EOLib.Shared/PathResolver.cs
@@ -1,6 +1,6 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Runtime.InteropServices;
-using System;
 
 namespace EOLib.Shared
 {

--- a/EOLib/EOLib.csproj
+++ b/EOLib/EOLib.csproj
@@ -6,6 +6,7 @@
     <OutputType>Library</OutputType>
     <OutputPath>..\bin\$(Configuration)\lib\</OutputPath>
     <Description>Base library for Endless Online development</Description>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
     <DefineConstants>$(DefineConstants);LINUX</DefineConstants>

--- a/EOLib/PacketHandlers/Guild/GuildReplyHandler.cs
+++ b/EOLib/PacketHandlers/Guild/GuildReplyHandler.cs
@@ -87,7 +87,6 @@ namespace EOLib.PacketHandlers.Guild
                             var updatedMemberList = new HashSet<string>(creationSession.Members) { data.Name };
                             _guildSessionRepository.CreationSession = Option.Some(creationSession.WithMembers(updatedMemberList));
                         });
-                        
                         break;
                     }
                 case GuildReply.JoinRequest:

--- a/EndlessClient.sln
+++ b/EndlessClient.sln
@@ -39,6 +39,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EndlessClient", "EndlessCli
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EOLib.Shared", "EOLib.Shared\EOLib.Shared.csproj", "{A71336EE-BAD7-4C90-87ED-A0B3A7A79EDA}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Editor", "Editor", "{D9B4D0D9-6792-4679-B2D3-1AC5105FD8CC}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/EndlessClient/EndlessClient.csproj
+++ b/EndlessClient/EndlessClient.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="dotnet format ./EndlessClient.csproj --verify-no-changes" />
-  </Target>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
@@ -34,6 +31,7 @@
     <OutputPath>..\bin\$(Configuration)\client</OutputPath>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
     <EndlessClientBinariesPackageVersion>1.4.0.2</EndlessClientBinariesPackageVersion>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Resources\Game.ico</ApplicationIcon>

--- a/EndlessClient/HUD/AStarPathFinder.cs
+++ b/EndlessClient/HUD/AStarPathFinder.cs
@@ -30,7 +30,7 @@ namespace EndlessClient.HUD
 
             var guessScores = new Dictionary<MapCoordinate, int>
             {
-                { start, heuristic(start, finish) }
+                { start, Heuristic(start, finish) }
             };
 
             while (openSet.Any())
@@ -47,10 +47,10 @@ namespace EndlessClient.HUD
                 }
 
                 if (current.Equals(finish))
-                    return reconstructPath(start, cameFrom, current);
+                    return ReconstructPath(start, cameFrom, current);
 
                 openSet.Remove(current);
-                foreach (var neighbor in getNeighbors(current))
+                foreach (var neighbor in GetNeighbors(current))
                 {
                     var tentativeScore = scores[current] + 1;
                     if (!scores.TryGetValue(neighbor, out var _))
@@ -60,7 +60,7 @@ namespace EndlessClient.HUD
                     {
                         cameFrom[neighbor] = current;
                         scores[neighbor] = tentativeScore;
-                        guessScores[neighbor] = tentativeScore + heuristic(neighbor, finish);
+                        guessScores[neighbor] = tentativeScore + Heuristic(neighbor, finish);
 
                         if (!openSet.Contains(neighbor))
                             openSet.Add(neighbor);
@@ -71,10 +71,10 @@ namespace EndlessClient.HUD
             return new Queue<MapCoordinate>();
         }
 
-        private static int heuristic(MapCoordinate current, MapCoordinate goal)
+        private static int Heuristic(MapCoordinate current, MapCoordinate goal)
             => Math.Abs(current.X - goal.X) + Math.Abs(current.Y - goal.Y);
 
-        private Queue<MapCoordinate> reconstructPath(MapCoordinate start, Dictionary<MapCoordinate, MapCoordinate> cameFrom, MapCoordinate current)
+        private Queue<MapCoordinate> ReconstructPath(MapCoordinate start, Dictionary<MapCoordinate, MapCoordinate> cameFrom, MapCoordinate current)
         {
             var retList = new List<MapCoordinate> { current };
             while (cameFrom.ContainsKey(current))
@@ -86,7 +86,7 @@ namespace EndlessClient.HUD
             return new Queue<MapCoordinate>(retList);
         }
 
-        private IEnumerable<MapCoordinate> getNeighbors(MapCoordinate current)
+        private IEnumerable<MapCoordinate> GetNeighbors(MapCoordinate current)
         {
             var points = new MapCoordinate[]
             {

--- a/EndlessClient/Program.cs
+++ b/EndlessClient/Program.cs
@@ -11,6 +11,7 @@ namespace EndlessClient
 
         [STAThread]
         public static void Main(string[] args)
+
         {
             var assemblyNames = new[]
             {

--- a/EndlessClient/UIControls/ScrollBar.cs
+++ b/EndlessClient/UIControls/ScrollBar.cs
@@ -71,11 +71,11 @@ namespace EndlessClient.UIControls
             var scrollBox = new Rectangle(0, vertOff, 16, 15);
 
             _upButton = new XNAButton(scrollSpriteSheet, Vector2.Zero, upArrows[0], upArrows[1]);
-            _upButton.OnMouseDown += arrowClicked;
+            _upButton.OnMouseDown += ArrowClicked;
             _upButton.SetParentControl(this);
 
             _downButton = new XNAButton(scrollSpriteSheet, new Vector2(0, size.Y - 15), downArrows[0], downArrows[1]);
-            _downButton.OnMouseDown += arrowClicked;
+            _downButton.OnMouseDown += ArrowClicked;
             _downButton.SetParentControl(this);
 
             _scrollButton = new XNAButton(scrollSpriteSheet, new Vector2(0, 15), scrollBox, scrollBox);
@@ -123,7 +123,7 @@ namespace EndlessClient.UIControls
         public void ScrollToEnd()
         {
             while (ScrollOffset < _totalHeight - LinesToRender)
-                arrowClicked(_downButton, new EventArgs());
+                ArrowClicked(_downButton, new EventArgs());
         }
 
         public void SetScrollOffset(int offset)
@@ -152,7 +152,7 @@ namespace EndlessClient.UIControls
         //     a way that ScrollOffset is updated and the Y coordinate for the scroll box is updated.
         //     ScrollOffset provides a value that is used within the EOScrollDialog.Draw method.
         //     The Y coordinate for the scroll box determines where it is drawn.
-        private void arrowClicked(object btn, EventArgs e)
+        private void ArrowClicked(object btn, EventArgs e)
         {
             //_totalHeight contains the number of lines to render
             //any less than LinesToRender shouldn't scroll


### PR DESCRIPTION
Use built-in analyzer for code formatting

Removes performance penalty of format check on build from running the dotnet format command independently of the build operation