### PR TITLE
EOBot: Array/Object Initializers and Compound Assignment operators

### DIFF
--- a/EOBot/Interpreter/BotTokenParser.cs
+++ b/EOBot/Interpreter/BotTokenParser.cs
@@ -88,6 +88,11 @@ namespace EOBot.Interpreter
                     do
                     {
                         inputChar = Read();
+                        if (inputChar == '\n')
+                        {
+                            LineNumber++;
+                            Column = 1;
+                        }
                     } while (!(inputChar == '*' && !_inputStream.EndOfStream && Peek() == '/'));
 
                     // skip the slash ending the comment and set input char to the character after the comment

--- a/EOBot/Interpreter/BotTokenParser.cs
+++ b/EOBot/Interpreter/BotTokenParser.cs
@@ -243,9 +243,21 @@ namespace EOBot.Interpreter
                                     return Token(BotTokenType.Error, inputChar.ToString());
                             }
                         }
-                    case '+': return Token(BotTokenType.PlusOperator, inputChar.ToString());
+                    case '+':
+                        if (_inputStream.EndOfStream)
+                            return Token(BotTokenType.PlusOperator, inputChar.ToString());
+
+                        return Peek() switch
+                        {
+                            '+' => Token(BotTokenType.Increment, $"{inputChar}{Read()}"),
+                            '=' => Token(BotTokenType.PlusEquals, $"{inputChar}{Read()}"),
+                            _ => Token(BotTokenType.PlusOperator, inputChar.ToString()),
+                        };
                     case '-':
                         {
+                            if (_inputStream.EndOfStream)
+                                return Token(BotTokenType.MinusOperator, inputChar.ToString());
+
                             var number = string.Empty;
                             while (char.IsDigit(Peek()) && !_inputStream.EndOfStream)
                                 number += Read();
@@ -254,13 +266,32 @@ namespace EOBot.Interpreter
                             {
                                 return Token(BotTokenType.Literal, $"{inputChar}{number}");
                             }
-                            else
+
+                            return Peek() switch
                             {
-                                return Token(BotTokenType.MinusOperator, inputChar.ToString());
-                            }
+                                '-' => Token(BotTokenType.Decrement, $"{inputChar}{Read()}"),
+                                '=' => Token(BotTokenType.MinusEquals, $"{inputChar}{Read()}"),
+                                _ => Token(BotTokenType.MinusOperator, inputChar.ToString()),
+                            };
                         }
-                    case '*': return Token(BotTokenType.MultiplyOperator, inputChar.ToString());
-                    case '/': return Token(BotTokenType.DivideOperator, inputChar.ToString());
+                    case '*':
+                        if (_inputStream.EndOfStream)
+                            return Token(BotTokenType.MultiplyOperator, inputChar.ToString());
+
+                        return Peek() switch
+                        {
+                            '=' => Token(BotTokenType.MultiplyEquals, $"{inputChar}{Read()}"),
+                            _ => Token(BotTokenType.MultiplyOperator, inputChar.ToString()),
+                        };
+                    case '/':
+                        if (_inputStream.EndOfStream)
+                            return Token(BotTokenType.DivideOperator, inputChar.ToString());
+
+                        return Peek() switch
+                        {
+                            '=' => Token(BotTokenType.DivideEquals, $"{inputChar}{Read()}"),
+                            _ => Token(BotTokenType.DivideOperator, inputChar.ToString()),
+                        };
                     case '%': return Token(BotTokenType.ModuloOperator, inputChar.ToString());
                     case '.': return Token(BotTokenType.Dot, inputChar.ToString());
                     case ';': return Token(BotTokenType.Semicolon, inputChar.ToString());

--- a/EOBot/Interpreter/BotTokenType.cs
+++ b/EOBot/Interpreter/BotTokenType.cs
@@ -33,6 +33,12 @@
         Dot,
         Semicolon,
         NewLine,
+        Increment,
+        Decrement,
+        PlusEquals,
+        MinusEquals,
+        MultiplyEquals,
+        DivideEquals,
         Error,
     }
 }

