### PR TITLE
EOBot: Support for user-defined functions in scripts; 'undefined' keyword

### DIFF
--- a/EOBot/Interpreter/BotInterpreter.cs
+++ b/EOBot/Interpreter/BotInterpreter.cs
@@ -10,7 +10,6 @@ namespace EOBot.Interpreter
     public class BotInterpreter
     {
         private readonly BotTokenParser _parser;
-        private readonly IScriptEvaluator _scriptEvaluator;
 
         public BotInterpreter(string filePath)
             : this(File.OpenText(filePath))
@@ -18,30 +17,8 @@ namespace EOBot.Interpreter
         }
 
         public BotInterpreter(StreamReader inputStream)
-            : this()
         {
             _parser = new BotTokenParser(inputStream);
-        }
-
-        private BotInterpreter()
-        {
-            var evaluators = new List<IScriptEvaluator>();
-            evaluators.Add(new StatementListEvaluator(evaluators));
-            evaluators.Add(new StatementEvaluator(evaluators));
-            evaluators.Add(new AssignmentEvaluator(evaluators));
-            evaluators.Add(new KeywordEvaluator(evaluators));
-            evaluators.Add(new LabelEvaluator());
-            evaluators.Add(new FunctionEvaluator(evaluators));
-            evaluators.Add(new VariableEvaluator(evaluators));
-            evaluators.Add(new ExpressionEvaluator(evaluators));
-            evaluators.Add(new ExpressionTailEvaluator(evaluators));
-            evaluators.Add(new OperandEvaluator(evaluators));
-            evaluators.Add(new IfEvaluator(evaluators));
-            evaluators.Add(new WhileEvaluator(evaluators));
-            evaluators.Add(new ForEvaluator(evaluators));
-            evaluators.Add(new ForeachEvaluator(evaluators));
-            evaluators.Add(new GotoEvaluator());
-            _scriptEvaluator = new ScriptEvaluator(evaluators);
         }
 
         public ProgramState Parse()
@@ -68,7 +45,7 @@ namespace EOBot.Interpreter
 
         public async Task Run(ProgramState programState, CancellationToken ct)
         {
-            var (result, reason, token) = await _scriptEvaluator.EvaluateAsync(programState, ct).ConfigureAwait(false);
+            var (result, reason, token) = await ScriptEvaluator.Instance.EvaluateAsync(programState, ct).ConfigureAwait(false);
 
             if (result == EvalResult.Failed)
             {

--- a/EOBot/Interpreter/BotScriptErrorException.cs
+++ b/EOBot/Interpreter/BotScriptErrorException.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Text;
 
 namespace EOBot.Interpreter
 {
@@ -8,6 +10,24 @@ namespace EOBot.Interpreter
             : base(message) { }
 
         public BotScriptErrorException(string message, BotToken token)
-            : base($"Error at line {token.LineNumber} column {token.Column}: {message}") { }
+            : base(GetMessage(message, token)) { }
+
+        public BotScriptErrorException(string message, BotToken token, IEnumerable<(string, BotToken, int)> stack)
+            : base(GetMessage(message, token, stack)) { }
+
+        private static string GetMessage(string message, BotToken token) => $"Error at line {token.LineNumber} column {token.Column}: {message}";
+
+        private static string GetMessage(string message, BotToken token, IEnumerable<(string FuncName, BotToken Token, int ExecutionIndex)> stack)
+        {
+            var sb = new StringBuilder("at:\n");
+
+            foreach (var frame in stack)
+                sb.AppendLine($"    {frame.FuncName}:{frame.Token.LineNumber}");
+
+            sb.AppendLine();
+            sb.Append(GetMessage(message, token));
+
+            return sb.ToString();
+        }
     }
 }

--- a/EOBot/Interpreter/BotTokenParser.cs
+++ b/EOBot/Interpreter/BotTokenParser.cs
@@ -126,14 +126,21 @@ namespace EOBot.Interpreter
                             ? BotTokenType.Literal
                             : BotTokenType.Identifier;
 
-                return Token(type, identifier);
+                if (type == BotTokenType.Literal)
+                {
+                    return Literal(identifier, identifier == KEYWORD_UNDEFINED ? null : bool.Parse(identifier));
+                }
+                else
+                {
+                    return Token(type, identifier);
+                }
             }
             else if (char.IsDigit(inputChar))
             {
                 var number = inputChar.ToString();
                 while (char.IsDigit(Peek()) && !_inputStream.EndOfStream)
                     number += Read();
-                return Token(BotTokenType.Literal, number);
+                return Literal(number, int.Parse(number));
             }
             else
             {
@@ -157,7 +164,7 @@ namespace EOBot.Interpreter
                                 return Token(BotTokenType.Error, string.Empty);
 
                             Read();
-                            return Token(BotTokenType.Literal, stringLiteral);
+                            return Literal(stringLiteral, stringLiteral);
                         }
                     case '=':
                         {
@@ -309,6 +316,11 @@ namespace EOBot.Interpreter
         private BotToken Token(BotTokenType tokenType, string tokenValue)
         {
             return new BotToken(tokenType, tokenValue, LineNumber, Column);
+        }
+
+        private LiteralBotToken Literal(string tokenValue, object literalValue)
+        {
+            return new LiteralBotToken(BotTokenType.Literal, tokenValue, literalValue, LineNumber, Column);
         }
 
         public void Dispose()

--- a/EOBot/Interpreter/BotTokenParser.cs
+++ b/EOBot/Interpreter/BotTokenParser.cs
@@ -15,8 +15,8 @@ namespace EOBot.Interpreter
         public const string KEYWORD_IN = "in";
         public const string KEYWORD_CONTINUE = "continue";
         public const string KEYWORD_BREAK = "break";
-        //public const string KEYWORD_FUNCTION = "function";
-        //public const string KEYWORD_RETURN = "return";
+        public const string KEYWORD_FUNC = "func";
+        public const string KEYWORD_RETURN = "return";
 
         public const string KEYWORD_UNDEFINED = "undefined";
         public const string KEYWORD_TRUE = "true";
@@ -33,8 +33,8 @@ namespace EOBot.Interpreter
             KEYWORD_IN,
             KEYWORD_CONTINUE,
             KEYWORD_BREAK,
-            //KEYWORD_FUNCTION,
-            //KEYWORD_RETURN
+            KEYWORD_FUNC,
+            KEYWORD_RETURN,
         ];
 
         private static readonly HashSet<string> Literals = [KEYWORD_TRUE, KEYWORD_FALSE, KEYWORD_UNDEFINED];