--- a/EOBot/Interpreter/BuiltInIdentifierConfigurator.cs
+++ b/EOBot/Interpreter/BuiltInIdentifierConfigurator.cs
@@ -85,7 +85,8 @@ namespace EOBot.Interpreter
 
             // game flow
             programState.SymbolTable[PredefinedIdentifiers.TICK] = Readonly(new AsyncVoidFunction(PredefinedIdentifiers.TICK, ct => Tick()));
-            programState.SymbolTable[PredefinedIdentifiers.GETPATHTO] = Readonly(new Function<int, int, List<IVariable>>(PredefinedIdentifiers.GETPATHTO, GetPathTo));
+            programState.SymbolTable[PredefinedIdentifiers.GETPATHTO] = Readonly(new Function<int, int, List<IVariable>>(PredefinedIdentifiers.GETPATHTO, (x, y) => GetPathTo(x, y, false)));
+            programState.SymbolTable[PredefinedIdentifiers.GETPATHTO_AVOIDINGWARPS] = Readonly(new Function<int, int, List<IVariable>>(PredefinedIdentifiers.GETPATHTO_AVOIDINGWARPS, (x, y) => GetPathTo(x, y, true)));
             programState.SymbolTable[PredefinedIdentifiers.GETCELLSTATE] = Readonly(new Function<int, int, ObjectVariable>(PredefinedIdentifiers.GETCELLSTATE, GetCellState));
 
             // in-game stuff
@@ -252,12 +253,12 @@ namespace EOBot.Interpreter
                 .PollForPacketsAndHandle();
         }
 