--- a/EOBot/Interpreter/BotTokenParser.cs
+++ b/EOBot/Interpreter/BotTokenParser.cs
@@ -18,6 +18,7 @@ namespace EOBot.Interpreter
         //public const string KEYWORD_FUNCTION = "function";
         //public const string KEYWORD_RETURN = "return";
 
+        public const string KEYWORD_UNDEFINED = "undefined";
         public const string KEYWORD_TRUE = "true";
         public const string KEYWORD_FALSE = "false";
 
@@ -36,7 +37,7 @@ namespace EOBot.Interpreter
             //KEYWORD_RETURN
         ];
 
-        private static readonly HashSet<string> Literals = [KEYWORD_TRUE, KEYWORD_FALSE];
+        private static readonly HashSet<string> Literals = [KEYWORD_TRUE, KEYWORD_FALSE, KEYWORD_UNDEFINED];
 
         private readonly StreamReader _inputStream;
         private readonly bool _streamNeedsDispose;

--- a/EOBot/Interpreter/BuiltInIdentifierConfigurator.cs
+++ b/EOBot/Interpreter/BuiltInIdentifierConfigurator.cs
@@ -69,6 +69,8 @@ namespace EOBot.Interpreter
             programState.SymbolTable[PredefinedIdentifiers.ABS_FUNC] = Readonly(new Function<int, int>(PredefinedIdentifiers.ABS_FUNC, Math.Abs));
             programState.SymbolTable[PredefinedIdentifiers.CONTAINS_FUNC] = Readonly(new Function<IVariable, IVariable, bool>(PredefinedIdentifiers.CONTAINS_FUNC, Contains));
             programState.SymbolTable[PredefinedIdentifiers.PARSE_FUNC] = Readonly(new Function<string, int>(PredefinedIdentifiers.PARSE_FUNC, Parse));
+            programState.SymbolTable[PredefinedIdentifiers.MAX_FUNC] = Readonly(new Function<int, int, int>(PredefinedIdentifiers.MAX_FUNC, Math.Max));
+            programState.SymbolTable[PredefinedIdentifiers.MIN_FUNC] = Readonly(new Function<int, int, int>(PredefinedIdentifiers.MIN_FUNC, Math.Min));
 
             if (OperatingSystem.IsWindows())
                 programState.SymbolTable[PredefinedIdentifiers.BEEP_FUNC] = Readonly(new VoidFunction<int, int>(PredefinedIdentifiers.BEEP_FUNC, Console.Beep));

--- a/EOBot/Interpreter/BuiltInIdentifierConfigurator.cs
+++ b/EOBot/Interpreter/BuiltInIdentifierConfigurator.cs
@@ -175,7 +175,7 @@ namespace EOBot.Interpreter
             var connectionActions = c.Resolve<INetworkConnectionActions>();
             var connectResult = await connectionActions.ConnectToServer().ConfigureAwait(false);
             if (connectResult != ConnectResult.Success)