-        private List<IVariable> GetPathTo(int x, int y)
+        private List<IVariable> GetPathTo(int x, int y, bool shouldAvoidWarps)
         {
             var c = DependencyMaster.TypeRegistry[_botIndex].Resolve<ICharacterProvider>().MainCharacter;
 
             var astarPathFinder = DependencyMaster.TypeRegistry[_botIndex].Resolve<IPathFinder>();
-            var path = astarPathFinder.FindPath(c.RenderProperties.Coordinates(), new MapCoordinate(x, y));
+            var path = astarPathFinder.FindPath(c.RenderProperties.Coordinates(), new MapCoordinate(x, y), shouldAvoidWarps);
 
             return path.Select(
                 entry => (IVariable)new ObjectVariable(

--- a/EOBot/Interpreter/BuiltInIdentifierConfigurator.cs
+++ b/EOBot/Interpreter/BuiltInIdentifierConfigurator.cs
@@ -517,6 +517,7 @@ namespace EOBot.Interpreter
             npcObj.SymbolTable["index"] = Readonly(new IntVariable(npc.Index));
             npcObj.SymbolTable["ismonster"] = Readonly(new BoolVariable(npcRecord.Type == EOLib.IO.NPCType.Passive || npcRecord.Type == EOLib.IO.NPCType.Aggressive));
             npcObj.SymbolTable["incombat"] = Readonly(new BoolVariable(npc.OpponentID.HasValue));
+            npcObj.SymbolTable["opponent"] = Readonly(npc.OpponentID.Match<IVariable>(x => new IntVariable(x), () => UndefinedVariable.Instance));
             return npcObj;
         }
 

--- a/EOBot/Interpreter/Extensions/BotTokenExtensions.cs
+++ b/EOBot/Interpreter/Extensions/BotTokenExtensions.cs
@@ -18,7 +18,10 @@ namespace EOBot.Interpreter.Extensions
 
         public static bool IsUnary(this BotToken token)
         {
-            return token != null && token.Is(BotTokenType.NotOperator);
+            return token != null && token.IsOneOf(
+                BotTokenType.NotOperator,
+                BotTokenType.Increment, BotTokenType.Decrement
+            );
         }
 
         public static bool IsBinary(this BotToken token)

--- a/EOBot/Interpreter/States/BaseEvaluator.cs
+++ b/EOBot/Interpreter/States/BaseEvaluator.cs
@@ -24,12 +24,12 @@ namespace EOBot.Interpreter.States
             return _evaluators.OfType<T>().Single();
         }
 
-        protected (EvalResult, string, BotToken) Success(BotToken token = null)
+        protected static (EvalResult, string, BotToken) Success(BotToken token = null)
         {
             return (EvalResult.Ok, string.Empty, token);
         }
 
-        protected (EvalResult, string, BotToken) Error(BotToken current, params BotTokenType[] expectedTypes)
+        protected static (EvalResult, string, BotToken) Error(BotToken current, params BotTokenType[] expectedTypes)
         {
             var extra = string.IsNullOrWhiteSpace(current.TokenValue)
                 ? string.Empty
@@ -43,7 +43,7 @@ namespace EOBot.Interpreter.States
                 return (EvalResult.Failed, $"Expected one of [{string.Join(", ", expectedTypes)}], got {current.TokenType}{extra}", current);
         }
 
-        protected (EvalResult, string, BotToken) UnexpectedTokenError(BotToken current, params BotTokenType[] unexpectedTypes)
+        protected static (EvalResult, string, BotToken) UnexpectedTokenError(BotToken current, params BotTokenType[] unexpectedTypes)
         {
             if (unexpectedTypes.Length == 0)
                 return (EvalResult.Failed, string.Empty, current);
@@ -53,32 +53,32 @@ namespace EOBot.Interpreter.States
                 return (EvalResult.Failed, $"One of {string.Join(",", unexpectedTypes)} was unexpected", current);
         }
 
-        protected (EvalResult, string, BotToken) StackEmptyError(BotToken current)
+        protected static (EvalResult, string, BotToken) StackEmptyError(BotToken current)
         {
             return (EvalResult.Failed, $"Expected operation stack to have operands, but it was empty", current);
         }
 
-        protected (EvalResult, string, BotToken) UnsupportedOperatorError(BotToken actualToken)
+        protected static (EvalResult, string, BotToken) UnsupportedOperatorError(BotToken actualToken)
         {
             return (EvalResult.Failed, $"Unsupported operator evaluating expression: {actualToken.TokenType}", actualToken);
         }
 
-        protected (EvalResult, string, BotToken) StackTokenError(BotTokenType expectedTokenType, BotToken actualToken)
+        protected static (EvalResult, string, BotToken) StackTokenError(BotTokenType expectedTokenType, BotToken actualToken)
         {
             return (EvalResult.Failed, $"Expected operation stack to have {expectedTokenType} token, got {actualToken.TokenType}", actualToken);
         }
 
-        protected (EvalResult, string, BotToken) ReadOnlyVariableError(IdentifierBotToken token)
+        protected static (EvalResult, string, BotToken) ReadOnlyVariableError(IdentifierBotToken token)
         {
             return (EvalResult.Failed, $"Attempted to assign value to read-only variable {token.TokenValue}", token);
         }
 
-        protected (EvalResult, string, BotToken) IdentifierNotFoundError(IdentifierBotToken token)
+        protected static (EvalResult, string, BotToken) IdentifierNotFoundError(IdentifierBotToken token)
         {
             return (EvalResult.Failed, $"Identifier {token.TokenValue} is not defined", token);
         }
 
-        protected (EvalResult, string, BotToken) GotoError(BotToken token)
+        protected static (EvalResult, string, BotToken) GotoError(BotToken token)
         {
             return (EvalResult.Failed, $"Failed to goto label {token.TokenValue}", token);
         }

--- a/EOBot/Interpreter/States/BaseEvaluator.cs
+++ b/EOBot/Interpreter/States/BaseEvaluator.cs
@@ -93,6 +93,8 @@ namespace EOBot.Interpreter.States
                 return new BoolVariable(!string.IsNullOrEmpty(stringVar.Value));
             else if (variable is ObjectVariable)
                 return new BoolVariable(true);
+            else if (variable is ArrayVariable arrayVar)
+                return new BoolVariable(arrayVar.Value.Count > 0);
             else if (variable is UndefinedVariable)
                 return new BoolVariable(false);
             else

--- a/EOBot/Interpreter/States/CommaDelimitedListEvaluator.cs
+++ b/EOBot/Interpreter/States/CommaDelimitedListEvaluator.cs
@@ -1,0 +1,77 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EOBot.Interpreter.Extensions;
+
+namespace EOBot.Interpreter.States
+{
+    public abstract class CommaDelimitedListEvaluator : BaseEvaluator
+    {
+        protected CommaDelimitedListEvaluator(IEnumerable<IScriptEvaluator> evaluators)
+            : base(evaluators) { }
+
+        protected async Task<(EvalResult Result, string Message, BotToken Token)> EvalCommaDelimitedList<TEvaluator>(ProgramState input, BotTokenType listEndToken, CancellationToken ct)
+            where TEvaluator : IScriptEvaluator
+        {
+            var firstParam = true;
+            while (!input.Match(listEndToken))
+            {
+                if (input.Expect(BotTokenType.EOF))
+                    return UnexpectedTokenError(input.Current(), BotTokenType.EOF);
+
+                if (!firstParam && !input.Expect(BotTokenType.Comma))
+                    return Error(input.Current(), BotTokenType.Comma);
+
+                while (input.Expect(BotTokenType.NewLine)) ;
+
+                var parameterExpression = await Evaluator<TEvaluator>().EvaluateAsync(input, ct);
+                if (parameterExpression.Result != EvalResult.Ok)
+                    return parameterExpression;
+
+                while (input.Expect(BotTokenType.NewLine)) ;
+
+                firstParam = false;
+            }
+
+            if (input.OperationStack.Count == 0)
+                return StackEmptyError(input.Current());
+
+            var rightToken = input.OperationStack.Pop();
+            if (rightToken.TokenType != listEndToken)
+                return StackTokenError(listEndToken, rightToken);
+
+            return Success();
+        }
+
+        protected static List<VariableBotToken> GetParametersFromStack(ProgramState input, BotTokenType listStartToken)
+        {
+            var parameters = new List<VariableBotToken>();
+            while (input.OperationStack.Count > 0 && input.OperationStack.Peek().TokenType != listStartToken)
+            {
+                // parameters are popped in reverse order
+                var parameter = (VariableBotToken)input.OperationStack.Pop();
+                parameters.Insert(0, parameter);
+            }
+            return parameters;
+        }
+
+        protected static List<(IdentifierBotToken, VariableBotToken)> GetAssignmentPairsFromStack(ProgramState input, BotTokenType listStartToken)
+        {
+            var parameters = new List<(IdentifierBotToken, VariableBotToken)>();
+            while (input.OperationStack.Count > 0 && input.OperationStack.Peek().TokenType != listStartToken)
+            {
+                // parameters are popped in reverse order
+                var parameter = (VariableBotToken)input.OperationStack.Pop();
+
+                var assignOp = input.OperationStack.Pop();
+                if (assignOp.TokenType != BotTokenType.AssignOperator)
+                    throw new BotScriptErrorException("Expected assignment token in object initialized", assignOp);
+
+                var target = (IdentifierBotToken)input.OperationStack.Pop();
+
+                parameters.Insert(0, (target, parameter));
+            }
+            return parameters;
+        }
+    }
+}

--- a/EOBot/Interpreter/Variables/PredefinedIdentifiers.cs
+++ b/EOBot/Interpreter/Variables/PredefinedIdentifiers.cs
@@ -55,6 +55,7 @@
 
         public const string TICK = "Tick";
         public const string GETPATHTO = "GetPathTo";
+        public const string GETPATHTO_AVOIDINGWARPS = "GetPathToAvoidingWarps";
         public const string GETCELLSTATE = "GetCellState";
 
         public const string JOIN_PARTY = "JoinParty";

--- a/EOLib/Domain/Map/MapCellStateProvider.cs
+++ b/EOLib/Domain/Map/MapCellStateProvider.cs
@@ -31,7 +31,7 @@ namespace EOLib.Domain.Map
 
         public IMapCellState GetCellStateAt(int x, int y)
         {
-            if (x <= 0 || y <= 0 || x > CurrentMap.Properties.Width || y > CurrentMap.Properties.Height)
+            if (x < 0 || y < 0 || x > CurrentMap.Properties.Width || y > CurrentMap.Properties.Height)
                 return new MapCellState { InBounds = false, TileSpec = TileSpec.MapEdge };
 
             var tileSpec = CurrentMap.Tiles[y, x];


### PR DESCRIPTION
Adds support for the following operators to eobot scripts:
- `+=`, `-=`, `*=`, `/=`
- `++`, `--`

Adds support for the following syntax to eobot script:
```js
$new_array = [ 1, 2, 3]
$new_object = { $a = 1, $b = 2, $c = 3 }
```

Partial work for #416 