-                throw new ArgumentException($"Bot {_botIndex}: Unable to connect to server! Host={host} Port={port}");
+                throw new BotScriptErrorException($"Bot {_botIndex}: Unable to connect to server! Host={host} Port={port}");
 
             var backgroundReceiveActions = c.Resolve<IBackgroundReceiveActions>();
             backgroundReceiveActions.RunBackgroundReceiveLoop();
@@ -183,7 +183,7 @@ namespace EOBot.Interpreter
             var handshakeResult = await connectionActions.BeginHandshake(_random.Next(Constants.MaxChallenge)).ConfigureAwait(false);
 
             if (handshakeResult.ReplyCode != InitReply.Ok)
-                throw new InvalidOperationException($"Bot {_botIndex}: Invalid response from server or connection failed! Must receive an OK reply.");
+                throw new BotScriptErrorException($"Bot {_botIndex}: Invalid response from server or connection failed! Must receive an OK reply.");
 
             var handshakeData = (InitInitServerPacket.ReplyCodeDataOk)handshakeResult.ReplyCodeData;
 

--- a/EOBot/Interpreter/IdentifierBotToken.cs
+++ b/EOBot/Interpreter/IdentifierBotToken.cs
@@ -1,18 +1,17 @@
-﻿namespace EOBot.Interpreter
+﻿using EOBot.Interpreter.Variables;
+
+namespace EOBot.Interpreter
 {
     public class IdentifierBotToken : BotToken
     {
-        public int? ArrayIndex { get; }
-
-        public string DictKey { get; }
+        public IVariable Indexer { get; }
 
         public IdentifierBotToken Member { get; }
 
-        public IdentifierBotToken(BotToken identifier, int? arrayIndex = null, string dictKey = null, IdentifierBotToken member = null)
+        public IdentifierBotToken(BotToken identifier, IVariable indexer = null, IdentifierBotToken member = null)
             : base(identifier.TokenType, identifier.TokenValue, identifier.LineNumber, identifier.Column)
         {
-            ArrayIndex = arrayIndex;
-            DictKey = dictKey;
+            Indexer = indexer;
             Member = member;
         }
     }

--- a/EOBot/Interpreter/LiteralBotToken.cs
+++ b/EOBot/Interpreter/LiteralBotToken.cs
@@ -1,0 +1,15 @@
+﻿namespace EOBot.Interpreter
+{
+    public class LiteralBotToken : BotToken
+    {
+        public object LiteralValue { get; }
+
+        public LiteralBotToken(BotTokenType tokenType, string tokenValue, object literalValue, int line, int col)
+            : base(tokenType, tokenValue, line, col)
+        {
+            LiteralValue = literalValue;
+        }
+
+        public override string ToString() => $"{base.ToString()} ({LiteralValue} : {LiteralValue.GetType().Name})";
+    }
+}

--- a/EOBot/Interpreter/States/AssignmentEvaluator.cs
+++ b/EOBot/Interpreter/States/AssignmentEvaluator.cs
@@ -142,7 +142,10 @@ namespace EOBot.Interpreter.States
                 if (symbols.ContainsKey(assignmentTarget.TokenValue) && symbols[assignmentTarget.TokenValue].ReadOnly)
                     return ReadOnlyVariableError(assignmentTarget);
 
-                if (symbols.ContainsKey(assignmentTarget.TokenValue) && symbols[assignmentTarget.TokenValue].Identifiable.GetType() != expressionResult.VariableValue.GetType())
+                if (symbols.ContainsKey(assignmentTarget.TokenValue) &&
+                    symbols[assignmentTarget.TokenValue].Identifiable.GetType() != expressionResult.VariableValue.GetType()
+                    && symbols[assignmentTarget.TokenValue].Identifiable is not UndefinedVariable
+                    && expressionResult.VariableValue is not UndefinedVariable)
                 {
                     // todo: surface warnings to caller and let caller decide what to do with it instead of making the interpreter write to console directly
                     ConsoleHelper.WriteMessage(ConsoleHelper.Type.Warning, $"Changing type of variable {assignmentTarget.TokenValue} from {symbols[assignmentTarget.TokenValue].Identifiable.GetType()} to {expressionResult.VariableValue.GetType()}", System.ConsoleColor.DarkYellow);

--- a/EOBot/Interpreter/States/ExpressionEvaluator.cs
+++ b/EOBot/Interpreter/States/ExpressionEvaluator.cs
@@ -257,14 +257,14 @@ namespace EOBot.Interpreter.States
         {
             if (nextToken is not VariableBotToken operand)
             {
-                if (nextToken.TokenType == BotTokenType.Literal)
+                if (nextToken is LiteralBotToken lbt)
                 {
                     if (nextToken.TokenValue == "undefined")
                         return Success(new VariableBotToken(BotTokenType.Literal, nextToken.TokenValue, UndefinedVariable.Instance));
-                    else if (int.TryParse(nextToken.TokenValue, out var intValue))
-                        return Success(new VariableBotToken(BotTokenType.Literal, nextToken.TokenValue, new IntVariable(intValue)));
-                    else if (bool.TryParse(nextToken.TokenValue, out var boolValue))
-                        return Success(new VariableBotToken(BotTokenType.Literal, nextToken.TokenValue, new BoolVariable(boolValue)));
+                    else if (lbt.LiteralValue is int iv)
+                        return Success(new VariableBotToken(BotTokenType.Literal, nextToken.TokenValue, new IntVariable(iv)));
+                    else if (lbt.LiteralValue is bool bv)
+                        return Success(new VariableBotToken(BotTokenType.Literal, nextToken.TokenValue, new BoolVariable(bv)));
                     else
                         return Success(new VariableBotToken(BotTokenType.Literal, nextToken.TokenValue, new StringVariable(nextToken.TokenValue)));
                 }

--- a/EOBot/Interpreter/States/ExpressionEvaluator.cs
+++ b/EOBot/Interpreter/States/ExpressionEvaluator.cs
@@ -259,7 +259,9 @@ namespace EOBot.Interpreter.States
             {
                 if (nextToken.TokenType == BotTokenType.Literal)
                 {
-                    if (int.TryParse(nextToken.TokenValue, out var intValue))
+                    if (nextToken.TokenValue == "undefined")
+                        return Success(new VariableBotToken(BotTokenType.Literal, nextToken.TokenValue, UndefinedVariable.Instance));
+                    else if (int.TryParse(nextToken.TokenValue, out var intValue))
                         return Success(new VariableBotToken(BotTokenType.Literal, nextToken.TokenValue, new IntVariable(intValue)));
                     else if (bool.TryParse(nextToken.TokenValue, out var boolValue))
                         return Success(new VariableBotToken(BotTokenType.Literal, nextToken.TokenValue, new BoolVariable(boolValue)));

--- a/EOBot/Interpreter/States/ExpressionEvaluator.cs
+++ b/EOBot/Interpreter/States/ExpressionEvaluator.cs
@@ -306,10 +306,10 @@ namespace EOBot.Interpreter.States
         }
 
         private static (IVariable, string) Add(IntVariable a, IntVariable b) => (new IntVariable(a.Value + b.Value), string.Empty);
-        private static (IVariable, string) Add(IntVariable a, StringVariable b) => (new StringVariable(a.Value + b.Value), string.Empty);
-        private static (IVariable, string) Add(StringVariable a, IntVariable b) => (new StringVariable(a.Value + b.Value), string.Empty);
         private static (IVariable, string) Add(StringVariable a, StringVariable b) => (new StringVariable(a.Value + b.Value), string.Empty);
-        private static (IVariable, string) Add(object a, object b) => (null, $"Objects {a} and {b} could not be added (currently the operands must be int or string)");
+        private static (IVariable, string) Add(IVariable a, StringVariable b) => (new StringVariable(a.StringValue + b.Value), string.Empty);
+        private static (IVariable, string) Add(StringVariable a, IVariable b) => (new StringVariable(a.Value + b.StringValue), string.Empty);
+        private static (IVariable, string) Add(object a, object b) => (null, $"Objects {a} and {b} could not be added (currently the operands must be int or convertable to variable)");
 
         private static (IVariable, string) Subtract(IntVariable a, IntVariable b) => (new IntVariable(a.Value - b.Value), string.Empty);
         private static (IVariable, string) Subtract(object a, object b) => (null, $"Objects {a} and {b} could not be subtracted (currently the operands must be int)");

--- a/EOBot/Interpreter/States/ForeachEvaluator.cs
+++ b/EOBot/Interpreter/States/ForeachEvaluator.cs
@@ -28,7 +28,7 @@ namespace EOBot.Interpreter.States
                 return (result, reason, token);
 
             var targetVariable = (IdentifierBotToken)token;
-            if (targetVariable.Member != null || targetVariable.ArrayIndex != null || targetVariable.DictKey != null)
+            if (targetVariable.Member != null || targetVariable.Indexer != null)
                 return (EvalResult.Failed, "foreach iteration must be assigned to simple identifier", targetVariable);
 
             if (!input.Current().Is(BotTokenType.Keyword, BotTokenParser.KEYWORD_IN))

--- a/EOBot/Interpreter/States/ForeachEvaluator.cs
+++ b/EOBot/Interpreter/States/ForeachEvaluator.cs
@@ -79,7 +79,7 @@ namespace EOBot.Interpreter.States
                 for (int i = 0; i < arrayVariable.Value.Count; i++)
                 {
                     input.Goto(blockStartIndex);
-                    input.SymbolTable[targetVariable.TokenValue] = (true, arrayVariable.Value[i]);
+                    input.SymbolTable[targetVariable.TokenValue] = (false, arrayVariable.Value[i]);
 
                     var blockEval = await EvaluateBlockAsync(input, ct);
                     if (blockEval.Item1 == EvalResult.ControlFlow)

--- a/EOBot/Interpreter/States/FunctionEvaluator.cs
+++ b/EOBot/Interpreter/States/FunctionEvaluator.cs
@@ -48,6 +48,8 @@ namespace EOBot.Interpreter.States
                     await CallAsync(input, ct, (dynamic)function, parameters.Select(x => x.VariableValue).ToArray()).ConfigureAwait(false);
                 else if (function is IFunction)
                     Call(input, (dynamic)function, parameters.Select(x => x.VariableValue).ToArray());
+                else if (function is IUserDefinedFunction udf)
+                    return await udf.CallAsync(input, ct, parameters.Select(x => x.VariableValue).ToArray());
                 else
                     return (EvalResult.Failed, $"Expected identifier {functionToken.TokenValue} to be a function, but it was {function.GetType().Name}", functionToken);
             }

--- a/EOBot/Interpreter/States/FunctionEvaluator.cs
+++ b/EOBot/Interpreter/States/FunctionEvaluator.cs
@@ -57,7 +57,7 @@ namespace EOBot.Interpreter.States
             {
                 // stack information isn't really important since this is only used to signal to the framework that a bot failed
                 // recreate the exception so it prints line number/column info with the error
-                throw new BotScriptErrorException(bse.Message, functionToken);
+                throw new BotScriptErrorException(bse.Message, functionToken, input.CallStack);
             }
             catch (ArgumentException ae)
             {

--- a/EOBot/Interpreter/States/KeywordEvaluator.cs
+++ b/EOBot/Interpreter/States/KeywordEvaluator.cs
@@ -21,8 +21,7 @@ namespace EOBot.Interpreter.States
                 Evaluator<WhileEvaluator>(),
                 Evaluator<ForEvaluator>(),
                 Evaluator<ForeachEvaluator>(),
-                // Evaluator<FunctionEvaluator>(),
-                // Evaluator<ReturnEvaluator>(),
+                Evaluator<ReturnEvaluator>(),
                 Evaluator<GotoEvaluator>(),
             ];
 

--- a/EOBot/Interpreter/States/ProgramState.cs
+++ b/EOBot/Interpreter/States/ProgramState.cs
@@ -141,7 +141,6 @@ namespace EOBot.Interpreter.States
         {
             var retDict = new Dictionary<string, (bool, IIdentifiable)>();
 
-            // todo: handle newlines
             for (int i = 0; i < program.Count; i++)
             {
                 if (!program[i].Is(BotTokenType.Keyword, BotTokenParser.KEYWORD_FUNC))
@@ -163,12 +162,19 @@ namespace EOBot.Interpreter.States
                         commas.Add(program[i++]);
                     }
 
+                    while (i < program.Count && program[i].TokenType == BotTokenType.NewLine) i++;
+
                     var nextParam = program[i++];
                     paramSpecs.Add(nextParam);
                     firstParam = false;
+
+                    while (i < program.Count && program[i].TokenType == BotTokenType.NewLine) i++;
                 }
 
                 var rparen = program[i++];
+
+                while (i < program.Count && program[i].TokenType == BotTokenType.NewLine) i++;
+
                 var lbrace = program[i++];
 
                 var tokenStartIndex = i; // incremented past first LBrace

--- a/EOBot/Interpreter/States/ProgramState.cs
+++ b/EOBot/Interpreter/States/ProgramState.cs
@@ -124,7 +124,7 @@ namespace EOBot.Interpreter.States
         public void InheritFrom(ProgramState parentState)
         {
             OperationStack.Clear();
-            SymbolTable = new Dictionary<string, (bool ReadOnly, IIdentifiable Identifiable)>(parentState.SymbolTable);
+            SymbolTable = parentState.SymbolTable;
             CallStack = parentState.CallStack;
         }
 

--- a/EOBot/Interpreter/States/ProgramState.cs
+++ b/EOBot/Interpreter/States/ProgramState.cs
@@ -123,6 +123,7 @@ namespace EOBot.Interpreter.States
         /// <param name="parentState">The parent program.</param>
         public void InheritFrom(ProgramState parentState)
         {
+            ExecutionIndex = 0;
             OperationStack.Clear();
             SymbolTable = parentState.SymbolTable;
             CallStack = parentState.CallStack;

--- a/EOBot/Interpreter/States/ReturnEvaluator.cs
+++ b/EOBot/Interpreter/States/ReturnEvaluator.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EOBot.Interpreter.Extensions;
+using EOBot.Interpreter.Variables;
+
+namespace EOBot.Interpreter.States
+{
+    public class ReturnEvaluator : BaseEvaluator
+    {
+        public ReturnEvaluator(IEnumerable<IScriptEvaluator> evaluators)
+            : base(evaluators) { }
+
+        public override async Task<(EvalResult Result, string Reason, BotToken Token)> EvaluateAsync(ProgramState input, CancellationToken ct)
+        {
+            if (!input.Current().Is(BotTokenType.Keyword, BotTokenParser.KEYWORD_RETURN))
+                return (EvalResult.NotMatch, string.Empty, input.Current());
+
+            if (input.CallStack.Count == 0)
+                return (EvalResult.Failed, "Call stack is empty. return can only be used within the context of a user-defined function.", input.Current());
+
+            input.Expect(BotTokenType.Keyword);
+
+            var result = await Evaluator<ExpressionEvaluator>().EvaluateAsync(input, ct);
+            if (result.Result != EvalResult.Ok)
+                return result;
+
+            // check for value-returning function
+            if (input.OperationStack.Count > 0)
+            {
+                var resultToken = input.OperationStack.Pop();
+                if (resultToken is not VariableBotToken resultVar)
+                    return StackTokenError(BotTokenType.Variable, resultToken);
+                input.SymbolTable[PredefinedIdentifiers.RESULT] = (true, resultVar.VariableValue);
+            }
+
+            return result;
+        }
+    }
+}

--- a/EOBot/Interpreter/States/ScriptEvaluator.cs
+++ b/EOBot/Interpreter/States/ScriptEvaluator.cs
@@ -7,6 +7,30 @@ namespace EOBot.Interpreter.States
 {
     public class ScriptEvaluator : BaseEvaluator
     {
+        static ScriptEvaluator()
+        {
+            var evaluators = new List<IScriptEvaluator>();
+            evaluators.Add(new StatementListEvaluator(evaluators));
+            evaluators.Add(new StatementEvaluator(evaluators));
+            evaluators.Add(new AssignmentEvaluator(evaluators));
+            evaluators.Add(new KeywordEvaluator(evaluators));
+            evaluators.Add(new LabelEvaluator());
+            evaluators.Add(new FunctionEvaluator(evaluators));
+            evaluators.Add(new VariableEvaluator(evaluators));
+            evaluators.Add(new ExpressionEvaluator(evaluators));
+            evaluators.Add(new ExpressionTailEvaluator(evaluators));
+            evaluators.Add(new OperandEvaluator(evaluators));
+            evaluators.Add(new IfEvaluator(evaluators));
+            evaluators.Add(new WhileEvaluator(evaluators));
+            evaluators.Add(new ForEvaluator(evaluators));
+            evaluators.Add(new ForeachEvaluator(evaluators));
+            evaluators.Add(new GotoEvaluator());
+            evaluators.Add(new ReturnEvaluator(evaluators));
+            Instance = new ScriptEvaluator(evaluators);
+        }
+
+        public static ScriptEvaluator Instance { get; }
+
         public ScriptEvaluator(IEnumerable<IScriptEvaluator> evaluators)
             : base(evaluators) { }
 

--- a/EOBot/Interpreter/States/StatementEvaluator.cs
+++ b/EOBot/Interpreter/States/StatementEvaluator.cs
@@ -12,8 +12,15 @@ namespace EOBot.Interpreter.States
 
         public override async Task<(EvalResult, string, BotToken)> EvaluateAsync(ProgramState input, CancellationToken ct)
         {
+            var hasNewLines = false;
             while (input.Current().TokenType == BotTokenType.NewLine)
+            {
+                hasNewLines = true;
                 input.Expect(BotTokenType.NewLine);
+            }
+
+            if (hasNewLines && input.Expect(BotTokenType.EOF))
+                return Success();
 
             var (result, reason, token) = await Evaluator<AssignmentEvaluator>().EvaluateAsync(input, ct);
             if (result == EvalResult.NotMatch)

--- a/EOBot/Interpreter/States/VariableEvaluator.cs
+++ b/EOBot/Interpreter/States/VariableEvaluator.cs
@@ -19,8 +19,7 @@ namespace EOBot.Interpreter.States
             if (!input.Match(BotTokenType.Variable))
                 return (EvalResult.NotMatch, string.Empty, input.Current());
 
-            int? arrayIndex = null;
-            string dictKey = null;
+            IVariable indexer = null;
             if (input.Match(BotTokenType.LBracket))
             {
                 var expressionEval = await Evaluator<ExpressionEvaluator>().EvaluateAsync(input, ct);
@@ -40,18 +39,7 @@ namespace EOBot.Interpreter.States
                 if (!lBracket.Is(BotTokenType.LBracket))
                     return StackTokenError(BotTokenType.LBracket, lBracket);
 
-                if (expressionResult.VariableValue is IntVariable iv)
-                {
-                    arrayIndex = iv.Value;
-                }
-                else if (expressionResult.VariableValue is StringVariable sv)
-                {
-                    dictKey = sv.Value;
-                }
-                else
-                {
-                    return (EvalResult.Failed, $"Expected index expression to be int or string, but it was {expressionResult.VariableValue.GetType().Name}", expressionResult);
-                }
+                indexer = expressionResult.VariableValue;
             }
 
             IdentifierBotToken nestedIdentifier = null;
@@ -78,7 +66,7 @@ namespace EOBot.Interpreter.States
                 return StackEmptyError(input.Current());
             var identifier = input.OperationStack.Pop();
 
-            input.OperationStack.Push(new IdentifierBotToken(identifier, arrayIndex, dictKey, nestedIdentifier));
+            input.OperationStack.Push(new IdentifierBotToken(identifier, indexer, nestedIdentifier));
 
             return Success();
         }

--- a/EOBot/Interpreter/Variables/ICallable.cs
+++ b/EOBot/Interpreter/Variables/ICallable.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using EOBot.Interpreter.States;
 
 namespace EOBot.Interpreter.Variables
 {
@@ -24,5 +25,10 @@ namespace EOBot.Interpreter.Variables
     public interface IAsyncCallable<T> : IAsyncFunction
     {
         Task<T> CallAsync(CancellationToken ct, params IIdentifiable[] parameters);
+    }
+
+    public interface IUserDefinedFunction : IIdentifiable
+    {
+        Task<(EvalResult Result, string Reason, BotToken Token)> CallAsync(ProgramState programState, CancellationToken ct, params IIdentifiable[] parameters);
     }
 }

--- a/EOBot/Interpreter/Variables/PredefinedIdentifiers.cs
+++ b/EOBot/Interpreter/Variables/PredefinedIdentifiers.cs
@@ -41,6 +41,8 @@
         public const string ABS_FUNC = "abs";
         public const string CONTAINS_FUNC = "contains";
         public const string PARSE_FUNC = "parse";
+        public const string MAX_FUNC = "max";
+        public const string MIN_FUNC = "min";
         public const string BEEP_FUNC = "beep";
 
         // game functions

--- a/EOBot/Interpreter/Variables/PredefinedIdentifiers.cs
+++ b/EOBot/Interpreter/Variables/PredefinedIdentifiers.cs
@@ -41,6 +41,7 @@
         public const string ABS_FUNC = "abs";
         public const string CONTAINS_FUNC = "contains";
         public const string PARSE_FUNC = "parse";
+        public const string BEEP_FUNC = "beep";
 
         // game functions
         public const string CONNECT_FUNC = "Connect";
@@ -65,6 +66,7 @@
         public const string WALK = "Walk";
         public const string ATTACK = "Attack";
         public const string SIT = "Sit";
+        public const string CAST = "Cast";
 
         public const string USEITEM = "UseItem";
         public const string DROP = "Drop";

--- a/EOBot/Interpreter/Variables/PredefinedIdentifiers.cs
+++ b/EOBot/Interpreter/Variables/PredefinedIdentifiers.cs
@@ -28,6 +28,9 @@
         public const string ARRAY_FUNC = "array";
         public const string DICT_FUNC = "dict";
         public const string APPEND_FUNC = "append";
+        public const string REMOVE_FUNC = "remove";
+        public const string REMOVEAT_FUNC = "removeat";
+        public const string INSERT_FUNC = "insert";
         public const string CLEAR_FUNC = "clear";
         public const string OBJECT_FUNC = "object";
         public const string SLEEP_FUNC = "sleep";
@@ -41,9 +44,14 @@
         public const string ABS_FUNC = "abs";
         public const string CONTAINS_FUNC = "contains";
         public const string PARSE_FUNC = "parse";
+        public const string BEEP_FUNC = "beep";
         public const string MAX_FUNC = "max";
         public const string MIN_FUNC = "min";
-        public const string BEEP_FUNC = "beep";
+        public const string TRIM_FUNC = "trim";
+        public const string SPLIT_FUNC = "split";
+
+        // io (todo: syntax to map .net types/functions to be referenced by the interpreter)
+        public const string READALL_FUNC = "readall";
 
         // game functions
         public const string CONNECT_FUNC = "Connect";

--- a/EOBot/Interpreter/Variables/UserDefinedFunction.cs
+++ b/EOBot/Interpreter/Variables/UserDefinedFunction.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EOBot.Interpreter.Extensions;
+using EOBot.Interpreter.States;
+
+namespace EOBot.Interpreter.Variables
+{
+    public class UserDefinedFunction : IUserDefinedFunction
+    {
+        private readonly ProgramState _funcState;
+        private readonly List<BotToken> _paramSpecs;
+
+        public string StringValue { get; }
+
+        public UserDefinedFunction(string functionName, List<BotToken> functionTokens, List<BotToken> paramSpecs)
+        {
+            StringValue = functionName;
+
+            // constructed here so any nested functions will be created/evaluated at program state initialization time
+            _funcState = new ProgramState(functionTokens);
+
+            _paramSpecs = paramSpecs;
+        }
+
+        public virtual async Task<(EvalResult, string, BotToken)> CallAsync(ProgramState programState, CancellationToken ct, params IIdentifiable[] parameters)
+        {
+            if (parameters.Length != _paramSpecs.Count)
+                throw new ArgumentException($"Calling function '{StringValue}' with wrong number of parameters");
+
+            _funcState.InheritFrom(programState);
+            var readOnlyItems = _funcState.SymbolTable.Where(x => x.Value.ReadOnly);
+
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                if (readOnlyItems.Any(x => x.Key == _paramSpecs[i].TokenValue))
+                    return ParameterOverwritesBuiltinError(_paramSpecs[i]);
+
+                _funcState.SymbolTable[_paramSpecs[i].TokenValue] = (false, parameters[i]);
+            }
+
+            _funcState.CallStack.Push((StringValue, _funcState.Program[0], programState.ExecutionIndex));
+            var (evalResult, reason, token) = await ScriptEvaluator.Instance.EvaluateAsync(_funcState, ct);
+
+            if (evalResult != EvalResult.Failed)
+            {
+                if (_funcState.SymbolTable.TryGetValue(PredefinedIdentifiers.RESULT, out var resultVar))
+                {
+                    programState.SymbolTable[PredefinedIdentifiers.RESULT] = resultVar;
+                    if (resultVar.Identifiable is not IVariable iv)
+                        return (EvalResult.Failed, $"Expected result to be a variable, but got {resultVar.Identifiable.GetType()}", programState.Current());
+                    programState.OperationStack.Push(new VariableBotToken(BotTokenType.Literal, iv.StringValue, iv));
+                }
+
+                foreach (var key in programState.SymbolTable.Keys)
+                {
+                    if (programState.SymbolTable[key].ReadOnly)
+                        continue;
+
+                    if (_funcState.SymbolTable.TryGetValue(key, out var updatedSymbol))
+                        programState.SymbolTable[key] = updatedSymbol;
+                }
+
+                _funcState.CallStack.Pop();
+            }
+
+            return (evalResult, reason, token);
+        }
+
+        private static (EvalResult, string, BotToken) ParameterOverwritesBuiltinError(BotToken paramSpec)
+        {
+            return (EvalResult.Failed, $"Parameter {paramSpec.TokenValue} overrides built-in variable or function.", paramSpec);
+        }
+    }
+}

--- a/EOBot/Program.cs
+++ b/EOBot/Program.cs
@@ -168,7 +168,12 @@ namespace EOBot
             public void NotifySelfSpellCast(int playerId, int spellId, int spellHp, int percentHealth)
             {
                 if (playerId == _characterProvider.MainCharacter.ID && spellHp > 0)
-                    ConsoleHelper.WriteMessage(ConsoleHelper.Type.Heal, $"{spellHp,7} - {percentHealth}% HP", ConsoleColor.DarkGreen);
+                {
+                    var stats = _characterProvider.MainCharacter.Stats;
+                    var tp = stats[CharacterStat.TP];
+                    var maxtp = stats[CharacterStat.MaxTP];
+                    ConsoleHelper.WriteMessage(ConsoleHelper.Type.Heal, $"{spellHp,7} - {percentHealth}% HP - {tp}/{maxtp} TP", ConsoleColor.DarkGreen);
+                }
             }
 
             public void NotifyStartSpellCast(int playerId, int spellId) { }


### PR DESCRIPTION
Function syntax:

```js
func my_void_func() {
    print("hello world!")
}

my_void_func()
```

```js
func my_cool_func($a, $b) {
    $res = $a + $b
    print("a + b = " + $res)
    return $res
}
print (my_cool_func(1, 1))
```

Also adds support for comparison/assignment of `undefined`

Also adds a few more builtins:
- `Cast(spellId)`
- `beep(frequency, duration)`
- `min` and `max` functions for integers
- Updates to `len` to make it work for string types too
- String/array manipulation: `remove`, `removeAt`, `insert` and `trim`, `split`

Partial work for #416 